### PR TITLE
Add map/reduce functionality to Collection

### DIFF
--- a/src/Propel/Runtime/Collection/Collection.php
+++ b/src/Propel/Runtime/Collection/Collection.php
@@ -20,7 +20,9 @@ use Propel\Runtime\Parser\AbstractParser;
 use Propel\Runtime\Propel;
 use Serializable;
 use Traversable;
+use function array_map;
 use function array_pop;
+use function array_reduce;
 use function array_search;
 use function array_shift;
 use function array_unshift;
@@ -62,17 +64,14 @@ use const E_USER_NOTICE;
  */
 class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializable
 {
-    /**
-     * @var string|null
-     */
-    protected $model;
+    protected string|null $model = null;
 
     /**
      * The fully qualified classname of the model
      *
      * @var class-string<RowFormat>|null
      */
-    protected $fullyQualifiedModel;
+    protected string|null $fullyQualifiedModel = null;
 
     /**
      * @var \Propel\Runtime\Formatter\AbstractFormatter<RowFormat, static>
@@ -82,7 +81,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
     /**
      * @var array<RowFormat>
      */
-    protected $data = [];
+    protected array $data = [];
 
     /**
      * @deprecated should not have a pluralzier.
@@ -744,5 +743,37 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
     public function hashCode(): string
     {
         return spl_object_hash($this);
+    }
+
+    /**
+     * Apply $callback to each element and return the results as array.
+     *
+     * To load related objects in an ObjectCollection, prefer {@see ObjectCollection::populateRelation()}.
+     *
+     * @template ReturnType
+     *
+     * @param callable(RowFormat):ReturnType $callback
+     *
+     * @return array<ReturnType>
+     */
+    public function map(callable $callback): array
+    {
+        return array_map($callback, $this->data);
+    }
+
+    /**
+     * Apply $callback to each element and return the result as array.
+     *
+     * @template InitialType
+     * @template AggregateType
+     *
+     * @param callable(InitialType|AggregateType, RowFormat):AggregateType $callback
+     * @param InitialType $initial
+     *
+     * @return InitialType|AggregateType
+     */
+    public function reduce(callable $callback, $initial)
+    {
+        return array_reduce($this->data, $callback, $initial);
     }
 }

--- a/src/Propel/Runtime/Collection/ObjectCollection.php
+++ b/src/Propel/Runtime/Collection/ObjectCollection.php
@@ -29,18 +29,12 @@ use function ucfirst;
  */
 class ObjectCollection extends Collection
 {
-    /**
-     * @var array
-     */
-    protected $index = [];
+    protected array $index = [];
+
+    protected array $indexSplHash = [];
 
     /**
-     * @var array
-     */
-    protected $indexSplHash = [];
-
-    /**
-     * @param array $data
+     * @param array<RowFormat> $data
      */
     public function __construct(array $data = [])
     {

--- a/tests/Propel/Tests/Runtime/Collection/CollectionTest.php
+++ b/tests/Propel/Tests/Runtime/Collection/CollectionTest.php
@@ -389,4 +389,28 @@ class CollectionTest extends BookstoreTestBase
         $this->assertInstanceOf('\Propel\Runtime\Collection\Collection', $result);
         $this->assertEquals(0, count($result));
     }
+
+    /**
+     * @return void
+     */
+    public function testMap()
+    {
+        $data = [['bar1'], ['bar2'], ['bar3']];
+        $col = new Collection($data);
+        $result = $col->map(fn($val) => $val[0]);
+
+        $this->assertSame(['bar1', 'bar2', 'bar3'], $result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testReduce()
+    {
+        $data = range(1,5);
+        $col = new Collection($data);
+        $result = $col->reduce(fn($agg, $val) => $agg + $val, 100);
+
+        $this->assertSame(115, $result);
+    }
 }

--- a/tests/Propel/Tests/Runtime/Collection/ObjectCollectionTest.php
+++ b/tests/Propel/Tests/Runtime/Collection/ObjectCollectionTest.php
@@ -346,6 +346,36 @@ class ObjectCollectionTest extends BookstoreTestBase
     }
 
     /**
+     * @return void
+     */
+    public function testMap()
+    {
+        $titles = array_map(fn($i) => "Foo$i", range(1, 3));
+        $titles[] = null;
+
+        $data = array_map(fn($title) => (new Book())->setTitle($title), $titles);
+        $col = new ObjectCollection($data);
+        $result = $col->map(fn($b) => $b->getTitle());
+
+        $this->assertSame($titles, $result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testReduce()
+    {
+        $titles = array_map(fn($i) => "Foo$i", range(1, 3));
+        $titles[] = null;
+
+        $data = array_map(fn($title) => (new Book())->setTitle($title), $titles);
+        $col = new ObjectCollection($data);
+        $result = $col->reduce(fn($agg, $b) => [...$agg, $b->getTitle()], []);
+
+        $this->assertSame($titles, $result);
+    }
+
+    /**
      * @afterClass
      *
      * @return void


### PR DESCRIPTION
Adds shorthand for map/reduce in Collections:
```php
$titles = $bookCollection->map(fn($book) => $book->getTitle());
$totalBooks = $authorCollection->reduce(fn ($bookCount, $author) => $bookCount + $author->countBooks(), 0);
```
instead of
```php
$titles = array_map(fn($book) => $book->getTitle(), $bookCollection->getData());
$totalBooks = array_reduce($authorCollection->getData(), fn ($bookCount, $author) => $bookCount + $author->countBooks(), 0);
```