### PR TITLE
MySQL: ignore size attribute on integer column type declarations

### DIFF
--- a/src/Propel/Common/Config/PropelConfiguration.php
+++ b/src/Propel/Common/Config/PropelConfiguration.php
@@ -182,6 +182,7 @@ class PropelConfiguration implements ConfigurationInterface
                                         ->scalarNode('tableType')->defaultValue('InnoDB')->treatNullLike('InnoDB')->end()
                                         ->scalarNode('tableEngineKeyword')->defaultValue('ENGINE')->end()
                                         ->scalarNode('uuidColumnType')->defaultValue('binary')->end()
+                                        ->booleanNode('ignoreSizeOnIntegerTypes')->defaultTrue()->end()
                                     ->end()
                                 ->end()
                                 ->arrayNode('sqlite')

--- a/src/Propel/Generator/Model/Column.php
+++ b/src/Propel/Generator/Model/Column.php
@@ -122,7 +122,7 @@ class Column extends MappingModel
     private $domain;
 
     /**
-     * @var \Propel\Generator\Model\Table
+     * @var \Propel\Generator\Model\Table|null
      */
     private $parentTable;
 

--- a/src/Propel/Generator/Model/Diff/ColumnComparator.php
+++ b/src/Propel/Generator/Model/Diff/ColumnComparator.php
@@ -28,20 +28,18 @@ class ColumnComparator
     public static function computeDiff(Column $fromColumn, Column $toColumn)
     {
         $changedProperties = self::compareColumns($fromColumn, $toColumn);
-        if ($changedProperties) {
-            if ($fromColumn->hasPlatform() || $toColumn->hasPlatform()) {
-                $platform = $fromColumn->hasPlatform() ? $fromColumn->getPlatform() : $toColumn->getPlatform();
-                if ($platform->getColumnDDL($fromColumn) == $platform->getColumnDDL($toColumn)) {
-                    return false;
-                }
-            }
-            $columnDiff = new ColumnDiff($fromColumn, $toColumn);
-            $columnDiff->setChangedProperties($changedProperties);
-
-            return $columnDiff;
+        if (!$changedProperties) {
+            return false;
         }
 
-        return false;
+        $platform = $fromColumn->getPlatform() ?: $toColumn->getPlatform();
+        if ($platform && $platform->getColumnDDL($fromColumn) === $platform->getColumnDDL($toColumn)) {
+            return false;
+        }
+        $columnDiff = new ColumnDiff($fromColumn, $toColumn);
+        $columnDiff->setChangedProperties($changedProperties);
+
+        return $columnDiff;
     }
 
     /**

--- a/src/Propel/Generator/Platform/MysqlPlatform.php
+++ b/src/Propel/Generator/Platform/MysqlPlatform.php
@@ -34,22 +34,27 @@ class MysqlPlatform extends DefaultPlatform
     /**
      * @var string
      */
-    protected $tableEngineKeyword = 'ENGINE';
+    protected string $tableEngineKeyword = 'ENGINE';
 
     /**
      * @var string
      */
-    protected $defaultTableEngine = 'InnoDB';
+    protected string $defaultTableEngine = 'InnoDB';
 
     /**
      * @var string|null
      */
-    protected $serverVersion;
+    protected string|null $serverVersion = null;
 
     /**
      * @var bool
      */
-    protected $useUuidNativeType = false;
+    protected bool $useUuidNativeType = false;
+
+    /**
+     * @var bool
+     */
+    protected bool $ignoreSizeOnIntegerTypes = true;
 
     /**
      * Initializes db specific domain mapping.
@@ -104,6 +109,8 @@ class MysqlPlatform extends DefaultPlatform
             $enable = strtolower($uuidColumnType) === 'native';
             $this->setUuidNativeType($enable);
         }
+
+        $this->ignoreSizeOnIntegerTypes = $mysqlConfig['ignoreSizeOnIntegerTypes'];
     }
 
     /**
@@ -1015,13 +1022,25 @@ ALTER TABLE %s ADD %s %s;
     #[\Override]
     public function hasSize(string $sqlType): bool
     {
-        return !in_array($sqlType, [
+        $unSizedTypes = [
             'MEDIUMTEXT',
             'LONGTEXT',
             'BLOB',
             'MEDIUMBLOB',
             'LONGBLOB',
-        ], true);
+        ];
+
+        if ($this->ignoreSizeOnIntegerTypes) {
+            array_push(
+                $unSizedTypes,
+                PropelTypes::BIGINT,
+                PropelTypes::INTEGER,
+                PropelTypes::SMALLINT,
+                PropelTypes::TINYINT,
+            );
+        }
+
+        return !in_array($sqlType, $unSizedTypes, true);
     }
 
     /**

--- a/tests/Propel/Tests/Generator/Model/Diff/ColumnComparatorTest.php
+++ b/tests/Propel/Tests/Generator/Model/Diff/ColumnComparatorTest.php
@@ -11,6 +11,7 @@ namespace Propel\Tests\Generator\Model\Diff;
 use Propel\Generator\Model\Column;
 use Propel\Generator\Model\ColumnDefaultValue;
 use Propel\Generator\Model\Diff\ColumnComparator;
+use Propel\Generator\Model\Table;
 use Propel\Generator\Platform\MysqlPlatform;
 use Propel\Tests\TestCase;
 
@@ -232,5 +233,27 @@ class ColumnComparatorTest extends TestCase
             'defaultValueValue' => [null, 123],
         ];
         $this->assertEquals($expectedChangedProperties, ColumnComparator::compareColumns($c1, $c2));
+    }
+
+    /**
+     * @return void
+     */
+    public function testIgnoreIntegerSizeOnMySQL()
+    {
+        $platform = new MysqlPlatform();
+        $domain = clone $platform->getDomainForType('INTEGER');
+
+        $tableStub = $this->createStub(Table::class);
+        $tableStub->method('getPlatform')->willReturn($platform);
+
+        $fromColumn = new Column('foo');
+        $fromColumn->setTable($tableStub);
+        $fromColumn->setDomain($domain);
+
+        $toColumn = clone $fromColumn;
+        $toColumn->getDomain()->setSize(5);
+
+        $hasChange = ColumnComparator::computeDiff($fromColumn, $toColumn);
+        $this->assertFalse($hasChange, 'Changing integer column size should not build diff on MySQL');
     }
 }

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformTest.php
@@ -482,6 +482,48 @@ DROP TABLE IF EXISTS `Woopah`.`foo`;
     }
 
     /**
+     * @return array{string, bool, string}[]
+     */
+    public function IntegerTypesDataProvider(): array
+    {
+        $integerTypes = [PropelTypes::INTEGER, PropelTypes::BIGINT, PropelTypes::SMALLINT, PropelTypes::TINYINT];
+
+        return array_merge([
+                [PropelTypes::DECIMAL, true, "`foo` DECIMAL(3)"],
+                [PropelTypes::DECIMAL, false, "`foo` DECIMAL(3)"],
+            ],
+            array_map(fn($type) => [$type, true, "`foo` $type"], $integerTypes),
+            array_map(fn($type) => [$type, false, "`foo` {$type}(3)"], $integerTypes),
+            
+        );
+    }
+
+    /**
+     * @dataProvider IntegerTypesDataProvider
+     *
+     * @param string $integerType
+     * @param bool $ignoreSize
+     * @param string $expectedDdl
+     *
+     * @return void
+     */
+    public function testGetColumnDDLIgnoresSizeOnInteger(string $integerType, bool $ignoreSize, string $expectedDdl)
+    {
+        $platform = new MysqlPlatform();
+        $this->setObjectPropertyValue($platform, 'ignoreSizeOnIntegerTypes', $ignoreSize);
+        $domain = clone $platform->getDomainForType($integerType);
+        $domain->replaceSize(3);
+
+        $column = new Column('foo');
+        $column->setDomain($domain);
+
+        $actual = $platform->getColumnDDL($column);
+
+        $this->assertEquals($expectedDdl, $actual);
+    }
+
+
+    /**
      * @return void
      */
     public function testGetColumnDDLCharsetVendor()


### PR DESCRIPTION
In MySQL DDL, the "size" attribute on integer column types (i.e. `my_column INTEGER(4)`) does not define bit size as in other RDBMSs, but set display width in output. It is considered deprecated (see [docs](https://dev.mysql.com/doc/refman/8.4/en/numeric-type-syntax.html)).

Declaring size on integer columns in schema.xml is often just an oversight, but it might make sense when using the same schema across multiple platforms. MySQL does not export display width, so when comparing schemas to create migrations, integer columns with `size` will always create `ALTER TABLE` statements that do nothing on migrate up, and remove display width on migrate down.

Perpl is not a good place to manage display width for text output, and due to the problem with migrations (and display width being deprecated anyway), the `size` attribute should be ignored on MySQL integer columns.

Setting the config property `database.adapters.mysql.ignoreSizeOnIntegerTypes` to false will restore the old behavior.

In **MariaDB**, the attribute is used in combination with `ZEROFILL` and determines left-padding with zeros ([docs](https://mariadb.com/docs/server/reference/data-types/numeric-data-types/int)), which does not affect the int value used in Perpl.