### PR TITLE
remove deserialization from Model::setByPostion()

### DIFF
--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/ArrayColumnCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/ArrayColumnCodeProducer.php
@@ -75,8 +75,7 @@ class ArrayColumnCodeProducer extends AbstractArrayColumnCodeProducer
             \$this->$cloUnserialized = [];
         }
         if (!\$this->$cloUnserialized && \$this->$clo !== null) {
-            \$$cloUnserialized = substr(\$this->$clo, 2, -2);
-            \$this->$cloUnserialized = \$$cloUnserialized !== '' ? explode(' | ', \$$cloUnserialized) : [];
+            \$this->$cloUnserialized = static::unserializeArray(\$this->$clo);
         }
 
         return \$this->$cloUnserialized;";
@@ -115,7 +114,7 @@ class ArrayColumnCodeProducer extends AbstractArrayColumnCodeProducer
         $script .= "
         if (\$this->$cloUnserialized !== \$v) {
             \$this->$cloUnserialized = \$v;
-            \$this->$clo = '| ' . implode(' | ', \$v) . ' |';
+            \$this->$clo = static::serializeArray(\$v);
             \$this->modifiedColumns[" . $this->objectBuilder->getColumnConstant($col) . "] = true;
         }\n";
     }

--- a/src/Propel/Generator/Builder/Om/TableMapBuilder.php
+++ b/src/Propel/Generator/Builder/Om/TableMapBuilder.php
@@ -273,12 +273,13 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
         foreach ($this->getTable()->getColumns() as $column) {
             $columnName = $column->getName();
             $columnConstant = $column->getConstantName();
+            $qualifiedName = $column->getFullyQualifiedName(true);
 
             $script .= "
     /**
      * The column name for the $columnName field
      */
-    public const {$columnConstant} = '$tableName.$columnName';\n";
+    public const {$columnConstant} = '$qualifiedName';\n";
         }
     }
 

--- a/src/Propel/Generator/Model/Column.php
+++ b/src/Propel/Generator/Model/Column.php
@@ -457,13 +457,17 @@ class Column extends MappingModel
     }
 
     /**
-     * Returns the fully qualified column name (table.column).
+     * Returns the fully qualified column name (table.COLUMN or table.column).
+     *
+     * @param bool $lowercaseColumnName
      *
      * @return string
      */
-    public function getFullyQualifiedName(): string
+    public function getFullyQualifiedName(bool $lowercaseColumnName = false): string
     {
-        return $this->parentTable->getName() . '.' . strtoupper($this->getName());
+        $columnName = $this->getName();
+
+        return $this->parentTable->getName() . '.' . ($lowercaseColumnName ? $columnName : strtoupper($columnName));
     }
 
     /**
@@ -712,7 +716,7 @@ class Column extends MappingModel
     }
 
     /**
-     * Returns the column constant name.
+     * Returns the column constant name (i.e. COL_ID).
      *
      * @return string
      */
@@ -1485,9 +1489,29 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function hasDefaultValue(): bool
+    public function hasDefault(): bool
     {
         return $this->getDefaultValue() !== null;
+    }
+
+    /**
+     * Check if the column has a default value that is a value (not an expression).
+     *
+     * @return bool
+     */
+    public function hasDefaultValue(): bool
+    {
+        return (bool)$this->getDefaultValue()?->isValue();
+    }
+
+    /**
+     * Check if the column has a default value that is an expression (not a value).
+     *
+     * @return bool
+     */
+    public function hasDefaultExpression(): bool
+    {
+        return (bool)$this->getDefaultValue()?->isExpression();
     }
 
     /**
@@ -1720,7 +1744,7 @@ class Column extends MappingModel
     public static function generatePhpName(string $name, ?string $phpNamingMethod = null, ?string $namePrefix = null): string
     {
         if ($phpNamingMethod === null) {
-            $phpNamingMethod = PhpNameGenerator::CONV_METHOD_CLEAN;
+            $phpNamingMethod = NameGeneratorInterface::CONV_METHOD_CLEAN;
         }
 
         return NameFactory::generateName(NameFactory::PHP_GENERATOR, [$name, $phpNamingMethod, (string)$namePrefix]);

--- a/src/Propel/Generator/Model/ColumnDefaultValue.php
+++ b/src/Propel/Generator/Model/ColumnDefaultValue.php
@@ -80,6 +80,16 @@ class ColumnDefaultValue
     }
 
     /**
+     * Check if this is a default value (and not an expression).
+     *
+     * @return bool Whether value this object holds is an expression.
+     */
+    public function isValue(): bool
+    {
+        return $this->type === self::TYPE_VALUE;
+    }
+
+    /**
      * @return string|int|null The value, as specified in the schema.
      */
     public function getValue()

