### PR TITLE
PHPCS: Fix SprykerDisallowFunctions rule

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -16,6 +16,11 @@
         <exclude name="SprykerStrict.TypeHints.ParameterTypeHint"/>
         <exclude name="SprykerStrict.TypeHints.PropertyTypeHint"/>
         <exclude name="SprykerStrict.TypeHints.ReturnTypeHint"/>
+        <exclude name="Spryker.Internal.SprykerBridge"/>
+        <exclude name="Spryker.Internal.SprykerFacade"/>
+        <exclude name="Spryker.Internal.SprykerNoDemoshop"/>
+        <exclude name="Spryker.Internal.SprykerPreferStaticOverSelf"/>
+        <exclude name="Spryker.Commenting.DocBlockApiAnnotation"/> <!-- Another Spryker internal function. -->
     </rule>
 
     <rule ref="Spryker.Internal.SprykerDisallowFunctions">


### PR DESCRIPTION
PHPCS has been really slow, it takes about twice as long as usual. See for example [this run](https://github.com/perplorm/perpl/actions/runs/21944158382) of 1m 23s compared to [this run](https://github.com/perplorm/perpl/actions/runs/22017945421) of 2. 58s.

Turns out the rule `Spryker.Internal.SprykerDisallowFunctions` requires a PHP version or has to be turned off, otherwise it goes nuts. In the file, it just says:
```
 * Do not use functions that are not available for lowest version supported.
 * By default, only applies to core if no PHP version is passed in.
```

And looking at the code, "core" means Spryker core:
```php
        if ($version === null && $this->isCore($phpcsFile)) {
            $version = static::PHP_MIN;
        }
```
and
```php
    protected function isCore(File $phpCsFile): bool
    {
        $namespace = $this->getNamespace($phpCsFile);

        return strpos($namespace, static::NAMESPACE_SPRYKER) === 0;
    }
```
There are lots of string operations involved in `getNamespace()`, and I think those are run for every single token, causing the issue.

Similar problem with  `Spryker.Internal.SprykerPreferStaticOverSelf`, now I kicked out all of them (except SprykerDisallowFunctions, which could be useful and is cheap when configured - 0.004s in Criteria).

<hr/>

The change to PHP version in SprykerDisallowFunctions should cause an error when functions from later PHP versions are used. So setting it to 8.1 would be wrong, since we are using symfony polyfills. However, there is no error when using `array_first()`, which was added in PHP 8.5. Don't know if the rule recognizes the polyfill? Does it even do anything? Maybe I should have just disabled it...