### PR TITLE
Fix PHP 8.5 compatibility warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,13 +106,21 @@ jobs:
     static-analysis:
         name: 'Stan & Psalm'
         runs-on: ubuntu-24.04
+        strategy:
+          fail-fast: false
+          matrix:
+            include:
+              - php-version: '8.1'
+                symfony-version: '6-max'
+              - php-version: '8.5'
+                symfony-version: '8-max'
         steps:
             - uses: actions/checkout@v3
             - id: build-container
               uses: ./.github/actions/setup-php
               with:
-                php-version: 8.1
-                symfony-version: 6-max
+                php-version: ${{ matrix.php-version }}
+                symfony-version: ${{ matrix.symfony-version }}
                 cache-key-suffix: sa
             - name: PHPStan
               env:

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -67,6 +67,12 @@ parameters:
 			path: src/Propel/Generator/Builder/Om/ObjectBuilder.php
 
 		-
+			message: '#^Call to deprecated function xml_parser_free\(\)\.$#'
+			identifier: function.deprecated
+			count: 1
+			path: src/Propel/Generator/Builder/Util/SchemaReader.php
+
+		-
 			message: '#^Variable \$migration might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
@@ -83,12 +89,6 @@ parameters:
 			identifier: variable.undefined
 			count: 1
 			path: src/Propel/Generator/Config/ArrayToPhpConverter.php
-
-		-
-			message: '#^Call to an undefined method Propel\\Generator\\Manager\\AbstractManager\:\:getLocation\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Propel/Generator/Manager/AbstractManager.php
 
 		-
 			message: '#^Call to function is_array\(\) with array\<Propel\\Generator\\Model\\Column\> will always evaluate to true\.$#'
@@ -121,7 +121,7 @@ parameters:
 			path: src/Propel/Generator/Reverse/SqliteSchemaParser.php
 
 		-
-			message: '#^Call to an undefined method( TNode of)? DOMNode\:\:setAttribute\(\)\.$#'
+			message: '#^Call to an undefined method TNode of DOMNode\:\:setAttribute\(\)\.$#'
 			identifier: method.notFound
 			count: 6
 			path: src/Propel/Generator/Schema/Dumper/XmlDumper.php
@@ -143,12 +143,6 @@ parameters:
 			identifier: method.childParameterType
 			count: 1
 			path: src/Propel/Runtime/ActiveQuery/Criterion/ExistsCriterion.php
-
-		-
-			message: '#^Parameter \#1 \$paramCollector of method Propel\\Runtime\\ActiveQuery\\FilterExpression\\ColumnFilterInterface\:\:buildStatement\(\) expects array\<string, array\{table\: string, column\: string, value\: mixed\}\>, array\<array\{table\?\: string\|null, column\?\: string, value\: mixed, type\?\: int\}\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Propel/Runtime/ActiveQuery/FilterExpression/AbstractFilter.php
 
 		-
 			message: '#^Trait Propel\\Runtime\\ActiveQuery\\InstancePoolTrait is used zero times and is not analysed\.$#'
@@ -242,7 +236,7 @@ parameters:
 			path: src/Propel/Runtime/ActiveQuery/SqlBuilder/SelectQuerySqlBuilder.php
 
 		-
-			message: '#^Call to an undefined method Propel\\Runtime\\Connection\\ConnectionInterface\:\:sqliteCreateFunction\(\)\.$#'
+			message: '#^Call to an undefined method PDO\:\:(sqliteC|c)reateFunction\(\)\.$#'
 			identifier: method.notFound
 			count: 1
 			path: src/Propel/Runtime/Adapter/Pdo/SqliteAdapter.php
@@ -315,3 +309,27 @@ parameters:
 			identifier: method.notFound
 			count: 1
 			path: src/Propel/Runtime/Util/PropelModelPager.php
+
+		-
+			message: '#^Parameter \$exactly of method Symfony\\Component\\Validator\\Constraints\\Length\:\:__construct\(\) expects int\<1, max\>\|null, int\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Propel/Runtime/Validator/Constraints/Length.php
+
+		-
+			message: '#^Parameter \$max of method Symfony\\Component\\Validator\\Constraints\\Length\:\:__construct\(\) expects int\<1, max\>\|null, int\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Propel/Runtime/Validator/Constraints/Length.php
+
+		-
+			message: '#^Parameter \$min of method Symfony\\Component\\Validator\\Constraints\\Length\:\:__construct\(\) expects int\<0, max\>\|null, int\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Propel/Runtime/Validator/Constraints/Length.php
+
+		-
+			message: '#^Parameter \#1 \$type of method Symfony\\Component\\Validator\\Constraints\\Type\:\:__construct\(\) expects list\<string\>\|string\|null, array given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Propel/Runtime/Validator/Constraints/Type.php