--- a/src/Propel/Generator/Model/ForeignKey.php
+++ b/src/Propel/Generator/Model/ForeignKey.php
@@ -881,7 +881,7 @@ class ForeignKey extends MappingModel
     public function hasColumnWithRequiredValue(): bool
     {
         foreach ($this->getLocalColumnObjects() as $pk) {
-            if ($pk->isNotNull() && !$pk->hasDefaultValue()) {
+            if ($pk->isNotNull() && !$pk->hasDefault()) {
                 return true;
             }
         }

--- a/src/Propel/Generator/Model/Table.php
+++ b/src/Propel/Generator/Model/Table.php
@@ -945,7 +945,7 @@ class Table extends ScopedMappingModel implements IdMethod
         /** @var array<\Propel\Generator\Model\Column> $pks */
         $pks = [];
         foreach ($this->getPrimaryKey() as $primaryKey) {
-            if ($primaryKey->isNotNull() && !$primaryKey->hasDefaultValue() && !in_array($primaryKey, $primaryKeys, true)) {
+            if ($primaryKey->isNotNull() && !$primaryKey->hasDefault() && !in_array($primaryKey, $primaryKeys, true)) {
                 $pks[] = $primaryKey;
             }
         }
@@ -1603,6 +1603,16 @@ class Table extends ScopedMappingModel implements IdMethod
     public function getColumns(): array
     {
         return $this->columns;
+    }
+
+    /**
+     * Get columns that are not lazy-load.
+     *
+     * @return array<\Propel\Generator\Model\Column>
+     */
+    public function getEagerColumns(): array
+    {
+        return array_filter($this->columns, fn (Column $col) => !$col->isLazyLoad());
     }
 
     /**

--- a/src/Propel/Runtime/ActiveRecord/ActiveRecordInterface.php
+++ b/src/Propel/Runtime/ActiveRecord/ActiveRecordInterface.php
@@ -8,6 +8,8 @@
 
 namespace Propel\Runtime\ActiveRecord;
 
+use Propel\Runtime\ActiveQuery\FilterExpression\FilterCollector;
+
 /**
  * This ActiveRecord interface helps to find Propel Object
  *
@@ -74,4 +76,11 @@ interface ActiveRecordInterface
      * @return void
      */
     public function setNew(bool $b): void;
+
+    /**
+     * @param \Propel\Runtime\ActiveQuery\FilterExpression\FilterCollector $filterCollector
+     *
+     * @return static
+     */
+    public static function createFromFilters(FilterCollector $filterCollector);
 }


### PR DESCRIPTION
Internal cleanup:
The model methods `setByPosition()`, `setByName()` and regular setters should behave the same. However, `setByPosition()` was changed so that it deserializes array, set, and enum values.

I assume this was a monkey patch to make `ModelCriteria::findOneOrCreate()` work, which creates a model instance from filter values. Filter values match representation in the DB, so enum and set types are integers and array type is a string. Model setters however only work with user-space representation, so presumably something had to give.

That logic is now moved into a static `createFromFilter()` method on the model class.

I will probably do more of this cleanup, I want to see if the amount of generated code can be reduced by extracting core functionality into an `ActiveRecord` parent class, I'll start by cutting down some weeds.  