### PR TITLE
Build model relation methods without ConnectionInterface param

### DIFF
--- a/src/Propel/Common/Config/PropelConfiguration.php
+++ b/src/Propel/Common/Config/PropelConfiguration.php
@@ -355,6 +355,7 @@ class PropelConfiguration implements ConfigurationInterface
                         ->booleanNode('namespaceAutoPackage')->defaultTrue()->end()
                         ->booleanNode('recursive')->defaultFalse()->end()
                         ->booleanNode('defaultToNativeEnumeratedColumnTypes')->defaultFalse()->end()
+                        ->booleanNode('omitConnectionInterfaceParameterOnRelationMethods')->defaultFalse()->end()
                         ->arrayNode('connections')
                             ->prototype('scalar')->end()
                         ->end()

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/AbstractManyToManyCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/AbstractManyToManyCodeProducer.php
@@ -421,12 +421,11 @@ abstract class AbstractManyToManyCodeProducer extends AbstractRelationCodeProduc
      * It will also schedule objects for deletion based on a diff between old objects (aka persisted)
      * and new objects from the given Propel collection.
      *
-     * @param \Propel\Runtime\Collection\Collection<$collectionContentType> $inputCollectionVar A Propel collection.
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null \$con Optional connection object
+     * @param \Propel\Runtime\Collection\Collection<$collectionContentType> $inputCollectionVar A Propel collection.{$this->putConDoc()}
      *
      * @return static
      */
-    public function set{$targetIdentifierPlural}(Collection $inputCollectionVar, ?ConnectionInterface \$con = null): static
+    public function set{$targetIdentifierPlural}(Collection $inputCollectionVar{$this->putConParam(true)}): static
     {
         \$this->clear{$targetIdentifierPlural}();
         \$current{$targetIdentifierPlural} = \$this->get{$targetIdentifierPlural}();
@@ -488,12 +487,11 @@ abstract class AbstractManyToManyCodeProducer extends AbstractRelationCodeProduc
      * to the current object by way of the $crossRefTableName cross-reference table.
      *
      * @param \Propel\Runtime\ActiveQuery\Criteria|null \$criteria Optional query object to filter the query
-     * @param bool \$distinct Set to true to force count distinct
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null \$con Optional connection object
+     * @param bool \$distinct Set to true to force count distinct{$this->putConDoc()}
      *
      * @return int The number of related $targetIdentifierSingular objects
      */
-    public function count{$targetIdentifierPlural}(?Criteria \$criteria = null, bool \$distinct = false, ?ConnectionInterface \$con = null): int
+    public function count{$targetIdentifierPlural}(?Criteria \$criteria = null, bool \$distinct = false{$this->putConParam(true)}): int
     {
         \$partial = \$this->{$attributeIsPartialName} && !\$this->isNew();
         if (\$this->$attributeName && !\$criteria && !\$partial) {
@@ -515,9 +513,8 @@ abstract class AbstractManyToManyCodeProducer extends AbstractRelationCodeProduc
 
         return \$query
             ->filterBy{$sourceIdentifierSingular}(\$this)
-            ->count(\$con);
-    }
-";
+            ->count({$this->putConVar()});
+    }\n";
 
         $script .= $this->buildAdditionalCountMethods();
     }

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/AbstractRelationCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/AbstractRelationCodeProducer.php
@@ -5,12 +5,17 @@ declare(strict_types = 1);
 namespace Propel\Generator\Builder\Om\ObjectBuilder\RelationCodeProducer;
 
 use Propel\Generator\Builder\Om\ObjectBuilder\ObjectCodeProducer;