--- a/src/Propel/Generator/Builder/Util/SchemaReader.php
+++ b/src/Propel/Generator/Builder/Util/SchemaReader.php
@@ -178,7 +178,7 @@ class SchemaReader
         }
 
         // store current schema file path
-        $this->schemasTagsStack[$xmlFile] = [];
+        $this->schemasTagsStack[$xmlFile ?? ''] = []; // HACK - fixes "Using null as an array offset is deprecated", but can $xmlString really be null?
         $this->currentXmlFile = $xmlFile;
 
         $parserStash = $this->parser;
@@ -195,7 +195,9 @@ class SchemaReader
                 ),
             );
         }
-        xml_parser_free($this->parser);
+        if (version_compare(phpversion(), '8.1', '<')) {
+            xml_parser_free($this->parser);
+        }
         $this->parser = $parserStash;
 
         array_pop($this->schemasTagsStack);

--- a/src/Propel/Generator/Util/QuickBuilder.php
+++ b/src/Propel/Generator/Util/QuickBuilder.php
@@ -284,7 +284,7 @@ class QuickBuilder
         $adapter = $adapter ?? new SqliteAdapter();
         $classTargets = $classTargets ?? $this->classTargets;
 
-        $pdo = new PdoConnection($dsn, $user, $pass);
+        $pdo = new PdoConnection($dsn, $user, $pass, [], $adapter->getPdoSubclass());
         $con = new ConnectionWrapper($pdo);
         $con->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
         /** @phpstan-var \Propel\Runtime\Adapter\Pdo\SqliteAdapter $adapter */

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -785,7 +785,7 @@ class Criteria
     }
 
     /**
-     * @deprecated use aptly named {@see static::addFilter()} or {@see static::setUpdateValue()}/{@see static::setUpdateExpression()}.
+     * @deprecated use aptly named {@see static::addAnd()} or {@see static::setUpdateValue()}/{@see static::setUpdateExpression()}.
      * Defaults to {@see static::addFilter}.
      *
      * @param \Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface|\Propel\Runtime\ActiveQuery\ColumnResolver\ColumnExpression\AbstractColumnExpression|string|null $columnOrClause The column to run the comparison on, or a Criterion object.

--- a/src/Propel/Runtime/Adapter/AdapterInterface.php
+++ b/src/Propel/Runtime/Adapter/AdapterInterface.php
@@ -209,4 +209,9 @@ interface AdapterInterface
      * @return string
      */
     public function getGroupBy(Criteria $criteria): string;
+
+    /**
+     * @return class-string<\PDO>
+     */
+    public function getPdoSubclass(): string;
 }

