### PR TITLE
disable VFS in tests via env var

### DIFF
--- a/src/Propel/Generator/Builder/Om/ExtensionBuilderInterface.php
+++ b/src/Propel/Generator/Builder/Om/ExtensionBuilderInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Generator\Builder\Om;
+
+use Propel\Generator\Model\Inheritance;
+
+/**
+ * Shared methods of builders for child classes declared via inheritance in schema.
+ */
+interface ExtensionBuilderInterface
+{
+    /**
+     * Sets the child object that we're operating on currently.
+     *
+     * @param \Propel\Generator\Model\Inheritance $child Inheritance
+     *
+     * @return void
+     */
+    public function setChild(Inheritance $child): void;
+
+    /**
+     * Returns the child object we're operating on currently.
+     *
+     * @throws \Propel\Generator\Exception\BuildException
+     *
+     * @return \Propel\Generator\Model\Inheritance
+     */
+    public function getChild(): Inheritance;
+
+    /**
+     * Builds the PHP source for current class and returns it as a string.
+     *
+     * This is the main entry point and defines a basic structure that classes should follow.
+     * In most cases this method will not need to be overridden by subclasses. This method
+     * does assume that the output language is PHP code, so it will need to be overridden if
+     * this is not the case.
+     *
+     * @return string The resulting PHP sourcecode.
+     */
+    public function build(): string;
+}

--- a/src/Propel/Generator/Builder/Om/ExtensionQueryInheritanceBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ExtensionQueryInheritanceBuilder.php
@@ -19,7 +19,7 @@ use Propel\Generator\Model\Inheritance;
  *
  * @author François Zaninotto
  */
-class ExtensionQueryInheritanceBuilder extends AbstractOMBuilder
+class ExtensionQueryInheritanceBuilder extends AbstractOMBuilder implements ExtensionBuilderInterface
 {
     /**
      * The current child "object" we are operating on.
@@ -57,6 +57,7 @@ class ExtensionQueryInheritanceBuilder extends AbstractOMBuilder
      *
      * @return void
      */
+    #[\Override]
     public function setChild(Inheritance $child): void
     {
         $this->child = $child;
@@ -69,6 +70,7 @@ class ExtensionQueryInheritanceBuilder extends AbstractOMBuilder
      *
      * @return \Propel\Generator\Model\Inheritance
      */
+    #[\Override]
     public function getChild(): Inheritance
     {
         if (!$this->child) {

--- a/src/Propel/Generator/Builder/Om/MultiExtendObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/MultiExtendObjectBuilder.php
@@ -20,7 +20,7 @@ use Propel\Generator\Model\Inheritance;
  *
  * @author Hans Lellelid <hans@xmpl.org>
  */
-class MultiExtendObjectBuilder extends AbstractObjectBuilder
+class MultiExtendObjectBuilder extends AbstractObjectBuilder implements ExtensionBuilderInterface
 {
     /**
      * The current child "object" we are operating on.
@@ -58,6 +58,7 @@ class MultiExtendObjectBuilder extends AbstractObjectBuilder
      *
      * @return void
      */
+    #[\Override]
     public function setChild(Inheritance $child): void
     {
         $this->child = $child;
@@ -70,6 +71,7 @@ class MultiExtendObjectBuilder extends AbstractObjectBuilder
      *
      * @return \Propel\Generator\Model\Inheritance
      */
+    #[\Override]
     public function getChild(): Inheritance
     {
         if (!$this->child) {

--- a/src/Propel/Generator/Builder/Om/QueryInheritanceBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryInheritanceBuilder.php
@@ -22,7 +22,7 @@ use Propel\Generator\Model\Table;
  *
  * @author François Zaninotto
  */
-class QueryInheritanceBuilder extends AbstractOMBuilder
+class QueryInheritanceBuilder extends AbstractOMBuilder implements ExtensionBuilderInterface
 {
     /**
      * @var \Propel\Generator\Builder\Util\EntityObjectClassNames
@@ -87,6 +87,7 @@ class QueryInheritanceBuilder extends AbstractOMBuilder
      *
      * @return void
      */
+    #[\Override]
     public function setChild(Inheritance $child): void
     {
         $this->child = $child;
@@ -99,6 +100,7 @@ class QueryInheritanceBuilder extends AbstractOMBuilder
      *
      * @return \Propel\Generator\Model\Inheritance
      */
+    #[\Override]
     public function getChild(): Inheritance
     {
         if (!$this->child) {

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectWithInterfaceTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectWithInterfaceTest.php
@@ -37,6 +37,6 @@ EOF;
      */
     public function testClassHasInterface()
     {
-          $this->assertInstanceOf('Foo\MyInterface', new MyClassWithInterface());
+        $this->assertInstanceOf('Foo\MyInterface', new MyClassWithInterface());
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,6 +2,8 @@
 
 require_once __DIR__ . '/../autoload.php.dist';
 
+use \Propel\Generator\Util\QuickBuilder;
+
 // check if user is root and
 if (function_exists("posix_getuid")) {
     if (posix_getuid() === 0 && !getenv('ALLOW_TESTS_AS_ROOT')) {
@@ -23,3 +25,7 @@ echo sprintf("Tests started in temp %s.\n", sys_get_temp_dir());
 ini_set('precision', '14');
 ini_set('serialize_precision', '14');
 setlocale(LC_ALL, 'en_US.utf8'); //fixed issues with hhvm and iconv
+
+if ((bool)getenv('DISABLE_VFS')) {
+    QuickBuilder::$disableVfs = true;
+}


### PR DESCRIPTION
The test suit builds classes to a virtual file system (vfs) in memory, which is good, except when there are errors in a generated class file, since you cannot inspect the file directly. Building to vfs can be deactivated by argument when calling `QuickBuilder::buildSchema()`, but this is inconvenient because you have to edit the test file (and later un-edit).

This adds a static flag to QuickBuilder which allows to disable vfs completely. During startup of tests, the flag is enabled when the env var `DISABLE_VFS` is set to a boolean value.

Completely building to tmp dir failed for some test setup, because classes defined via inheritance and interfaces were built into every class file, which is fixed now.