### PR TITLE
ignore security advisory for symfony/validator in CI

### DIFF
--- a/tests/composer/composer-symfony5-min.json
+++ b/tests/composer/composer-symfony5-min.json
@@ -63,6 +63,11 @@
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
+        },
+        "audit": {
+            "ignore": {
+                "PKSA-w2tw-kmfg-rt9s": "Ignore Security Advisories in symfony/valdiator (https://symfony.com/blog/cve-2025-64500-incorrect-parsing-of-path-info-can-lead-to-limited-authorization-bypass)"
+            }
         }
     }
 }

--- a/tests/composer/composer-symfony6-min.json
+++ b/tests/composer/composer-symfony6-min.json
@@ -60,6 +60,11 @@
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
+        },
+        "audit": {
+            "ignore": {
+                "PKSA-w2tw-kmfg-rt9s": "Ignore Security Advisories in symfony/valdiator (https://symfony.com/blog/cve-2025-64500-incorrect-parsing-of-path-info-can-lead-to-limited-authorization-bypass)"
+            }
         }
     }
 }

--- a/tests/composer/composer-symfony7-min.json
+++ b/tests/composer/composer-symfony7-min.json
@@ -61,6 +61,11 @@
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
+        },
+        "audit": {
+            "ignore": {
+                "PKSA-w2tw-kmfg-rt9s": "Ignore Security Advisories in symfony/valdiator (https://symfony.com/blog/cve-2025-64500-incorrect-parsing-of-path-info-can-lead-to-limited-authorization-bypass)"
+            }
         }
     }
 }


### PR DESCRIPTION
CI runs with symfony-min setup fail due to a security advisory error during install of symfony/validator:
```
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires symfony/validator ~5.0.0, found symfony/validator[v5.0.0, ..., v5.0.11] 
      but these were not loaded, because they are affected by security advisories. To ignore the advisories,
     add ("PKSA-w2tw-kmfg-rt9s") to the audit "ignore" config. To turn the feature off entirely, you can 
     set "block-insecure" to false in your "audit" config.

Error: Your requirements could not be resolved to an installable set of packages.
``` 
see [failed run](https://github.com/perplorm/perpl/actions/runs/19459357187/job/55679716940)

Description of the security advisory issue:
https://symfony.com/blog/cve-2025-64500-incorrect-parsing-of-path-info-can-lead-to-limited-authorization-bypass

Fixed as suggested, no risk in CI anyway.