### PR TITLE
fix missing alias when merging a query with a second instance of the main table 

### DIFF
--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -834,7 +834,7 @@ class Criteria
      */
     public function setUpdateValue($columnIdentifierOrMap, $value, $pdoType = null)
     {
-// NOTE: $pdoType is not typed as `?int` due to fallback.
+        // NOTE: $pdoType is not typed as `?int` due to fallback.
 
         if (is_array($value) && isset($value['raw'])) {
             trigger_error('Use Criteria::setUpdateExpression() instead of deprecated column value ' . print_r($value, true), E_USER_WARNING);
@@ -1740,7 +1740,11 @@ class Criteria
 
         // merge join
         foreach ($criteria->getJoins() as $key => $join) {
-            if ($join->getLeftTableName() !== $this->getPrimaryTableName() && $join->getRightTableName() === $this->getPrimaryTableName()) {
+            if (
+                $join->getLeftTableName() !== $this->getPrimaryTableName()
+                && $join->getRightTableName() === $this->getPrimaryTableName()
+                && (!$this instanceof BaseModelCriteria || $join->getRightTableAlias() === $this->getModelAlias())
+            ) {
                 $join->invert();
             }
         }

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
@@ -2838,6 +2838,24 @@ class ModelCriteriaTest extends BookstoreTestBase
     /**
      * @return void
      */
+    public function testMergeWithSecondTableInstance()
+    {
+        $params = [];
+        $actualSql = BookQuery::create()
+        ->useAuthorQuery()
+            ->joinBook('lastBook')
+            ->addDescendingOrderByColumn('lastBookId')
+            ->addAsColumn('lastBookId', 'lastBook.id')
+        ->endUse()
+        ->filterById(1)
+        ->createSelectSql($params);
+        $expectedSql = $this->getSql('SELECT lastBook.id AS lastBookId FROM book LEFT JOIN author ON (book.author_id=author.id) LEFT JOIN book lastBook ON (author.id=lastBook.author_id) WHERE book.id=:p1 ORDER BY lastBookId DESC');
+        $this->assertSame($expectedSql, $actualSql);
+    }
+
+    /**
+     * @return void
+     */
     public function testMergeWithWiths()
     {
         $c1 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book', 'b');


### PR DESCRIPTION
Fixes #77 

When merging queries after `useQuery()`, the merge normalizes joins of the source query to the table of the target query, because since it is the main table of the query, it is expected to be the left-hand table in the Join instance. However, the check ignored possible table aliases, which caused multiple joins to the same table to get mixed up.

The fix adds a check for table aliases to keep those joins unchanged. 