--- a/src/Propel/Runtime/Adapter/Pdo/MysqlAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/MysqlAdapter.php
@@ -27,6 +27,18 @@ use Propel\Runtime\Map\ColumnMap;
 class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
 {
     /**
+     * @return class-string<\PDO>
+     */
+    #[\Override]
+    public function getPdoSubclass(): string
+    {
+        /** @var class-string<\PDO> $class */
+        $class = class_exists('\PDO\Mysql') ? '\PDO\Mysql' : PDO::class;
+
+        return $class;
+    }
+
+    /**
      * Returns SQL which concatenates the second string to the first.
      *
      * @param string $s1 String to concatenate.

--- a/src/Propel/Runtime/Adapter/Pdo/OracleAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/OracleAdapter.php
@@ -8,6 +8,7 @@
 
 namespace Propel\Runtime\Adapter\Pdo;
 
+use PDO;
 use Propel\Generator\Model\PropelTypes;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\ActiveQuery\Lock;
@@ -31,6 +32,18 @@ use RuntimeException;
  */
 class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
 {
+    /**
+     * @return class-string<\PDO>
+     */
+    #[\Override]
+    public function getPdoSubclass(): string
+    {
+        /** @var class-string<\PDO> $class */
+        $class = class_exists('\PDO\Odbc') ? '\PDO\Odbc' : PDO::class;
+
+        return $class;
+    }
+
     /**
      * This method is called after a connection was created to run necessary
      * post-initialization queries or code.
@@ -134,7 +147,7 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
         if ($offset > 0) {
             $sql .= ' B.PROPEL_ROWNUM > ' . $offset;
             if ($limit > 0) {
-                $sql .= ' AND B.PROPEL_ROWNUM <= ' . ( $offset + $limit );
+                $sql .= ' AND B.PROPEL_ROWNUM <= ' . ($offset + $limit);
             }
         } else {
             $sql .= ' B.PROPEL_ROWNUM <= ' . $limit;

--- a/src/Propel/Runtime/Adapter/Pdo/PgsqlAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/PgsqlAdapter.php
@@ -8,6 +8,7 @@
 
 namespace Propel\Runtime\Adapter\Pdo;
 
+use PDO;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\ActiveQuery\Lock;
 use Propel\Runtime\Adapter\AdapterInterface;
@@ -25,6 +26,18 @@ use RuntimeException;
  */
 class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
 {
+    /**
+     * @return class-string<\PDO>
+     */
+    #[\Override]
+    public function getPdoSubclass(): string
+    {
+        /** @var class-string<\PDO> $class */
+        $class = class_exists('\PDO\Pgsql') ? '\PDO\Pgsql' : PDO::class;
+
+        return $class;
+    }
+
     /**
      * @see PdoAdapter::SUPPORTS_ALIASES_IN_DELETE
      *

--- a/src/Propel/Runtime/Adapter/Pdo/SqliteAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/SqliteAdapter.php
@@ -8,10 +8,14 @@
 
 namespace Propel\Runtime\Adapter\Pdo;
 
+use PDO;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\ActiveQuery\Lock;
 use Propel\Runtime\Adapter\SqlAdapterInterface;
 use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\Connection\ConnectionWrapper;
+use Propel\Runtime\Connection\PdoConnection;
+use RuntimeException;
 
 /**
  * This is used in order to connect to a SQLite database.
@@ -20,6 +24,18 @@ use Propel\Runtime\Connection\ConnectionInterface;
  */
 class SqliteAdapter extends PdoAdapter implements SqlAdapterInterface
 {
+    /**
+     * @return class-string<\PDO>
+     */
+    #[\Override]
+    public function getPdoSubclass(): string
+    {
+        /** @var class-string<\PDO> $class */
+        $class = class_exists('\PDO\Sqlite') ? '\PDO\Sqlite' : PDO::class;
+
+        return $class;
+    }
+
     /**
      * For SQLite this method has no effect, since SQLite doesn't support specifying a character
      * set (or, another way to look at it, it doesn't require a single character set per DB).
@@ -47,11 +63,39 @@ class SqliteAdapter extends PdoAdapter implements SqlAdapterInterface
         parent::initConnection($con, $settings);
 
         //add regex support
-        $con->sqliteCreateFunction('regexp', function ($pattern, $value) {
+        $this->createFunction($con, 'regexp', function ($pattern, $value) {
             mb_regex_encoding('UTF-8');
 
             return (mb_ereg($pattern, $value) !== false) ? 1 : 0;
         });
+    }
+
+    /**
+     * @param \Propel\Runtime\Connection\ConnectionInterface $con
+     * @param string $functionName
+     * @param callable $callback
+     *
+     * @throws \RuntimeException
+     *
+     * @return void
+     */
+    protected function createFunction(ConnectionInterface $con, string $functionName, callable $callback): void
+    {
+        $unwrappedConnection = $con instanceof ConnectionWrapper ? $con->getWrappedConnection() : $con;
+        if (!$unwrappedConnection instanceof PdoConnection) {
+            throw new RuntimeException('Expected PDO connection but got ' . get_class($con));
+        }
+        $pdo = $unwrappedConnection->getPdo();
+
+        if (method_exists($pdo, 'createFunction')) {
+            $createFunction = 'createFunction'; // $pdo is \PDO\Sqlite (available since PH 8.4)
+        } elseif (method_exists($pdo, 'sqliteCreateFunction')) {
+            $createFunction = 'sqliteCreateFunction'; // $pdo is PDO before PHP 8.5
+        } else {
+            throw new RuntimeException(sprintf('Cannot create function on PDO class %s (PHP %s)', get_class($con), phpversion()));
+        }
+
+        $pdo->$createFunction($functionName, $callback);
     }
 
     /**

--- a/src/Propel/Runtime/Collection/ObjectCollection.php
+++ b/src/Propel/Runtime/Collection/ObjectCollection.php
@@ -281,7 +281,8 @@ class ObjectCollection extends Collection
         $keyGetterMethod = 'get' . $keyColumn;
         $valueGetterMethod = ($valueColumn === null) ? '__toString' : ('get' . $valueColumn);
         foreach ($this as $obj) {
-            $ret[$obj->$keyGetterMethod()] = $obj->$valueGetterMethod();
+            $key = $obj->$keyGetterMethod();
+            $ret[$key ?? 'null'] = $obj->$valueGetterMethod();
         }
 
         return $ret;

--- a/src/Propel/Runtime/Connection/PdoConnection.php
+++ b/src/Propel/Runtime/Connection/PdoConnection.php
@@ -44,6 +44,14 @@ class PdoConnection implements ConnectionInterface
     }
 
     /**
+     * @return \PDO
+     */
+    public function getPdo(): PDO
+    {
+        return $this->pdo;
+    }
+
+    /**
      * @param string $name The datasource name associated to this connection
      *
      * @return void
@@ -70,8 +78,9 @@ class PdoConnection implements ConnectionInterface
      * @param string|null $user
      * @param string|null $password
      * @param array|null $options
+     * @param class-string<\PDO>|null $pdoSubclass
      */
-    public function __construct(string $dsn, ?string $user = null, ?string $password = null, ?array $options = null)
+    public function __construct(string $dsn, ?string $user = null, ?string $password = null, ?array $options = null, ?string $pdoSubclass = null)
     {
         // Convert option keys from a string to a PDO:: constant
         $pdoOptions = [];
@@ -82,7 +91,8 @@ class PdoConnection implements ConnectionInterface
             }
         }
 
-        $this->pdo = new PDO($dsn, $user, $password, $pdoOptions);
+        $pdoSubclass ??= PDO::class;
+        $this->pdo = new $pdoSubclass($dsn, $user, $password, $pdoOptions);
         $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     }
 

--- a/src/Propel/Runtime/Formatter/AbstractFormatterWithHydration.php
+++ b/src/Propel/Runtime/Formatter/AbstractFormatterWithHydration.php
@@ -102,16 +102,12 @@ abstract class AbstractFormatterWithHydration extends AbstractFormatter
             }
 
             // hydrate related object or take it from registry
-            $key = $modelWith->getTableMap()::getPrimaryKeyHashFromRow($row, $col, $indexType);
+            $key = $modelWith->getTableMap()::getPrimaryKeyHashFromRow($row, $col, $indexType) ?? 'null';
             // we hydrate the main object even in case of a one-to-many relationship
             // in order to get the $col variable increased anyway
             $secondaryObject = $this->getSingleObjectFromRow($row, $class, $col);
             if (!isset($this->alreadyHydratedObjects[$relAlias][$key])) {
-                if ($secondaryObject->isPrimaryKeyNull()) {
-                    $this->alreadyHydratedObjects[$relAlias][$key] = [];
-                } else {
-                    $this->alreadyHydratedObjects[$relAlias][$key] = $secondaryObject->toArray();
-                }
+                $this->alreadyHydratedObjects[$relAlias][$key] = $secondaryObject->isPrimaryKeyNull() ? [] : $secondaryObject->toArray();
             }
 
             if ($modelWith->isPrimary()) {

--- a/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifierTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifierTest.php
@@ -337,7 +337,7 @@ class SortableBehaviorObjectBuilderModifierTest extends TestCase
         $this->assertEquals($expected, $this->getFixturesArray(), 'removeFromList() does not change the list until the object is saved');
         $t2->save();
          SortableTable11TableMap::clearInstancePool();
-        $expected = [null => 'row2', 1 => 'row1', 2 => 'row3', 3 => 'row4'];
+        $expected = ['null' => 'row2', 1 => 'row1', 2 => 'row3', 3 => 'row4'];
         $this->assertEquals($expected, $this->getFixturesArray(), 'removeFromList() changes the list once the object is saved');
     }
 }