+use Propel\Generator\Config\GeneratorConfigInterface;
+use Propel\Generator\Model\Table;
+use function is_string;
 
 /**
  * Generates a database loader file, which is used to register all table maps with the DatabaseMap.
  */
 abstract class AbstractRelationCodeProducer extends ObjectCodeProducer
 {
+    protected bool $omitConnectionInterfaceParam = true;
+
     /**
      * @param string $script
      *
@@ -47,4 +52,70 @@ abstract class AbstractRelationCodeProducer extends ObjectCodeProducer
      * @return string Attribute name used by ObjectBuilder.
      */
     abstract public function addClearReferencesCode(string &$script): string;
+
+    /**
+     * @param \Propel\Generator\Model\Table $table
+     * @param \Propel\Generator\Config\GeneratorConfigInterface|null $generatorConfig
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function init(Table $table, ?GeneratorConfigInterface $generatorConfig): void
+    {
+        parent::init($table, $generatorConfig);
+        if (!$generatorConfig) {
+            return;
+        }
+        $this->omitConnectionInterfaceParam = (bool)$this->getBuildProperty('generator.omitConnectionInterfaceParameterOnRelationMethods', true);
+    }
+
+    /**
+     * @param bool $withTrailingEmptyLine
+     *
+     * @return string
+     */
+    protected function putConDoc(bool $withTrailingEmptyLine = false): string
+    {
+        $trailingEmptyLine = !$withTrailingEmptyLine ? '' : "\n     *";
+
+        return $this->omitConnectionInterfaceParam ? '' : "
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null \$con{$trailingEmptyLine}";
+    }
+
+    /**
+     * @param string|bool $withLeadingComma
+     * @param string|bool $withTrailingComma
+     *
+     * @return string
+     */
+    protected function putConParam(bool|string $withLeadingComma = false, bool|string $withTrailingComma = false): string
+    {
+        return $this->omitConnectionInterfaceParam ? '' : $this->withCommas($withLeadingComma, '?ConnectionInterface $con = null', $withTrailingComma);
+    }
+
+    /**
+     * @param string|bool $withLeadingComma
+     * @param string|bool $withTrailingComma
+     *
+     * @return string
+     */
+    protected function putConVar(bool|string $withLeadingComma = false, bool|string $withTrailingComma = false): string
+    {
+        return $this->omitConnectionInterfaceParam ? '' : $this->withCommas($withLeadingComma, '$con', $withTrailingComma);
+    }
+
+    /**
+     * @param string|bool $withLeadingComma
+     * @param string $content
+     * @param string|bool $withTrailingComma
+     *
+     * @return string
+     */
+    protected function withCommas(bool|string $withLeadingComma, string $content, bool|string $withTrailingComma): string
+    {
+        $leadingComma = is_string($withLeadingComma) ? $withLeadingComma : ($withLeadingComma ? ', ' : '');
+        $trailingComma = is_string($withTrailingComma) ? $withTrailingComma : ($withTrailingComma ? ', ' : '');
+
+        return "{$leadingComma}{$content}{$trailingComma}";
+    }
 }

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/FkRelationCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/FkRelationCodeProducer.php
@@ -245,23 +245,21 @@ class FkRelationCodeProducer extends AbstractRelationCodeProducer
         $script .= "
     /**
      * Get the associated $relationIdentifierSingular object
-     *
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null \$con Optional Connection object.
-     *
+     *{$this->putConDoc(true)}
      * @return {$targetType}|null
      */