--- a/tests/Propel/Tests/Generator/Behavior/Sortable/TestCase.php
+++ b/tests/Propel/Tests/Generator/Behavior/Sortable/TestCase.php
@@ -184,7 +184,7 @@ class TestCase extends TestCaseFixturesDatabase
         $ts = SortableTable11Query::create()->orderByRank()->find();
         $ret = [];
         foreach ($ts as $t) {
-            $ret[$t->getRank()] = $t->getTitle();
+            $ret[$t->getRank() ?? 'null'] = $t->getTitle();
         }
 
         return $ret;
@@ -193,7 +193,7 @@ class TestCase extends TestCaseFixturesDatabase
     protected function getFixturesArrayWithScope($scope = null)
     {
         $c = new Criteria();
-        $c->add(SortableTable12TableMap::SCOPE_COL, $scope);
+        $c->addAnd(SortableTable12TableMap::SCOPE_COL, $scope);
         $ts = SortableTable12Query::create(null, $c)->orderByPosition()->find();
         $ret = [];
 

--- a/tests/Propel/Tests/Generator/Config/GeneratorConfigTest.php
+++ b/tests/Propel/Tests/Generator/Config/GeneratorConfigTest.php
@@ -34,7 +34,6 @@ class GeneratorConfigTest extends TestCase
     {
         $ref = new ReflectionClass('\\Propel\\Common\\Config\\ConfigurationManager');
         $refProp = $ref->getProperty('config');
-        $refProp->setAccessible(true);
         $refProp->setValue($this->generatorConfig, $config);
     }
 


### PR DESCRIPTION
Running tests on PHP 8.5 locally produced some errors and warning:
- deprecated methods 
   - `xml_parser_free` (removed)
   - `PDO::sqliteCreateFunction()` (now `\PDO\Sqlite::createFunction()` )
- cannot use `null` as array key

Updated Stan baseline

Also merged CI services for generated code style.