-    public function get{$relationIdentifierSingular}(?ConnectionInterface \$con = null)
+    public function get{$relationIdentifierSingular}({$this->putConParam()})
     {";
         $script .= "
         if (\$this->$varName === null && ($valueIsEmpty)) {";
         if ($findPk) {
             $script .= "
-            \$this->$varName = {$targetQueryClassName}::create()->findPk($targetGetPkArgs, \$con);";
+            \$this->$varName = {$targetQueryClassName}::create()->findPk($targetGetPkArgs{$this->putConVar(true)});";
         } else {
             $script .= "
             \$this->$varName = {$targetQueryClassName}::create()
                 ->filterBy{$relationIdentifierReversedSingular}(\$this) // here
-                ->findOne(\$con);";
+                ->findOne({$this->putConVar()});";
         }
         if ($fk->isLocalPrimaryKey()) {
             $this->referencedClasses->registerFunction('assert');

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/ManyToManyRelationCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/ManyToManyRelationCodeProducer.php
@@ -145,12 +145,11 @@ class ManyToManyRelationCodeProducer extends AbstractManyToManyCodeProducer
      * If this $ownModelClassName is new, it will return
      * an empty collection or the current collection; the criteria is ignored on a new object.
      *
-     * @param \Propel\Runtime\ActiveQuery\Criteria|null \$criteria Optional query object to filter the query
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null \$con Optional connection object
+     * @param \Propel\Runtime\ActiveQuery\Criteria|null \$criteria Optional query object to filter the query{$this->putConDoc()}
      *
      * @return $objectCollectionType
      */
-    public function get{$targetIdentifierPlural}(?Criteria \$criteria = null, ?ConnectionInterface \$con = null): $objectCollectionClass
+    public function get{$targetIdentifierPlural}(?Criteria \$criteria = null{$this->putConParam(true)}): $objectCollectionClass
     {
         \$partial = \$this->{$attributeIsPartialName} && !\$this->isNew();
         if (\$this->$attributeName === null || \$criteria !== null || \$partial) {
@@ -162,7 +161,7 @@ class ManyToManyRelationCodeProducer extends AbstractManyToManyCodeProducer
             } else {
                 \$query = $targetQueryClassName::create(null, \$criteria)
                     ->filterBy{$sourceIdentifierSingular}(\$this);
-                \$$attributeName = \$query->findObjects(\$con);
+                \$$attributeName = \$query->findObjects({$this->putConVar()});
                 if (\$criteria !== null) {
                     return \$$attributeName;
                 }

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/OneToManyRelationCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/OneToManyRelationCodeProducer.php
@@ -286,12 +286,11 @@ class OneToManyRelationCodeProducer extends AbstractIncomingRelationCode
      * Returns the number of related $targetClassName objects.
      *
      * @param \Propel\Runtime\ActiveQuery\Criteria|null \$criteria
-     * @param bool \$distinct
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null \$con
+     * @param bool \$distinct{$this->putConDoc()}
      *
      * @return int Count of related $targetClassName objects.
      */
-    public function count{$relCol}(?Criteria \$criteria = null, bool \$distinct = false, ?ConnectionInterface \$con = null): int
+    public function count{$relCol}(?Criteria \$criteria = null, bool \$distinct = false{$this->putConParam(true)}): int
     {
         \$partial = \$this->{$collName}Partial && !\$this->isNew();
         if (\$this->$collName === null || \$criteria !== null || \$partial) {
@@ -310,7 +309,7 @@ class OneToManyRelationCodeProducer extends AbstractIncomingRelationCode
 
             return \$query
                 ->filterBy{$identifier}(\$this)
-                ->count(\$con);
+                ->count({$this->putConVar()});
         }
 
         return count(\$this->$collName);
@@ -343,18 +342,17 @@ class OneToManyRelationCodeProducer extends AbstractIncomingRelationCode
     /**
      * Gets $targetModelClassName objects which contain a foreign key that references this object.
      *
-     * If the \$criteria is not null, it is used to always fetch the results from the database.
-     * Otherwise the results are fetched from the database the first time, then cached.
-     * Next time the same method is called without \$criteria, the cached collection is returned.
-     * If this $ownModelClassName is new, it will return
-     * an empty collection or the current collection; the criteria is ignored on a new object.
+     * - If \$criteria is given, the result will be fetched from database using the \$criteria as filter.
+     * - Without \$criteria, all related $targetModelClassName objects will be loaded and cached for
+     *   subsequent calls.
+     * - If this $ownModelClassName is new, an empty collection or the current collection is returned.
+     * - On a new object, \$criteria is ignored.
      *
-     * @param \Propel\Runtime\ActiveQuery\Criteria|null \$criteria
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null \$con
+     * @param \Propel\Runtime\ActiveQuery\Criteria|null \$criteria{$this->putConDoc()}
      *
      * @return $targetCollectionClassNameFq
      */
-    public function get$relationIdentifierPlural(?Criteria \$criteria = null, ?ConnectionInterface \$con = null): $targetCollectionClassName
+    public function get$relationIdentifierPlural(?Criteria \$criteria = null{$this->putConParam(true)}): $targetCollectionClassName
     {
         \$partial = \$this->{$attributeName}Partial && !\$this->isNew();
         if (\$this->$attributeName && !\$criteria && !\$partial) {
@@ -377,7 +375,7 @@ class OneToManyRelationCodeProducer extends AbstractIncomingRelationCode
 
         \$$attributeName = $relationQueryClassName::create(null, \$criteria)
             ->filterBy{$relationIdentifierSingular}(\$this)
-            ->findObjects(\$con);
+            ->findObjects({$this->putConVar()});
 
         if (\$criteria) {
             if (\$this->{$attributeName}Partial !== false && count(\$$attributeName)) {
@@ -442,14 +440,13 @@ class OneToManyRelationCodeProducer extends AbstractIncomingRelationCode
      * It will also schedule objects for deletion based on a diff between old objects (aka persisted)
      * and new objects from the given Propel collection.
      *
-     * @param \Propel\Runtime\Collection\Collection<$targetModelClassNameFq> \${$inputCollectionVar}
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null \$con
+     * @param \Propel\Runtime\Collection\Collection<$targetModelClassNameFq> \${$inputCollectionVar}{$this->putConDoc()}
      *
      * @return static
      */
-    public function set{$relationIdentifierPlural}(Collection \${$inputCollectionVar}, ?ConnectionInterface \$con = null): static
+    public function set{$relationIdentifierPlural}(Collection \${$inputCollectionVar}{$this->putConParam(true)}): static
     {
-        \${$inputCollectionVar}ToDelete = \$this->get{$relationIdentifierPlural}(null, \$con)->diff(\${$inputCollectionVar});\n";
+        \${$inputCollectionVar}ToDelete = \$this->get{$relationIdentifierPlural}(null{$this->putConVar(true)})->diff(\${$inputCollectionVar});\n";
 
         if ($this->relation->isAtLeastOneLocalPrimaryKey()) {
             $script .= "
@@ -629,22 +626,20 @@ class OneToManyRelationCodeProducer extends AbstractIncomingRelationCode
      * an empty collection; or if this $modelClassName has previously
      * been saved, it will retrieve related $relationIdentifierPlural from storage.
      *
-     * @param \Propel\Runtime\ActiveQuery\Criteria|null \$criteria
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null \$con
+     * @param \Propel\Runtime\ActiveQuery\Criteria|null \$criteria{$this->putConDoc()}
      * @param string \$joinBehavior optional join type to use (defaults to $joinBehavior)
      *
      * @return $targetCollectionType
      */
     public function get{$relationIdentifierPlural}Join{$currentRelationIdentifier}(
-        ?Criteria \$criteria = null,
-        ?ConnectionInterface \$con = null,
+        ?Criteria \$criteria = null,{$this->putConParam("\n        ", ',')}
         \$joinBehavior = $joinBehavior
     ): $targetCollectionClassName {";
                 $script .= "
         \$query = $targetQueryClassName::create(null, \$criteria);
         \$query->joinWith('$currentRelationIdentifier', \$joinBehavior);
 
-        return \$this->get{$relationIdentifierPlural}(\$query, \$con);
+        return \$this->get{$relationIdentifierPlural}(\$query{$this->putConVar(true)});
     }
 ";
         }

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/RelationFromOneCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/RelationFromOneCodeProducer.php
@@ -108,15 +108,13 @@ class RelationFromOneCodeProducer extends AbstractIncomingRelationCode
         $script .= "
     /**
      * Gets a single $modelClassName object, which is related to this object by a one-to-one relationship.
-     *
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null \$con optional connection object
-     *
+     *{$this->putConDoc(true)}
      * @return $modelClassNameFq|null
      */
-    public function get{$relationIdentifier}(?ConnectionInterface \$con = null)
+    public function get{$relationIdentifier}({$this->putConParam()})
     {
         if (\$this->$varName === null && !\$this->isNew()) {
-            \$this->$varName = $queryClassName::create()->findPk(\$this->getPrimaryKey(), \$con);
+            \$this->$varName = $queryClassName::create()->findPk(\$this->getPrimaryKey(){$this->putConVar(true)});
         }
 
         return \$this->$varName;

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/TernaryRelationCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/TernaryRelationCodeProducer.php
@@ -182,12 +182,11 @@ class TernaryRelationCodeProducer extends AbstractManyToManyCodeProducer
      * If this $ownModelClassName is new, it will return
      * an empty collection or the current collection; the criteria is ignored on a new object.
      *
-     * @param \Propel\Runtime\ActiveQuery\Criteria|null \$criteria Optional query object to filter the query
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null \$con Optional connection object
+     * @param \Propel\Runtime\ActiveQuery\Criteria|null \$criteria Optional query object to filter the query{$this->putConDoc()}
      *
      * @return $objectCollectionType
      */
-    public function get{$targetIdentifierPlural}(?Criteria \$criteria = null, ?ConnectionInterface \$con = null): $objectCollectionClassName
+    public function get{$targetIdentifierPlural}(?Criteria \$criteria = null{$this->putConParam(true)}): $objectCollectionClassName
     {
         \$partial = \$this->$attributeIsPartialName && !\$this->isNew();
         if (\$this->$attributeName !== null && !\$partial && !\$criteria) {
@@ -214,7 +213,7 @@ class TernaryRelationCodeProducer extends AbstractManyToManyCodeProducer
             $script .= "
             ;
 
-        \$items = \$query->find(\$con);
+        \$items = \$query->find({$this->putConVar()});
         \$$attributeName = new ObjectCombinationCollection();
         foreach (\$items as \$item) {
             \$combination = [];\n";
@@ -283,14 +282,13 @@ class TernaryRelationCodeProducer extends AbstractManyToManyCodeProducer
      * If you have attached new $relatedObjectClassName object to this object you need to call `save` first to get
      * the correct return value. Use get$targetIdentifierPlural() to get the current internal state.
      *$phpDoc
-     * @param \Propel\Runtime\ActiveQuery\Criteria|null \$criteria
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null \$con
+     * @param \Propel\Runtime\ActiveQuery\Criteria|null \$criteria{$this->putConDoc()}
      *
      * @return $objectCollectionType
      */
-    public function get{$relationIdentifier}($argumentDeclaration, ?Criteria \$criteria = null, ?ConnectionInterface \$con = null)
+    public function get{$relationIdentifier}($argumentDeclaration, ?Criteria \$criteria = null{$this->putConParam(true)})
     {
-        return \$this->create{$relationIdentifier}Query($functionParameters, \$criteria)->find(\$con);
+        return \$this->create{$relationIdentifier}Query($functionParameters, \$criteria)->find({$this->putConVar()});
     }
 ";
     }
@@ -432,14 +430,13 @@ class TernaryRelationCodeProducer extends AbstractManyToManyCodeProducer
      * If you have attached new $argsCsv object to this object you need to call `save` first to get
      * the correct return value. Use get$targetIdentifierPlural() to get the current internal state.
      *$phpDoc
-     * @param \Propel\Runtime\ActiveQuery\Criteria|null \$criteria
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null \$con
+     * @param \Propel\Runtime\ActiveQuery\Criteria|null \$criteria{$this->putConDoc()}
      *
      * @return int
      */
-    public function count{$relationIdentifier}($argumentDeclarations, ?Criteria \$criteria = null, ?ConnectionInterface \$con = null): int
+    public function count{$relationIdentifier}($argumentDeclarations, ?Criteria \$criteria = null{$this->putConParam(true)}): int
     {
-        return \$this->create{$relationIdentifier}Query($functionParameters, \$criteria)->count(\$con);
+        return \$this->create{$relationIdentifier}Query($functionParameters, \$criteria)->count({$this->putConVar()});
     }
 ";
     }

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/ManyToManyNamedRelationCodeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/ManyToManyNamedRelationCodeTest.php
@@ -176,7 +176,7 @@ class ManyToManyNamedRelationCodeTest extends AbstractManyToManyCodeTest
      * an empty collection or the current collection; the criteria is ignored on a new object.
      *
      * @param \Propel\Runtime\ActiveQuery\Criteria|null $criteria Optional query object to filter the query
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con Optional connection object
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
      *
      * @return \Base\Collection\TeamCollection
      */
@@ -227,7 +227,7 @@ class ManyToManyNamedRelationCodeTest extends AbstractManyToManyCodeTest
      * and new objects from the given Propel collection.
      *
      * @param \Propel\Runtime\Collection\Collection<\Team> $leTeams A Propel collection.
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con Optional connection object
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
      *
      * @return static
      */
@@ -267,7 +267,7 @@ class ManyToManyNamedRelationCodeTest extends AbstractManyToManyCodeTest
      *
      * @param \Propel\Runtime\ActiveQuery\Criteria|null $criteria Optional query object to filter the query
      * @param bool $distinct Set to true to force count distinct
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con Optional connection object
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
      *
      * @return int The number of related LeTeam objects
      */

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/ManyToManyRelationCodeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/ManyToManyRelationCodeTest.php
@@ -178,7 +178,7 @@ class ManyToManyRelationCodeTest extends AbstractManyToManyCodeTest
      * an empty collection or the current collection; the criteria is ignored on a new object.
      *
      * @param \Propel\Runtime\ActiveQuery\Criteria|null $criteria Optional query object to filter the query
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con Optional connection object
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
      *
      * @return \Base\Collection\TeamCollection
      */
@@ -229,7 +229,7 @@ class ManyToManyRelationCodeTest extends AbstractManyToManyCodeTest
      * and new objects from the given Propel collection.
      *
      * @param \Propel\Runtime\Collection\Collection<\Team> $teams A Propel collection.
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con Optional connection object
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
      *
      * @return static
      */
@@ -269,7 +269,7 @@ class ManyToManyRelationCodeTest extends AbstractManyToManyCodeTest
      *
      * @param \Propel\Runtime\ActiveQuery\Criteria|null $criteria Optional query object to filter the query
      * @param bool $distinct Set to true to force count distinct
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con Optional connection object
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
      *
      * @return int The number of related Team objects
      */

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/ManyToManyRelationWithParameterCodeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/ManyToManyRelationWithParameterCodeTest.php
@@ -238,7 +238,7 @@ class ManyToManyRelationWithParameterCodeTest extends AbstractManyToManyCodeTest
      * an empty collection or the current collection; the criteria is ignored on a new object.
      *
      * @param \Propel\Runtime\ActiveQuery\Criteria|null $criteria Optional query object to filter the query
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con Optional connection object
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
      *
      * @return \Propel\Runtime\Collection\ObjectCombinationCollection<array{\Team, string, int}>
      */
@@ -327,7 +327,7 @@ class ManyToManyRelationWithParameterCodeTest extends AbstractManyToManyCodeTest
      * and new objects from the given Propel collection.
      *
      * @param \Propel\Runtime\Collection\Collection<array{\Team, string, int}> $teamDayTypes A Propel collection.
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con Optional connection object
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
      *
      * @return static
      */
@@ -370,7 +370,7 @@ class ManyToManyRelationWithParameterCodeTest extends AbstractManyToManyCodeTest
      *
      * @param \Propel\Runtime\ActiveQuery\Criteria|null $criteria Optional query object to filter the query
      * @param bool $distinct Set to true to force count distinct
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con Optional connection object
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
      *
      * @return int The number of related TeamDayType objects
      */

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/TernaryNamedRelationCodeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/TernaryNamedRelationCodeTest.php
@@ -272,7 +272,7 @@ class TernaryNamedRelationCodeTest extends AbstractManyToManyCodeTest
      * an empty collection or the current collection; the criteria is ignored on a new object.
      *
      * @param \Propel\Runtime\ActiveQuery\Criteria|null $criteria Optional query object to filter the query
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con Optional connection object
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
      *
      * @return \Propel\Runtime\Collection\ObjectCombinationCollection<array{\Team, \Event, string}>
      */
@@ -379,7 +379,7 @@ class TernaryNamedRelationCodeTest extends AbstractManyToManyCodeTest
      * and new objects from the given Propel collection.
      *
      * @param \Propel\Runtime\Collection\Collection<array{\Team, \Event, string}> $leTeamLeEventDates A Propel collection.
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con Optional connection object
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
      *
      * @return static
      */
@@ -422,7 +422,7 @@ class TernaryNamedRelationCodeTest extends AbstractManyToManyCodeTest
      *
      * @param \Propel\Runtime\ActiveQuery\Criteria|null $criteria Optional query object to filter the query
      * @param bool $distinct Set to true to force count distinct
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con Optional connection object
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
      *
      * @return int The number of related LeTeamLeEventDate objects
      */

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/TernaryRelationCodeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/TernaryRelationCodeTest.php
@@ -261,7 +261,7 @@ class TernaryRelationCodeTest extends AbstractManyToManyCodeTest
      * an empty collection or the current collection; the criteria is ignored on a new object.
      *
      * @param \Propel\Runtime\ActiveQuery\Criteria|null $criteria Optional query object to filter the query
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con Optional connection object
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
      *
      * @return \Propel\Runtime\Collection\ObjectCombinationCollection<array{\Team, \Event}>
      */
@@ -365,7 +365,7 @@ class TernaryRelationCodeTest extends AbstractManyToManyCodeTest
      * and new objects from the given Propel collection.
      *
      * @param \Propel\Runtime\Collection\Collection<array{\Team, \Event}> $teamEvents A Propel collection.
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con Optional connection object
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
      *
      * @return static
      */
@@ -408,7 +408,7 @@ class TernaryRelationCodeTest extends AbstractManyToManyCodeTest
      *
      * @param \Propel\Runtime\ActiveQuery\Criteria|null $criteria Optional query object to filter the query
      * @param bool $distinct Set to true to force count distinct
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con Optional connection object
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
      *
      * @return int The number of related TeamEvent objects
      */


### PR DESCRIPTION
First draft for removing the `ConnectionInterface` parameter from relation methods by setting configuration parameter `generator.omitConnectionInterfaceParameterOnRelationMethods` to `true`.

Example:
```php
    /**
     * @param \Propel\Runtime\ActiveQuery\Criteria|null $criteria
     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
     *
     * @return \Propel\Tests\Bookstore\Base\Collection\BookCollection
     */
    public function getBooks(?Criteria $criteria = null, ?ConnectionInterface $con = null): BookCollection
    {
```
becomes
```php
    /**
     * @param \Propel\Runtime\ActiveQuery\Criteria|null $criteria
     *
     * @return \Propel\Tests\Bookstore\Base\Collection\BookCollection
     */
    public function getBooks(?Criteria $criteria = null): BookCollection
    {
```

Not sure if this matches #41 as there is still the `?Criteria $criteria = null` param.

Manual setup passes sniffer and linter, but no tests yet.