### PR TITLE
Add string field for date columns and ColumnCodeProducer cleanup

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -24,6 +24,7 @@
         <exclude name="Spryker.Commenting.DocBlockApiAnnotation"/> <!-- Another Spryker internal function. -->
         <exclude name="Spryker.Commenting.DocBlockReturnSelf.InvalidChainable"/> <!-- methods with "@return $this" must end with "return $this", but cannot return $this through another method -->
         <exclude name="Spryker.Commenting.DocBlockParamAllowDefaultValue.Typehint"/> <!-- fails to recognize array shapes (like `array{int, string})`-->
+        <exclude name="Spryker.Commenting.DocBlockParamAllowDefaultValue.WrongNullable"/> <!-- Checks for null as '?' (?string) but not '|null' (string|null) in spryker/code-sniffer 0.17.30 -->
     </rule>
 
     <rule ref="Spryker.Internal.SprykerDisallowFunctions">

--- a/src/Propel/Generator/Builder/DataModelBuilder.php
+++ b/src/Propel/Generator/Builder/DataModelBuilder.php
@@ -600,13 +600,11 @@ abstract class DataModelBuilder
     /**
      * @param string ...$classNames
      *
-     * @return void
+     * @return array<string>
      */
-    public function declareClasses(string ...$classNames): void
+    public function declareClasses(string ...$classNames): array
     {
-        foreach ($classNames as $class) {
-            $this->declareClass($class);
-        }
+        return array_map([$this, 'declareClass'], $classNames);
     }
 
     /**

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -1119,6 +1119,10 @@ abstract class {$this->getUnqualifiedClassName()}$parentClass implements ActiveR
         $hasFks = $this->getTable()->hasRelations();
         $objectClassName = $this->getUnqualifiedClassName();
         $defaultKeyType = $this->getDefaultKeyType();
+        $tableMapClassName = $this->getTableMapClassName();
+        $fkParam = $hasFks ? ',
+        bool $includeForeignObjects = false' : '';
+
         $script .= "
     /**
      * Exports the object as an array.
@@ -1142,41 +1146,31 @@ abstract class {$this->getUnqualifiedClassName()}$parentClass implements ActiveR
     public function toArray(
         string \$keyType = TableMap::$defaultKeyType,
         bool \$includeLazyLoadColumns = true,
-        array \$alreadyDumpedObjects = []" . ($hasFks ? ',
-        bool $includeForeignObjects = false' : '') . "
+        array \$alreadyDumpedObjects = []{$fkParam}
     ): array {
         if (isset(\$alreadyDumpedObjects['$objectClassName'][\$this->hashCode()])) {
             return ['*RECURSION*'];
         }
         \$alreadyDumpedObjects['$objectClassName'][\$this->hashCode()] = true;
-        \$keys = " . $this->getTableMapClassName() . "::getFieldNames(\$keyType);
+        \$keys = $tableMapClassName::getFieldNames(\$keyType);
         \$result = [";
-        foreach ($this->getTable()->getColumns() as $num => $col) {
-            $columnName = $col->getPhpName();
-            if ($col->isLazyLoad()) {
-                $script .= "
-            \$keys[$num] => (\$includeLazyLoadColumns) ? \$this->get{$columnName}() : null,";
-            } else {
-                $script .= "
-            \$keys[$num] => \$this->get{$columnName}(),";
-            }
-        }
-        $script .= "
-        ];";
 
         foreach ($this->getTable()->getColumns() as $num => $col) {
-            if ($col->isTemporalType()) {
-                $this->declareClass('DateTimeInterface');
-                $dateFormat = $this->getPlatformOrFail()->getTemporalFormatter($col);
-                $script .= "
-        if (\$result[\$keys[$num]] instanceof DateTimeInterface) {
-            \$result[\$keys[$num]] = \$result[\$keys[$num]]->format('$dateFormat');
-        }\n";
-            }
+            $columnName = $col->getPhpName();
+            $getter = match (true) {
+                $col->isLazyLoad() => "(\$includeLazyLoadColumns) ? \$this->get{$columnName}() : null",
+                $col->isTemporalType() => "\$this->get{$columnName}('" . $this->getPlatformOrFail()->getTemporalFormatter($col) . "')",
+                default => "\$this->get{$columnName}()",
+            };
+
+            $script .= "
+            \$keys[$num] => $getter,";
         }
+
         $script .= "
-        \$virtualColumns = \$this->virtualColumns;
-        foreach (\$virtualColumns as \$key => \$virtualColumn) {
+        ];
+
+        foreach (\$this->virtualColumns as \$key => \$virtualColumn) {
             \$result[\$key] = \$virtualColumn;
         }\n";
 

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -4,7 +4,9 @@ declare(strict_types = 1);
 
 namespace Propel\Generator\Builder\Om;
 
+use Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes\ColumnCodeProducer;
 use Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes\ColumnCodeProducerFactory;
+use Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes\LazyLoadColumnCodeProducer;
 use Propel\Generator\Builder\Om\ObjectBuilder\RelationCodeProducer\AbstractIncomingRelationCode;
 use Propel\Generator\Builder\Om\ObjectBuilder\RelationCodeProducer\AbstractManyToManyCodeProducer;
 use Propel\Generator\Builder\Om\ObjectBuilder\RelationCodeProducer\FkRelationCodeProducer;
@@ -16,13 +18,12 @@ use Propel\Generator\Model\IdMethod;
 use Propel\Generator\Model\PropelTypes;
 use Propel\Generator\Model\Table;
 use Propel\Generator\Platform\MssqlPlatform;
-use Propel\Generator\Platform\MysqlPlatform;
-use Propel\Generator\Platform\OraclePlatform;
 use Propel\Generator\Platform\PlatformInterface;
 use Propel\Runtime\ActiveQuery\FilterExpression\FilterCollector;
 use Propel\Runtime\Exception\PropelException;
 use function addslashes;
 use function array_any;
+use function array_filter;
 use function array_intersect;
 use function array_map;
 use function array_values;
@@ -386,8 +387,6 @@ abstract class {$this->getUnqualifiedClassName()}$parentClass implements ActiveR
 
         foreach ($this->columnCodeProducers as $producer) {
             $producer->addAccessor($script);
-        }
-        foreach ($this->columnCodeProducers as $producer) {
             $producer->addMutator($script);
         }
 
@@ -470,8 +469,7 @@ abstract class {$this->getUnqualifiedClassName()}$parentClass implements ActiveR
     #[\Override]
     protected function addClassClose(string &$script): void
     {
-        $script .= "}
-";
+        $script .= "}\n";
         $this->applyBehaviorModifier('objectFilter', $script, '');
     }
 
@@ -605,8 +603,7 @@ abstract class {$this->getUnqualifiedClassName()}$parentClass implements ActiveR
     protected function addConstructorClose(string &$script): void
     {
         $script .= "
-    }
-";
+    }\n";
     }
 
     /**
@@ -737,8 +734,7 @@ abstract class {$this->getUnqualifiedClassName()}$parentClass implements ActiveR
     protected function addApplyDefaultValuesClose(string &$script): void
     {
         $script .= "
-    }
-";
+    }\n";
     }
 
     /**
@@ -750,23 +746,10 @@ abstract class {$this->getUnqualifiedClassName()}$parentClass implements ActiveR
      */
     protected function addHasOnlyDefaultValues(string &$script): void
     {
-        $this->addHasOnlyDefaultValuesComment($script);
-        $this->addHasOnlyDefaultValuesOpen($script);
-        $this->addHasOnlyDefaultValuesBody($script);
-        $this->addHasOnlyDefaultValuesClose($script);
-    }
+        $defaultValueCodeProducers = array_filter($this->columnCodeProducers, fn (ColumnCodeProducer $producer) => (bool)$producer->getColumn()->getDefaultValue()?->isValueType());
+        $checkStatements = array_map(fn (ColumnCodeProducer $p) => $p->getIsDefaultValueStatement(), $defaultValueCodeProducers);
+        $checksConjunction = implode("\n            && ", $checkStatements) ?: 'true';
 
-    /**
-     * Adds the comment for the hasOnlyDefaultValues method
-     *
-     * @see addHasOnlyDefaultValues
-     *
-     * @param string $script The script will be modified in this method.
-     *
-     * @return void
-     */
-    protected function addHasOnlyDefaultValuesComment(string &$script): void
-    {
         $script .= "
     /**
      * Indicates whether the columns in this object are only set to default values.
@@ -775,85 +758,11 @@ abstract class {$this->getUnqualifiedClassName()}$parentClass implements ActiveR
      * modified _and_ has some values set which are non-default.
      *
      * @return bool Whether the columns in this object are only been set with default values.
-     */";
-    }
-
-    /**
-     * Adds the function declaration for the hasOnlyDefaultValues method
-     *
-     * @see addHasOnlyDefaultValues
-     *
-     * @param string $script The script will be modified in this method.
-     *
-     * @return void
      */
-    protected function addHasOnlyDefaultValuesOpen(string &$script): void
-    {
-        $script .= "
     public function hasOnlyDefaultValues(): bool
-    {";
-    }
-
-    /**
-     * Adds the function body for the hasOnlyDefaultValues method
-     *
-     * @see addHasOnlyDefaultValues
-     *
-     * @param string $script The script will be modified in this method.
-     *
-     * @return void
-     */
-    protected function addHasOnlyDefaultValuesBody(string &$script): void
     {
-        $table = $this->getTable();
-        $colsWithDefaults = [];
-        foreach ($table->getColumns() as $col) {
-            $def = $col->getDefaultValue();
-            if ($def !== null && !$def->isExpression()) {
-                $colsWithDefaults[] = $col;
-            }
-        }
-
-        foreach ($colsWithDefaults as $col) {
-            /** @var \Propel\Generator\Model\Column $col */
-            $clo = $col->getLowercasedName();
-            $accessor = "\$this->$clo";
-            if ($col->isTemporalType()) {
-                $fmt = $this->getPlatformOrFail()->getTemporalFormatter($col);
-                $accessor = "\$this->$clo && \$this->{$clo}->format('$fmt')";
-            }
-            $notEquals = '!==';
-            $defaultValueString = ColumnCodeProducerFactory::create($col, $this)->getDefaultValueString();
-            if ($col->isPhpObjectType()) {
-                $assumedClassName = $this->declareClass($col->getPhpType());
-                $defaultValueString = "new $assumedClassName($defaultValueString)";
-            }
-            if (strpos($defaultValueString, 'new ') === 0) {
-                $notEquals = '!='; // allow object-comparison for custom PHP types
-            }
-            $script .= "
-        if ($accessor $notEquals $defaultValueString) {
-            return false;
-        }\n";
-        }
-    }
-
-    /**
-     * Adds the function close for the hasOnlyDefaultValues method
-     *
-     * @see addHasOnlyDefaultValues
-     *
-     * @param string $script The script will be modified in this method.
-     *
-     * @return void
-     */
-    protected function addHasOnlyDefaultValuesClose(string &$script): void
-    {
-        $script .= "
-        return true;";
-        $script .= "
-    }
-";
+        return $checksConjunction;
+    }\n";
     }
 
     /**
@@ -931,9 +840,6 @@ abstract class {$this->getUnqualifiedClassName()}$parentClass implements ActiveR
      */
     protected function addHydrateBody(string &$script): void
     {
-        $table = $this->getTable();
-        $platform = $this->getPlatform();
-
         $tableMapClassName = $this->getTableMapClassName();
 
         $script .= "
@@ -941,76 +847,20 @@ abstract class {$this->getUnqualifiedClassName()}$parentClass implements ActiveR
             \$useNumericIndex = \$indexType === TableMap::TYPE_NUM;";
 
         $rowOffset = 0;
-        foreach ($table->getColumns() as $col) {
+        foreach ($this->columnCodeProducers as $columnCodeProducer) {
+            $col = $columnCodeProducer->getColumn();
             if ($col->isLazyLoad()) {
                 continue;
             }
+            $columnPhpName = $col->getPhpName();
+            $varName = '$' . lcfirst($columnPhpName) . 'Value';
 
             $script .= "\n
-            \$rowIndex = \$useNumericIndex ? \$startcol + $rowOffset : $tableMapClassName::translateFieldName('{$col->getPhpName()}', TableMap::TYPE_PHPNAME, \$indexType);
-            \$columnValue = \$row[\$rowIndex];";
-            $clo = $col->getLowercasedName();
-            if ($col->getType() === PropelTypes::CLOB_EMU && $this->getPlatform() instanceof OraclePlatform) {
-                // PDO_OCI returns a stream for CLOB objects, while other PDO adapters return a string...
-                $this->declareGlobalFunction('stream_get_contents');
-                $script .= "
-            \$this->$clo = stream_get_contents(\$columnValue);";
-            } elseif ($col->isLobType() && !$platform->hasStreamBlobImpl()) {
-                $script .= "
-            \$this->$clo = \$this->writeResource(\$columnValue);";
-            } elseif ($col->isTemporalType()) {
-                $dateTimeClass = $this->resolveColumnDateTimeClass($col);
-                $handleMysqlDate = false;
-                if ($this->getPlatform() instanceof MysqlPlatform) {
-                    if (in_array($col->getType(), [PropelTypes::TIMESTAMP, PropelTypes::DATETIME], true)) {
-                        $handleMysqlDate = true;
-                        $mysqlInvalidDateString = '0000-00-00 00:00:00';
-                    } elseif ($col->getType() === PropelTypes::DATE) {
-                        $handleMysqlDate = true;
-                        $mysqlInvalidDateString = '0000-00-00';
-                    }
-                    // 00:00:00 is a valid time, so no need to check for that.
-                }
-                if ($handleMysqlDate) {
-                    $script .= "
-            if (\$columnValue === '$mysqlInvalidDateString') {
-                \$columnValue = null;
-            }";
-                }
-                $script .= "
-            \$this->$clo = (\$columnValue !== null) ? PropelDateTime::newInstance(\$columnValue, null, '$dateTimeClass') : null;";
-            } elseif ($col->isUuidBinaryType()) {
-                $this->declareGlobalFunction('is_resource', 'stream_get_contents');
-                $uuidSwapFlag = $this->getUuidSwapFlagLiteral();
-                $script .= "
-            if (is_resource(\$columnValue)) {
-                \$columnValue = stream_get_contents(\$columnValue);
-            }
-            \$this->$clo = UuidConverter::binToUuid(\$columnValue, $uuidSwapFlag);";
-            } elseif ($col->isPhpPrimitiveType()) {
-                $script .= "
-            \$this->$clo = \$columnValue !== null ? ({$col->getPhpType()})\$columnValue : null;";
-            } elseif ($col->getType() === PropelTypes::OBJECT) {
-                $script .= "
-            \$this->$clo = \$columnValue;";
-            } elseif ($col->getType() === PropelTypes::PHP_ARRAY) {
-                $cloUnserialized = $clo . '_unserialized';
-                $script .= "
-            \$this->$clo = \$columnValue;
-            \$this->$cloUnserialized = null;";
-            } elseif ($col->isBinarySetType()) {
-                $cloConverted = $clo . '_converted';
-                $script .= "
-            \$this->$clo = \$columnValue;
-            \$this->$cloConverted = null;";
-            } elseif ($col->isPhpObjectType()) {
-                $assumedClassName = $this->declareClass($col->getPhpType());
-                $script .= "
-            \$this->$clo = (\$columnValue === null) ? null : new $assumedClassName(\$columnValue);";
-            } else {
-                $script .= "
-            \$this->$clo = \$columnValue;";
-            }
+            \$rowIndex = \$useNumericIndex ? \$startcol + $rowOffset : $tableMapClassName::translateFieldName('$columnPhpName', TableMap::TYPE_PHPNAME, \$indexType);
+            $varName = \$row[\$rowIndex];";
+
+            $script .= $columnCodeProducer->getHydrateStatement($varName);
+
             $rowOffset++;
         }
 
@@ -1158,8 +1008,7 @@ abstract class {$this->getUnqualifiedClassName()}$parentClass implements ActiveR
         $script .= "
 
         return \$query;
-    }
-";
+    }\n";
     }
 
     /**
@@ -1225,10 +1074,11 @@ abstract class {$this->getUnqualifiedClassName()}$parentClass implements ActiveR
     {
         $script .= "
         \$tableMap = {$this->getTableMapClass()}::getTableMap();
-        \$criteria = new Criteria(" . $this->getTableMapClass() . "::DATABASE_NAME);
-";
-        foreach ($this->getTable()->getColumns() as $col) {
-            $accessValueStatement = $this->getAccessValueStatement($col);
+        \$criteria = new Criteria(" . $this->getTableMapClass() . "::DATABASE_NAME);\n";
+
+        foreach ($this->columnCodeProducers as $columnCodeProducer) {
+            $col = $columnCodeProducer->getColumn();
+            $accessValueStatement = $columnCodeProducer->getAccessValueStatement();
             $columnConstant = $this->getColumnConstant($col);
             $columnName = $col->getName();
             $script .= "
@@ -1252,8 +1102,7 @@ abstract class {$this->getUnqualifiedClassName()}$parentClass implements ActiveR
         $script .= "
 
         return \$criteria;
-    }
-";
+    }\n";
     }
 
     /**
@@ -1362,8 +1211,7 @@ abstract class {$this->getUnqualifiedClassName()}$parentClass implements ActiveR
         }
         $script .= "
         return \$result;
-    }
-";
+    }\n";
     }
 
     // addToArray()
@@ -1432,8 +1280,7 @@ $indent};";
         \$pos = {$tableMapClassName}::translateFieldName(\$name, \$type, TableMap::TYPE_NUM);
 
         return \$this->getByPosition(\$pos);
-    }
-";
+    }\n";
     }
 
     /**
@@ -1466,8 +1313,7 @@ $indent};";
         $script .= "
             default => null
         };
-    }
-";
+    }\n";
     }
 
     /**
@@ -1499,8 +1345,7 @@ $indent};";
         \$this->setByPosition(\$pos, \$value);
 
         return \$this;
-    }
-";
+    }\n";
     }
 
     /**
@@ -1570,8 +1415,8 @@ $indent};";
      */
     public function fromArray(array \$arr, string \$keyType = TableMap::$defaultKeyType)
     {
-        \$keys = " . $this->getTableMapClassName() . "::getFieldNames(\$keyType);
-";
+        \$keys = " . $this->getTableMapClassName() . "::getFieldNames(\$keyType);\n";
+
         foreach ($table->getColumns() as $num => $col) {
             $cfc = $col->getPhpName();
             $script .= "
@@ -1582,8 +1427,7 @@ $indent};";
         $script .= "
 
         return \$this;
-    }
-";
+    }\n";
     }
 
     /**
@@ -1622,8 +1466,7 @@ $indent};";
         \$this->fromArray(\$parser->toArray(\$data), \$keyType);
 
         return \$this;
-    }
-";
+    }\n";
     }
 
     /**
@@ -1748,8 +1591,7 @@ $indent};";
     protected function addDeleteClose(string &$script): void
     {
         $script .= "
-    }
-";
+    }\n";
     }
 
     /**
@@ -1761,7 +1603,6 @@ $indent};";
      */
     protected function addReload(string &$script): void
     {
-        $table = $this->getTable();
         $tableMapClass = $this->getTableMapClass();
         $queryClassName = $this->getQueryClassName();
         $script .= "
@@ -1795,24 +1636,16 @@ $indent};";
         if (!\$row || \$row === true) {
             throw new PropelException('Cannot find matching row in the database to reload object values.');
         }
-        \$this->hydrate(\$row, 0, true, \$dataFetcher->getIndexType()); // rehydrate
-";
+        \$this->hydrate(\$row, 0, true, \$dataFetcher->getIndexType());\n";
 
-        // support for lazy load columns
-        foreach ($table->getColumns() as $col) {
-            if (!$col->isLazyLoad()) {
-                continue;
-            }
-            $clo = $col->getLowercasedName();
-            $script .= "
-        // Reset the $clo lazy-load column
-        \$this->{$clo} = null;
-        \$this->{$clo}_isLoaded = false;
-";
+        /** @var array<\Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes\LazyLoadColumnCodeProducer> $lazyLoadCodeProducers */
+        $lazyLoadCodeProducers = array_filter($this->columnCodeProducers, fn (ColumnCodeProducer $p) => $p instanceof LazyLoadColumnCodeProducer);
+        foreach ($lazyLoadCodeProducers as $producer) {
+            $script .= $producer->getReloadStatement();
         }
 
         $script .= "
-        if (\$deep) { // also de-associate any related objects?";
+        if (\$deep) {";
 
         foreach ($this->fkRelationCodeProducers as $producer) {
             $producer->addOnReloadCode($script);
@@ -1828,8 +1661,7 @@ $indent};";
 
         $script .= "
         }
-    }
-";
+    }\n";
     }
 
     /**
@@ -1931,8 +1763,7 @@ $indent};";
         }
         $script .= "
         return spl_object_hash(\$this);
-    }
-";
+    }\n";
     }
 
     /**
@@ -1978,8 +1809,7 @@ $indent};";
     public function getPrimaryKey()
     {
         return \$this->get{$name}();
-    }
-";
+    }\n";
     }
 
     /**
@@ -2034,8 +1864,7 @@ $indent};";
     public function getPrimaryKey()
     {
         return null;
-    }
-";
+    }\n";
     }
 
     /**
@@ -2149,8 +1978,7 @@ $indent};";
     public function isPrimaryKeyNull(): bool
     {
         return {$returnExpression};
-    }
-";
+    }\n";
     }
 
     /**
@@ -2306,8 +2134,7 @@ $indent};";
         }
         $script .= "
         return \$affectedRows;
-    }
-";
+    }\n";
     }
 
     /**
@@ -2362,8 +2189,7 @@ $indent};";
         }
         $script .= "
         \$this->setNew(false);
-    }
-";
+    }\n";
 
         return $script;
     }
@@ -2498,8 +2324,7 @@ $indent};";
             } catch (Exception \$e) {
                 throw new PropelException('Unable to get sequence id.', 0, \$e);
             }
-        }
-";
+        }\n";
         }
 
         $script .= "
@@ -2531,9 +2356,10 @@ $indent};";
                 switch (\$columnName) {";
 
         $tab = '                        ';
-        foreach ($table->getColumns() as $column) {
+        foreach ($this->columnCodeProducers as $columnCodeProducer) {
+            $column = $columnCodeProducer->getColumn();
             $columnNameCase = var_export($this->quoteIdentifier($column->getName()), true);
-            $accessValueStatement = $this->getAccessValueStatement($column);
+            $accessValueStatement = $columnCodeProducer->getAccessValueStatement();
             $bindValueStatement = $platform->getColumnBindingPHP($column, '$identifier', $accessValueStatement, $tab);
             $script .= "
                     case $columnNameCase:$bindValueStatement
@@ -2548,8 +2374,7 @@ $indent};";
             Propel::log(\$e->getMessage(), Propel::LOG_ERR);
 
             throw new PropelException(\"Unable to execute INSERT statement [\$sql]\", 0, \$e);
-        }
-";
+        }\n";
 
         // if auto-increment, get the id after
         if ($platform->isNativeIdMethodAutoIncrement() && $table->getIdMethod() === 'native') {
@@ -2574,35 +2399,10 @@ $indent};";
         \$this->set{$columnName}($cast\$pk);";
                 }
             }
-            $script .= "
-";
+            $script .= "\n";
         }
 
         return $script;
-    }
-
-    /**
-     * Get the statement how a column value is accessed in the script.
-     *
-     * Note that this is not necessarily just the getter. If the value is
-     * stored on the model in an encoded format, the statement returned by
-     * this method includes the statement to decode the value.
-     *
-     * @param \Propel\Generator\Model\Column $column
-     *
-     * @return string
-     */
-    protected function getAccessValueStatement(Column $column): string
-    {
-        $columnName = $column->getLowercasedName();
-
-        if ($column->isUuidBinaryType()) {
-            $uuidSwapFlag = $this->getUuidSwapFlagLiteral();
-
-            return "UuidConverter::uuidToBin(\$this->$columnName, $uuidSwapFlag)";
-        }
-
-        return "\$this->$columnName";
     }
 
     /**
@@ -2628,8 +2428,7 @@ $indent};";
         \$valuesCriteria = \$this->buildCriteria();
 
         return \$selectCriteria->doUpdate(\$valuesCriteria, \$con);
-    }
-";
+    }\n";
     }
 
     /**
@@ -2646,8 +2445,7 @@ $indent};";
      * Flag to prevent endless save loop, if this object is referenced
      * by another object which falls in this transaction.
      */
-    protected bool \$alreadyInSave = false;
-";
+    protected bool \$alreadyInSave = false;\n";
     }
 
     /**
@@ -2867,8 +2665,7 @@ $indent};";
     protected function addSaveClose(string &$script): void
     {
         $script .= "
-    }
-";
+    }\n";
     }
 
     /**
@@ -2978,8 +2775,7 @@ $indent};";
         if (\$deepCopy) {
             // important: temporarily setNew(false) because this affects the behavior of
             // the getter/setter methods for fkey referrer objects.
-            \$copyObj->setNew(false);
-";
+            \$copyObj->setNew(false);\n";
             foreach ($table->getReferrers() as $fk) {
                 //HL: commenting out self-referential check below
                 //        it seems to work as expected and is probably desirable to have those referrers from same table deep-copied.
@@ -3009,8 +2805,7 @@ $indent};";
                 // } /* if tblFK != table */
             }
             $script .= "
-        }
-";
+        }\n";
         } /* if (count referrers > 0 ) */
 
         $script .= "
@@ -3027,8 +2822,7 @@ $indent};";
         }
         $script .= "
         }
-    }
-";
+    }\n";
     }
 
     /**
@@ -3062,38 +2856,20 @@ $indent};";
         }
 
         foreach ($table->getForeignKeys() as $fk) {
-            $attributeName = $this->getFKVarName($fk);
+            $attribute = '$this->' . $this->getFKVarName($fk);
             $relationIdentifier = $fk->getIdentifierReversed();
             $removeMethodCall = $fk->isOneToOne()
-            ? "set{$relationIdentifier}(null)"
-            : "remove{$relationIdentifier}(\$this)";
+                ? "set{$relationIdentifier}(null)"
+                : "remove{$relationIdentifier}(\$this)";
 
             $script .= "
-        if (\$this->$attributeName !== null) {
-            \$this->$attributeName->$removeMethodCall;
+        if ($attribute !== null) {
+            {$attribute}->$removeMethodCall;
         }";
         }
 
-        foreach ($table->getColumns() as $col) {
-            $clo = $col->getLowercasedName();
-            $script .= "
-        \$this->" . $clo . ' = null;';
-            if ($col->isLazyLoad()) {
-                $script .= "
-        \$this->" . $clo . '_isLoaded = false;';
-            }
-            if ($col->getType() == PropelTypes::OBJECT || $col->getType() == PropelTypes::PHP_ARRAY) {
-                $cloUnserialized = $clo . '_unserialized';
-
-                $script .= "
-        \$this->$cloUnserialized = null;";
-            }
-            if ($col->isBinarySetType()) {
-                $cloConverted = $clo . '_converted';
-
-                $script .= "
-        \$this->$cloConverted = null;";
-            }
+        foreach ($this->columnCodeProducers as $columnCodeProducer) {
+            $script .= $columnCodeProducer->getClearValueStatement();
         }
 
         $script .= "
@@ -3111,8 +2887,7 @@ $indent};";
         \$this->setDeleted(false);
 
         return \$this;
-    }
-";
+    }\n";
     }
 
     /**
@@ -3144,8 +2919,7 @@ $indent};";
     public function clearAllReferences(bool \$deep = false): static
     {{$methodBodyCode}
         return \$this;
-    }
-";
+    }\n";
     }
 
     /**
@@ -3205,8 +2979,7 @@ $indent};";
     public function __toString(): string
     {
         return (string)\$this->get{$column->getPhpName()}();
-    }
-";
+    }\n";
 
                 return;
             }
@@ -3221,8 +2994,7 @@ $indent};";
     public function __toString()
     {
         return (string)\$this->exportTo(" . $this->getTableMapClassName() . "::DEFAULT_STRING_FORMAT);
-    }
-";
+    }\n";
     }
 
     /**

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/AbstractArrayColumnCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/AbstractArrayColumnCodeProducer.php
@@ -7,8 +7,23 @@ namespace Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes;
 /**
  * Base class for array-based column types (array and set).
  */
-abstract class AbstractArrayColumnCodeProducer extends ColumnCodeProducer
+abstract class AbstractArrayColumnCodeProducer extends AbstractDeserializableColumnCodeProducer
 {
+    /**
+     * Get template strings for when this is a lazy-loaded column
+     *
+     * @return array{string, string, string}
+     */
+    protected function getLazyLoadConnectionInterfaceDeclarations(): array
+    {
+        return !$this->column->isLazyLoad() ? ['', '', ''] : [
+            '
+     * @param \Propel\Runtime\Connection\ConnectionInterface $con Optional ConnectionInterface connection fetch lazy-loaded column.',
+            ', ?ConnectionInterface $con = null',
+            '$con',
+        ];
+    }
+
     /**
      * Adds a tester method for an array column.
      *
@@ -24,29 +39,20 @@ abstract class AbstractArrayColumnCodeProducer extends ColumnCodeProducer
         $cfc = $this->column->getPhpName();
         $visibility = $this->column->getAccessorVisibility();
         $singularPhpName = $this->column->getPhpSingularName();
-        $script .= $this->column->isLazyLoad() ? "
+
+        [$conDoc, $conParam, $conVar] = $this->getLazyLoadConnectionInterfaceDeclarations();
+
+        $script .= "
     /**
      * Test the presence of a value in the [$clo] $typeDescription column value.
      *
-     * @param mixed \$value
-     * @param \Propel\Runtime\Connection\ConnectionInterface \$con An optional ConnectionInterface connection to use for fetching this lazy-loaded column.
+     * @param mixed \$value{$conDoc}
      *
      * @return bool
      */
-    $visibility function has$singularPhpName(\$value, ?ConnectionInterface \$con = null): bool
+    $visibility function has$singularPhpName(\$value{$conParam}): bool
     {
-        return in_array(\$value, \$this->get$cfc(\$con));
-    }\n" : "
-    /**
-     * Test the presence of a value in the [$clo] $typeDescription column value.
-     *
-     * @param mixed \$value
-     *
-     * @return bool
-     */
-    $visibility function has$singularPhpName(\$value): bool
-    {
-        return in_array(\$value, \$this->get$cfc());
+        return in_array(\$value, \$this->get$cfc($conVar));
     }\n";
     }
 
@@ -65,33 +71,19 @@ abstract class AbstractArrayColumnCodeProducer extends ColumnCodeProducer
         $cfc = $col->getPhpName();
         $visibility = $col->getAccessorVisibility();
         $singularPhpName = $col->getPhpSingularName();
-        $script .= $this->column->isLazyLoad() ? "
-    /**
-     * Adds a value to the [$clo] $typeDescription column value.{$this->getColumnDescriptionDoc()}
-     *
-     * @param mixed \$value
-     * @param ConnectionInterface \$con An optional ConnectionInterface connection to use for fetching this lazy-loaded column.
-     *
-     * @return \$this
-     */
-    $visibility function add$singularPhpName(\$value, ?ConnectionInterface \$con = null)
-    {
-        \$currentArray = \$this->get$cfc(\$con);
-        \$currentArray[] = \$value;
-        \$this->set$cfc(\$currentArray);
+        [$conDoc, $conParam, $conVar] = $this->getLazyLoadConnectionInterfaceDeclarations();
 
-        return \$this;
-    }\n" : "
+        $script .= "
     /**
      * Adds a value to the [$clo] $typeDescription column value.{$this->getColumnDescriptionDoc()}
      *
-     * @param mixed \$value
+     * @param mixed \$value{$conDoc}
      *
      * @return \$this
      */
-    $visibility function add$singularPhpName(\$value)
+    $visibility function add$singularPhpName(\$value{$conParam})
     {
-        \$currentArray = \$this->get$cfc();
+        \$currentArray = \$this->get$cfc($conVar);
         \$currentArray[] = \$value;
         \$this->set$cfc(\$currentArray);
 
@@ -114,39 +106,20 @@ abstract class AbstractArrayColumnCodeProducer extends ColumnCodeProducer
         $cfc = $col->getPhpName();
         $visibility = $col->getAccessorVisibility();
         $singularPhpName = $col->getPhpSingularName();
-        $script .= $this->column->isLazyLoad() ? "
-    /**
-     * Removes a value from the [$clo] $typeDescription column value.{$this->getColumnDescriptionDoc()}
-     *
-     * @param mixed \$value
-     *
-     * @param \Propel\Runtime\Connection\ConnectionInterface \$con An optional ConnectionInterface connection to use for fetching this lazy-loaded column.
-     *
-     * @return \$this
-     */
-    $visibility function remove$singularPhpName(\$value, ?ConnectionInterface \$con = null)
-    {
-        \$targetArray = [];
-        foreach (\$this->get$cfc(\$con) as \$element) {
-            if (\$element != \$value) {
-                \$targetArray[] = \$element;
-            }
-        }
-        \$this->set$cfc(\$targetArray);
+        [$conDoc, $conParam, $conVar] = $this->getLazyLoadConnectionInterfaceDeclarations();
 
-        return \$this;
-    }\n" : "
+        $script .= "
     /**
      * Removes a value from the [$clo] $typeDescription column value.{$this->getColumnDescriptionDoc()}
      *
-     * @param mixed \$value
+     * @param mixed \$value{$conDoc}
      *
      * @return \$this
      */
-    $visibility function remove$singularPhpName(\$value)
+    $visibility function remove$singularPhpName(\$value{$conParam})
     {
         \$targetArray = [];
-        foreach (\$this->get$cfc() as \$element) {
+        foreach (\$this->get$cfc($conVar) as \$element) {
             if (\$element != \$value) {
                 \$targetArray[] = \$element;
             }

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/AbstractDeserializableColumnCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/AbstractDeserializableColumnCodeProducer.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes;
+
+abstract class AbstractDeserializableColumnCodeProducer extends ColumnCodeProducer
+{
+    /**
+     * Default affix for attribute holding deserialized value.
+     *
+     * @see static::addColumnAttributeDeserialized()
+     *
+     * @var string
+     */
+    protected const DESERIALIZED_ATTRIBUTE_AFFIX = '_deserialized';
+
+    /**
+     * Get attribute types in order [database field type, deserialized type]
+     *
+     * @return array{string, string}
+     */
+    abstract protected function getQualifiedAttributeTypes(): array;
+
+    /**
+     * @param string $prefix
+     *
+     * @return string
+     */
+    protected function getDeserializedAttributeName(string $prefix = '$this->'): string
+    {
+        return $this->getAttributeName($prefix, static::DESERIALIZED_ATTRIBUTE_AFFIX);
+    }
+
+    /**
+     * @param string $script The script will be modified in this method.
+     *
+     * @return void
+     */
+    #[\Override]
+    public function addColumnAttributes(string &$script): void
+    {
+        [$dbType, $deserializedValueType] = $this->getQualifiedAttributeTypes();
+        $this->addDefaultColumnAttribute($script, $dbType);
+        $this->addColumnAttributeDeserialized($script, $deserializedValueType);
+    }
+
+    /**
+     * Adds attribute for deserialized value of array and object columns.
+     *
+     * @param string $script
+     * @param string $typeHint
+     *
+     * @return void
+     */
+    protected function addColumnAttributeDeserialized(string &$script, string $typeHint): void
+    {
+        $valueColumnName = $this->column->getLowercasedName();
+        $description = "Deserialized value of [$valueColumnName] field.";
+        $columnName = $valueColumnName . static::DESERIALIZED_ATTRIBUTE_AFFIX;
+
+        $script .= $this->buildDeclareColumnCode($columnName, $description, $typeHint);
+    }
+
+    /**
+     * Build statement used in Model::hydrate()
+     *
+     * @see ObjectBuilder::addHydrateBody()}
+     *
+     * @param string $valueVariable
+     *
+     * @return string
+     */
+    #[\Override]
+    public function getHydrateStatement(string $valueVariable): string
+    {
+        $dbValueAttribute = $this->getAttributeName();
+        $deserializedAttribute = $this->getDeserializedAttributeName();
+
+        return "
+            $dbValueAttribute = $valueVariable;
+            $deserializedAttribute = null;";
+    }
+
+    /**
+     * Build statement used in Model::clear()
+     *
+     * @see ObjectBuilder::addClear()}
+     *
+     * @return string
+     */
+    #[\Override]
+    public function getClearValueStatement(): string
+    {
+        $deserializedAttribute = $this->getDeserializedAttributeName();
+
+        return parent::getClearValueStatement() . "
+        $deserializedAttribute = null;";
+    }
+}

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/ArrayColumnCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/ArrayColumnCodeProducer.php
@@ -14,19 +14,18 @@ class ArrayColumnCodeProducer extends AbstractArrayColumnCodeProducer
     #[\Override]
     protected function getQualifiedTypeString(): string
     {
-        return 'array';
+        return 'array<string>';
     }
 
     /**
-     * @param string $script The script will be modified in this method.
+     * Get attribute types in order [database field type, deserialized type]
      *
-     * @return void
+     * @return array{string, string}
      */
     #[\Override]
-    public function addColumnAttributes(string &$script): void
+    protected function getQualifiedAttributeTypes(): array
     {
-        $this->addDefaultColumnAttribute($script, 'string');
-        $this->addColumnAttributeUnserialized($script, 'array<string>');
+        return ['string', 'array<string>'];
     }
 
     /**
@@ -65,18 +64,15 @@ class ArrayColumnCodeProducer extends AbstractArrayColumnCodeProducer
     #[\Override]
     protected function addAccessorBody(string &$script): void
     {
-        $clo = $this->column->getLowercasedName();
-        $cloUnserialized = $clo . '_unserialized';
+        $stringAttribute = $this->getAttributeName();
+        $arrayAttribute = $this->getDeserializedAttributeName();
 
         $script .= "
-        if (\$this->$cloUnserialized === null) {
-            \$this->$cloUnserialized = [];
-        }
-        if (!\$this->$cloUnserialized && \$this->$clo !== null) {
-            \$this->$cloUnserialized = static::unserializeArray(\$this->$clo);
+        if ($arrayAttribute === null) {
+            $arrayAttribute = !$stringAttribute ? [] : static::unserializeArray($stringAttribute);
         }
 
-        return \$this->$cloUnserialized;";
+        return $arrayAttribute;";
     }
 
     /**
@@ -105,15 +101,15 @@ class ArrayColumnCodeProducer extends AbstractArrayColumnCodeProducer
     #[\Override]
     protected function addMutatorBody(string &$script): void
     {
-        $col = $this->column;
-        $clo = $col->getLowercasedName();
-        $cloUnserialized = $clo . '_unserialized';
+        $stringAttribute = $this->getAttributeName();
+        $arrayAttribute = $this->getDeserializedAttributeName();
+        $columnConstant = $this->builder->getColumnConstant($this->getColumn());
 
         $script .= "
-        if (\$this->$cloUnserialized !== \$v) {
-            \$this->$cloUnserialized = \$v;
-            \$this->$clo = static::serializeArray(\$v);
-            \$this->modifiedColumns[" . $this->builder->getColumnConstant($col) . "] = true;
+        if ($arrayAttribute !== \$v) {
+            $arrayAttribute = \$v;
+            $stringAttribute = static::serializeArray(\$v);
+            \$this->modifiedColumns[$columnConstant] = true;
         }\n";
     }
 

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/BoolColumnCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/BoolColumnCodeProducer.php
@@ -121,9 +121,8 @@ class BoolColumnCodeProducer extends ColumnCodeProducer
     protected function addMutatorBody(string &$script): void
     {
         $this->declareGlobalFunction('in_array', 'is_string', 'strtolower');
-        $col = $this->column;
-        $clo = $col->getLowercasedName();
-        $columnConstant = $this->builder->getColumnConstant($col);
+        $attribute = $this->getAttributeName();
+        $columnConstant = $this->builder->getColumnConstant($this->column);
 
         $script .= "
         if (\$v !== null) {
@@ -132,8 +131,8 @@ class BoolColumnCodeProducer extends ColumnCodeProducer
                 : (bool)\$v;
         }
 
-        if (\$this->$clo !== \$v) {
-            \$this->$clo = \$v;
+        if ($attribute !== \$v) {
+            $attribute = \$v;
             \$this->modifiedColumns[$columnConstant] = true;
         }\n";
     }

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/ColumnCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/ColumnCodeProducer.php
@@ -7,9 +7,13 @@ namespace Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes;
 use Propel\Generator\Builder\Om\AbstractSubsectionCodeProducer;
 use Propel\Generator\Builder\Om\ObjectBuilder;
 use Propel\Generator\Model\Column;
+use Propel\Generator\Model\PropelTypes;
+use Propel\Generator\Platform\OraclePlatform;
+use Propel\Runtime\Util\UuidConverter;
 use function array_intersect;
 use function explode;
 use function settype;
+use function str_starts_with;
 use function var_export;
 
 /**
@@ -41,6 +45,17 @@ class ColumnCodeProducer extends AbstractSubsectionCodeProducer
     }
 
     /**
+     * @param string $prefix
+     * @param string|null $suffix
+     *
+     * @return string
+     */
+    protected function getAttributeName(string $prefix = '$this->', string|null $suffix = null): string
+    {
+        return $prefix . $this->column->getLowercasedName() . ($suffix ?? '');
+    }
+
+    /**
      * @return string
      */
     protected function getQualifiedTypeString(): string
@@ -69,26 +84,9 @@ class ColumnCodeProducer extends AbstractSubsectionCodeProducer
     public function addDefaultColumnAttribute(string &$script, ?string $columnDocType = null): void
     {
         $columnName = $this->column->getLowercasedName();
-        $description = "The value for the $columnName field.{$this->getColumnDescriptionDoc()}{$this->getDefaultValueDescription()}";
+        $description = "Value of [$columnName] field.{$this->getColumnDescriptionDoc()}{$this->getDefaultValueDescription()}";
         $docType = $columnDocType ?? $this->getQualifiedTypeString();
         $script .= $this->buildDeclareColumnCode($columnName, $description, $docType);
-    }
-
-    /**
-     * Adds attribute for unserialized value of array and object columns.
-     *
-     * @param string $script
-     * @param string $typeHint
-     *
-     * @return void
-     */
-    protected function addColumnAttributeUnserialized(string &$script, string $typeHint): void
-    {
-        $valueColumnName = $this->column->getLowercasedName();
-        $description = "The unserialized \$$valueColumnName value.";
-        $columnName = "{$valueColumnName}_unserialized";
-
-        $script .= $this->buildDeclareColumnCode($columnName, $description, $typeHint);
     }
 
     /**
@@ -111,8 +109,8 @@ class ColumnCodeProducer extends AbstractSubsectionCodeProducer
         if (!$declareType) {
             $columnDeclaration = "\${$columnName}";
         } else {
-            $typeDeclaration = $this->referencedClasses->resolveTypeDeclarationFromDocType($docType) . '|null';
-            $columnDeclaration = "$typeDeclaration \${$columnName} = null";
+            $typeDeclaration = $this->referencedClasses->resolveTypeDeclarationFromDocType($docType);
+            $columnDeclaration = "$typeDeclaration|null \${$columnName} = null";
         }
 
         return "
@@ -153,21 +151,105 @@ class ColumnCodeProducer extends AbstractSubsectionCodeProducer
     }
 
     /**
+     * Build statement used in Model::hydrate()
+     *
+     * @see ObjectBuilder::addBuildCriteriaBody()}
+     * @see ObjectBuilder::addDoInsertBodyRaw()}
+     *
+     * @return string
+     */
+    public function getAccessValueStatement(): string
+    {
+        $attribute = $this->getAttributeName();
+
+        if ($this->column->isUuidBinaryType()) {
+            $uuidSwapFlag = $this->builder->getUuidSwapFlagLiteral();
+
+            return "UuidConverter::uuidToBin($attribute, $uuidSwapFlag)";
+        }
+
+        return $attribute;
+    }
+
+    /**
+     * Build statement used in Model::hydrate()
+     *
+     * @see ObjectBuilder::addHydrateBody()}
+     *
+     * @param string $valueVariable
+     *
+     * @return string
+     */
+    public function getHydrateStatement(string $valueVariable): string
+    {
+        $col = $this->column;
+        $attribute = $this->getAttributeName();
+
+        if ($col->getType() === PropelTypes::CLOB_EMU && $this->getPlatform() instanceof OraclePlatform) {
+            // PDO_OCI returns a stream for CLOB objects, while other PDO adapters return a string...
+            $this->declareGlobalFunction('stream_get_contents');
+
+            return "
+            $attribute = stream_get_contents($valueVariable);";
+        } elseif ($col->isUuidBinaryType()) {
+            $this->declareClasses(UuidConverter::class);
+            $this->declareGlobalFunction('is_resource', 'stream_get_contents');
+            $uuidSwapFlag = $this->builder->getUuidSwapFlagLiteral();
+
+            return "
+            if (is_resource($valueVariable)) {
+                $valueVariable = stream_get_contents($valueVariable);
+            }
+            $attribute = UuidConverter::binToUuid($valueVariable, $uuidSwapFlag);";
+        } elseif ($col->isPhpPrimitiveType()) {
+            $className = $col->getPhpType();
+
+            return "
+            $attribute = $valueVariable !== null ? ($className)$valueVariable : null;";
+        } elseif ($col->isPhpObjectType()) {
+            $constructor = $this->declareClass($col->getPhpType());
+
+            return "
+            $attribute = ($valueVariable === null) ? null : new $constructor($valueVariable);";
+        } else {
+            return "
+            $attribute = $valueVariable;";
+        }
+    }
+
+    /**
+     * Build statement used in Model::clear()
+     *
+     * @see ObjectBuilder::addClear()}
+     *
+     * @return string
+     */
+    public function getClearValueStatement(): string
+    {
+        $attribute = $this->getAttributeName();
+
+        return "
+        $attribute = null;";
+    }
+
+    /**
      * Build statement used in Model::applyDefaultValues()
+     *
+     * @see ObjectBuilder::addApplyDefaultValuesBody()}
      *
      * @return string
      */
     public function getApplyDefaultValueStatement(): string
     {
-        $clo = $this->column->getLowercasedName();
+        $attribute = $this->getAttributeName();
         $defaultValue = $this->getDefaultValueString();
         if ($this->column->isPhpObjectType()) {
-            $assumedClassName = $this->declareClass($this->column->getPhpType());
-            $defaultValue = "new $assumedClassName($defaultValue)";
+            $constructor = $this->declareClass($this->column->getPhpType());
+            $defaultValue = "new $constructor($defaultValue)";
         }
 
         return "
-        \$this->{$clo} = $defaultValue;";
+        $attribute = $defaultValue;";
     }
 
     /**
@@ -187,6 +269,30 @@ class ColumnCodeProducer extends AbstractSubsectionCodeProducer
         }
 
         return var_export($defaultValue, true);
+    }
+
+    /**
+     * Build statement to check if current value is the default value.
+     *
+     * @see ObjectBuilder::addHasOnlyDefaultValuesBody()
+     *
+     * @return string
+     */
+    public function getIsDefaultValueStatement(): string
+    {
+            $attribute = $this->getAttributeName();
+
+            $defaultValueString = $this->getDefaultValueString();
+        if ($this->column->isPhpObjectType()) {
+            $assumedClassName = $this->declareClass($this->column->getPhpType());
+            $defaultValueString = "new $assumedClassName($defaultValueString)";
+        }
+
+            $equals = str_starts_with($defaultValueString, 'new ')
+                ? '==' // allow object-comparison for custom PHP types
+                : '===';
+
+            return "$attribute $equals $defaultValueString";
     }
 
     /**

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/ColumnCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/ColumnCodeProducer.php
@@ -151,8 +151,6 @@ class ColumnCodeProducer extends AbstractSubsectionCodeProducer
     }
 
     /**
-     * Build statement used in Model::hydrate()
-     *
      * @see ObjectBuilder::addBuildCriteriaBody()}
      * @see ObjectBuilder::addDoInsertBodyRaw()}
      *

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/EnumBinaryColumnCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/EnumBinaryColumnCodeProducer.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes;
 
 use Propel\Generator\Exception\EngineException;
+use Propel\Runtime\Exception\PropelException;
 use function array_search;
 use function in_array;
 use function sprintf;
@@ -61,18 +62,22 @@ class EnumBinaryColumnCodeProducer extends ColumnCodeProducer
     #[\Override]
     protected function addAccessorBody(string &$script): void
     {
-        $clo = $this->column->getLowercasedName();
+        $this->declareClass(PropelException::class);
+
+        $attribute = $this->getAttributeName();
+        $columnConstant = $this->builder->getColumnConstant($this->column);
+        $tableMapClassName = $this->getTableMapClassName();
 
         $script .= "
-        if (\$this->$clo === null) {
+        if ($attribute === null) {
             return null;
         }
-        \$valueSet = " . $this->getTableMapClassName() . '::getValueSet(' . $this->builder->getColumnConstant($this->column) . ");
-        if (!isset(\$valueSet[\$this->$clo])) {
-            throw new PropelException('Unknown stored enum key: ' . \$this->$clo);
+        \$valueSet = {$tableMapClassName}::getValueSet($columnConstant);
+        if (!isset(\$valueSet[$attribute])) {
+            throw new PropelException('Unknown stored enum key: ' . $attribute);
         }
 
-        return \$valueSet[\$this->$clo];";
+        return \$valueSet[$attribute];";
     }
 
     /**
@@ -84,13 +89,12 @@ class EnumBinaryColumnCodeProducer extends ColumnCodeProducer
     public function addMutatorComment(string &$script): void
     {
         $clo = $this->column->getLowercasedName();
-        $orNull = $this->column->isNotNull() ? '' : '|null';
 
         $script .= "
     /**
      * Set the value of [$clo] column.{$this->getColumnDescriptionDoc()}
      *
-     * @param string{$orNull} \$v new value
+     * @param string|null \$v new value
      *
      * @throws \\Propel\\Runtime\\Exception\\PropelException
      *
@@ -108,14 +112,16 @@ class EnumBinaryColumnCodeProducer extends ColumnCodeProducer
     #[\Override]
     protected function addMutatorBody(string &$script): void
     {
+        $this->declareClass(PropelException::class);
         $this->declareGlobalFunction('array_search', 'is_int');
         $col = $this->column;
-        $clo = $col->getLowercasedName();
+        $attribute = $this->getAttributeName();
+        $tableMapClassName = $this->getTableMapClassName();
         $columnConstant = $this->builder->getColumnConstant($col);
 
         $script .= "
         if (\$v !== null) {
-            \$valueSet = " . $this->getTableMapClassName() . "::getValueSet($columnConstant);
+            \$valueSet = {$tableMapClassName}::getValueSet($columnConstant);
             \$keyId = array_search(\$v, \$valueSet);
             if (!is_int(\$keyId)) {
                 throw new PropelException(\"Value '\$v' is not accepted in this enumerated column\");
@@ -123,8 +129,8 @@ class EnumBinaryColumnCodeProducer extends ColumnCodeProducer
             \$v = \$keyId;
         }
 
-        if (\$this->$clo !== \$v) {
-            \$this->$clo = \$v;
+        if ($attribute !== \$v) {
+            $attribute = \$v;
             \$this->modifiedColumns[$columnConstant] = true;
         }\n";
     }

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/JsonColumnCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/JsonColumnCodeProducer.php
@@ -17,15 +17,13 @@ class JsonColumnCodeProducer extends ColumnCodeProducer
     {
         $clo = $this->column->getLowercasedName();
 
-        $orNull = $this->column->isNotNull() ? '' : '|null';
-
         $script .= "
     /**
      * Get the [$clo] column value.{$this->getColumnDescriptionDoc()}
      *
      * @param bool \$asArray Returns the JSON data as array instead of object{$additionalParam}
      *
-     * @return object|array{$orNull}
+     * @return object|array
      */";
     }
 
@@ -57,9 +55,10 @@ class JsonColumnCodeProducer extends ColumnCodeProducer
     #[\Override]
     protected function addAccessorBody(string &$script): void
     {
-        $clo = $this->column->getLowercasedName();
+        $stringAttribute = $this->getAttributeName();
+
         $script .= "
-        return json_decode(\$this->$clo, \$asArray);";
+        return json_decode($stringAttribute, \$asArray);";
     }
 
     /**
@@ -98,7 +97,8 @@ class JsonColumnCodeProducer extends ColumnCodeProducer
     #[\Override]
     protected function addMutatorBody(string &$script): void
     {
-        $clo = $this->column->getLowercasedName();
+        $stringAttribute = $this->getAttributeName();
+        $columnConstant = $this->builder->getColumnConstant($this->column);
 
         $script .= "
         if (is_string(\$v)) {
@@ -106,9 +106,9 @@ class JsonColumnCodeProducer extends ColumnCodeProducer
             \$v = json_decode(\$v);
         }
         \$encodedValue = json_encode(\$v);
-        if (\$encodedValue !== \$this->$clo) {
-            \$this->$clo = \$encodedValue;
-            \$this->modifiedColumns[" . $this->builder->getColumnConstant($this->column) . "] = true;
+        if (\$encodedValue !== $stringAttribute) {
+            $stringAttribute = \$encodedValue;
+            \$this->modifiedColumns[$columnConstant] = true;
         }\n";
     }
 }

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/LazyLoadColumnCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/LazyLoadColumnCodeProducer.php
@@ -365,13 +365,8 @@ class LazyLoadColumnCodeProducer extends ColumnCodeProducer
     #[\Override]
     protected function addMutatorBody(string &$script): void
     {
-        $cfc = $this->column->getPhpName();
         $isLoadedAttribute = $this->getIsLoadedAttributeName();
         $script .= "
-        // explicitly set the is-loaded flag to true for this lazy load col;
-        // it doesn't matter if the value is actually set or not (logic below) as
-        // any attempt to set the value means that no db lookup should be performed
-        // when the get$cfc() method is called.
         $isLoadedAttribute = true;\n";
 
         $this->columnCodeProducer->addMutatorBody($script);

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/LazyLoadColumnCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/LazyLoadColumnCodeProducer.php
@@ -4,10 +4,10 @@ declare(strict_types = 1);
 
 namespace Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes;
 
+use LogicException;
 use Propel\Generator\Config\AbstractGeneratorConfig;
 use Propel\Generator\Model\PropelTypes;
 use Propel\Generator\Model\Table;
-use Propel\Generator\Platform\OraclePlatform;
 use Propel\Generator\Platform\SqlsrvPlatform;
 
 class LazyLoadColumnCodeProducer extends ColumnCodeProducer
@@ -124,6 +124,19 @@ class LazyLoadColumnCodeProducer extends ColumnCodeProducer
     public function getDefaultValueString(): string
     {
         return $this->columnCodeProducer->getDefaultValueString();
+    }
+
+    /**
+     * @param string $valueVariable
+     *
+     * @throws \LogicException
+     *
+     * @return string
+     */
+    #[\Override]
+    public function getHydrateStatement(string $valueVariable): string
+    {
+        throw new LogicException('Lazy-load column should never be hydrated directly.');
     }
 
     /**
@@ -270,72 +283,37 @@ class LazyLoadColumnCodeProducer extends ColumnCodeProducer
      */
     protected function addLazyLoaderBody(string &$script): void
     {
-        $this->declareGlobalFunction('current');
+        $this->declareGlobalFunction('current', 'is_bool', 'current');
         $platform = $this->getPlatform();
-        $fieldAttribute = $this->getAttributeName();
         $isLoadedAttribute = $this->getIsLoadedAttributeName();
         $columnConstant = $this->builder->getColumnConstant($this->column);
         $queryClassName = $this->getQueryClassName();
         $clo = $this->column->getLowercasedName();
+        $hydrateFieldStatement = "\n" . $this->columnCodeProducer->getHydrateStatement('$firstColumn');
 
-        // pdo_sqlsrv driver requires the use of PDOStatement::bindColumn() or a hex string will be returned
-        if ($this->column->getType() === PropelTypes::BLOB && $platform instanceof SqlsrvPlatform) {
-            $script .= "
+        $script .= "
         \$c = \$this->buildPkeyCriteria();
         \$c->addSelectColumn($columnConstant);
         try {
-            \$row = [0 => null];
-            \$dataFetcher = {$queryClassName}::create(null, \$c)->fetch(\$con);
+            \$dataFetcher = {$queryClassName}::create(null, \$c)->fetch(\$con);";
+
+        if (!$platform instanceof SqlsrvPlatform || $this->column->getType() !== PropelTypes::BLOB) {
+            $script .= "
+            \$row = \$dataFetcher->fetch();";
+        } else {
+            // pdo_sqlsrv driver requires the use of PDOStatement::bindColumn() or a hex string will be returned
+            $script .= "
             if (\$dataFetcher instanceof PDODataFetcher) {
-                \$dataFetcher->bindColumn(1, \$row[0], PDO::PARAM_LOB, 0, PDO::SQLSRV_ENCODING_BINARY);
+                \$param = [0 => null];
+                \$dataFetcher->bindColumn(1, \$param[0], PDO::PARAM_LOB, 0, PDO::SQLSRV_ENCODING_BINARY);
             }
-            \$row = \$dataFetcher->fetch(PDO::FETCH_BOUND);
-            \$dataFetcher->close();";
-        } else {
-            $script .= "
-        \$c = \$this->buildPkeyCriteria();
-        \$c->addSelectColumn($columnConstant);
-        try {
-            \$dataFetcher = {$queryClassName}::create(null, \$c)->fetch(\$con);
-            \$row = \$dataFetcher->fetch();
-            \$dataFetcher->close();";
-        }
-
-        $script .= "\n
-            \$firstColumn = is_bool(\$row) ? null : current(\$row);\n";
-
-        if ($this->column->getType() === PropelTypes::CLOB && $platform instanceof OraclePlatform) {
-            // PDO_OCI returns a stream for CLOB objects, while other PDO adapters return a string...
-            $this->declareGlobalFunction('stream_get_contents');
-            $script .= "
-            if (\$firstColumn) {
-                $fieldAttribute = stream_get_contents(\$firstColumn);
-            }";
-        } elseif ($this->column->isLobType() && !$platform->hasStreamBlobImpl()) {
-            $script .= "
-            $fieldAttribute = \$this->writeResource(\$firstColumn);";
-        } elseif ($this->column->isPhpPrimitiveType()) {
-            $phpType = $this->column->getPhpType();
-            $script .= "
-            $fieldAttribute = (\$firstColumn !== null) ? ($phpType)\$firstColumn : null;";
-        } elseif ($this->column->isPhpObjectType()) {
-            $phpType = $this->column->getPhpType();
-            $script .= "
-            $fieldAttribute = (\$firstColumn !== null) ? new $phpType(\$firstColumn) : null;";
-        } elseif ($this->column->getType() === PropelTypes::UUID_BINARY) {
-            $uuidSwapFlag = $this->builder->getUuidSwapFlagLiteral();
-            $this->declareGlobalFunction('is_resource', 'stream_get_contents');
-            $script .= "
-            if (is_resource(\$firstColumn)) {
-                \$firstColumn = stream_get_contents(\$firstColumn);
-            }
-            $fieldAttribute = UuidConverter::binToUuid(\$firstColumn, $uuidSwapFlag);";
-        } else {
-            $script .= "
-            $fieldAttribute = \$firstColumn;";
+            \$row = \$dataFetcher->fetch(PDO::FETCH_BOUND);";
         }
 
         $script .= "
+            \$dataFetcher->close();
+
+            \$firstColumn = is_bool(\$row) ? null : current(\$row);{$hydrateFieldStatement}
             $isLoadedAttribute = true;
         } catch (Exception \$e) {
             throw new PropelException('Error loading value for [$clo] column on demand.', 0, \$e);

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/LazyLoadColumnCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/LazyLoadColumnCodeProducer.php
@@ -13,6 +13,11 @@ use Propel\Generator\Platform\SqlsrvPlatform;
 class LazyLoadColumnCodeProducer extends ColumnCodeProducer
 {
     /**
+     * @var string
+     */
+    protected const IS_LOADED_ATTRIBUTE_SUFFIX = '_is_loaded';
+
+    /**
      * @var \Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes\ColumnCodeProducer
      */
     protected ColumnCodeProducer $columnCodeProducer;
@@ -40,12 +45,13 @@ class LazyLoadColumnCodeProducer extends ColumnCodeProducer
     }
 
     /**
+     * @param string $prefix
+     *
      * @return string
      */
-    #[\Override]
-    public function getDefaultValueString(): string
+    protected function getIsLoadedAttributeName(string $prefix = '$this->'): string
     {
-        return $this->columnCodeProducer->getDefaultValueString();
+        return $this->getAttributeName($prefix, static::IS_LOADED_ATTRIBUTE_SUFFIX);
     }
 
     /**
@@ -68,12 +74,56 @@ class LazyLoadColumnCodeProducer extends ColumnCodeProducer
     protected function addColumnAttributeLoaderDeclaration(string &$script): void
     {
         $clo = $this->column->getLowercasedName();
+        $isLoadedAttribute = $this->getIsLoadedAttributeName('$');
+
         $script .= "
     /**
      * Whether the lazy-loaded \$$clo value has been loaded from database.
      * This is necessary to avoid repeated lookups if \$$clo column is NULL in the db.
      */
-    protected bool \${$clo}_isLoaded = false;\n";
+    protected bool $isLoadedAttribute = false;\n";
+    }
+
+    /**
+     * Build statement used in Model::clear()
+     *
+     * @see ObjectBuilder::addClear()}
+     *
+     * @return string
+     */
+    #[\Override]
+    public function getClearValueStatement(): string
+    {
+        $isLoadedAttribute = $this->getIsLoadedAttributeName();
+
+        return $this->columnCodeProducer->getClearValueStatement() . "
+        $isLoadedAttribute = false;";
+    }
+
+    /**
+     * Build statement used in Model::reload()
+     *
+     * @see ObjectBuilder::addReload()}
+     *
+     * @return string
+     */
+    public function getReloadStatement(): string
+    {
+        $isLoadedAttribute = $this->getIsLoadedAttributeName();
+        $fieldAttribute = $this->getAttributeName();
+
+        return "
+        $fieldAttribute = null;
+        $isLoadedAttribute = false;\n";
+    }
+
+    /**
+     * @return string
+     */
+    #[\Override]
+    public function getDefaultValueString(): string
+    {
+        return $this->columnCodeProducer->getDefaultValueString();
     }
 
     /**
@@ -132,12 +182,14 @@ class LazyLoadColumnCodeProducer extends ColumnCodeProducer
      */
     protected function getAccessorLazyLoadSnippet(): string
     {
-        $clo = $this->column->getLowercasedName();
+        $fieldAttribute = $this->getAttributeName();
+        $isLoadedAttribute = $this->getIsLoadedAttributeName();
         $defaultValueString = $this->getDefaultValueString();
+        $callLoad = 'load' . $this->column->getPhpName();
 
         return "
-        if (!\$this->{$clo}_isLoaded && \$this->{$clo} === {$defaultValueString} && !\$this->isNew()) {
-            \$this->load{$this->column->getPhpName()}(\$con);
+        if (!$isLoadedAttribute && $fieldAttribute === $defaultValueString && !\$this->isNew()) {
+            \$this->$callLoad(\$con);
         }\n";
     }
 
@@ -220,9 +272,11 @@ class LazyLoadColumnCodeProducer extends ColumnCodeProducer
     {
         $this->declareGlobalFunction('current');
         $platform = $this->getPlatform();
-        $clo = $this->column->getLowercasedName();
+        $fieldAttribute = $this->getAttributeName();
+        $isLoadedAttribute = $this->getIsLoadedAttributeName();
         $columnConstant = $this->builder->getColumnConstant($this->column);
         $queryClassName = $this->getQueryClassName();
+        $clo = $this->column->getLowercasedName();
 
         // pdo_sqlsrv driver requires the use of PDOStatement::bindColumn() or a hex string will be returned
         if ($this->column->getType() === PropelTypes::BLOB && $platform instanceof SqlsrvPlatform) {
@@ -255,17 +309,19 @@ class LazyLoadColumnCodeProducer extends ColumnCodeProducer
             $this->declareGlobalFunction('stream_get_contents');
             $script .= "
             if (\$firstColumn) {
-                \$this->$clo = stream_get_contents(\$firstColumn);
+                $fieldAttribute = stream_get_contents(\$firstColumn);
             }";
         } elseif ($this->column->isLobType() && !$platform->hasStreamBlobImpl()) {
             $script .= "
-            \$this->$clo = \$this->writeResource(\$firstColumn);";
+            $fieldAttribute = \$this->writeResource(\$firstColumn);";
         } elseif ($this->column->isPhpPrimitiveType()) {
+            $phpType = $this->column->getPhpType();
             $script .= "
-            \$this->$clo = (\$firstColumn !== null) ? (" . $this->column->getPhpType() . ')$firstColumn : null;';
+            $fieldAttribute = (\$firstColumn !== null) ? ($phpType)\$firstColumn : null;";
         } elseif ($this->column->isPhpObjectType()) {
+            $phpType = $this->column->getPhpType();
             $script .= "
-            \$this->$clo = (\$firstColumn !== null) ? new " . $this->column->getPhpType() . '($firstColumn) : null;';
+            $fieldAttribute = (\$firstColumn !== null) ? new $phpType(\$firstColumn) : null;";
         } elseif ($this->column->getType() === PropelTypes::UUID_BINARY) {
             $uuidSwapFlag = $this->builder->getUuidSwapFlagLiteral();
             $this->declareGlobalFunction('is_resource', 'stream_get_contents');
@@ -273,14 +329,14 @@ class LazyLoadColumnCodeProducer extends ColumnCodeProducer
             if (is_resource(\$firstColumn)) {
                 \$firstColumn = stream_get_contents(\$firstColumn);
             }
-            \$this->$clo = UuidConverter::binToUuid(\$firstColumn, $uuidSwapFlag);";
+            $fieldAttribute = UuidConverter::binToUuid(\$firstColumn, $uuidSwapFlag);";
         } else {
             $script .= "
-            \$this->$clo = \$firstColumn;";
+            $fieldAttribute = \$firstColumn;";
         }
 
         $script .= "
-            \$this->" . $clo . "_isLoaded = true;
+            $isLoadedAttribute = true;
         } catch (Exception \$e) {
             throw new PropelException('Error loading value for [$clo] column on demand.', 0, \$e);
         }";
@@ -331,14 +387,14 @@ class LazyLoadColumnCodeProducer extends ColumnCodeProducer
     #[\Override]
     protected function addMutatorBody(string &$script): void
     {
-        $clo = $this->column->getLowercasedName();
         $cfc = $this->column->getPhpName();
+        $isLoadedAttribute = $this->getIsLoadedAttributeName();
         $script .= "
         // explicitly set the is-loaded flag to true for this lazy load col;
         // it doesn't matter if the value is actually set or not (logic below) as
         // any attempt to set the value means that no db lookup should be performed
         // when the get$cfc() method is called.
-        \$this->{$clo}_isLoaded = true;\n";
+        $isLoadedAttribute = true;\n";
 
         $this->columnCodeProducer->addMutatorBody($script);
     }

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/LobColumnCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/LobColumnCodeProducer.php
@@ -42,11 +42,7 @@ class LobColumnCodeProducer extends ColumnCodeProducer
         $columnConstant = $this->builder->getColumnConstant($this->column);
 
         $script .= "
-        // Because BLOB columns are streams in PDO we have to assume that they are
-        // always modified when a new value is passed in.  For example, the contents
-        // of the stream itself may have changed externally.
         $serializedAttribute = \$this->writeResource(\$v);
-
         \$this->modifiedColumns[$columnConstant] = true;\n";
     }
 }

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/LobColumnCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/LobColumnCodeProducer.php
@@ -7,6 +7,26 @@ namespace Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes;
 class LobColumnCodeProducer extends ColumnCodeProducer
 {
     /**
+     * Build statement used in Model::hydrate()
+     *
+     * @see ObjectBuilder::addHydrateBody()}
+     *
+     * @param string $valueVariable
+     *
+     * @return string
+     */
+    #[\Override]
+    public function getHydrateStatement(string $valueVariable): string
+    {
+        $serializedAttribute = $this->getAttributeName();
+
+        return $this->getPlatform()->hasStreamBlobImpl()
+        ? parent::getHydrateStatement($valueVariable)
+        : "
+            $serializedAttribute = \$this->writeResource($valueVariable);";
+    }
+
+    /**
      * Adds a setter for BLOB columns.
      *
      * @see parent::addColumnMutators()
@@ -18,15 +38,14 @@ class LobColumnCodeProducer extends ColumnCodeProducer
     #[\Override]
     protected function addMutatorBody(string &$script): void
     {
-        $col = $this->column;
-        $clo = $col->getLowercasedName();
-        $columnConstant = $this->builder->getColumnConstant($col);
+        $serializedAttribute = $this->getAttributeName();
+        $columnConstant = $this->builder->getColumnConstant($this->column);
 
         $script .= "
         // Because BLOB columns are streams in PDO we have to assume that they are
         // always modified when a new value is passed in.  For example, the contents
         // of the stream itself may have changed externally.
-        \$this->$clo = \$this->writeResource(\$v);
+        $serializedAttribute = \$this->writeResource(\$v);
 
         \$this->modifiedColumns[$columnConstant] = true;\n";
     }

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/ObjectColumnCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/ObjectColumnCodeProducer.php
@@ -6,19 +6,17 @@ namespace Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes;
 
 use function var_export;
 
-class ObjectColumnCodeProducer extends ColumnCodeProducer
+class ObjectColumnCodeProducer extends AbstractDeserializableColumnCodeProducer
 {
     /**
-     * @param string $script The script will be modified in this method.
+     * Get attribute types in order [database field type, deserialized type]
      *
-     * @return void
+     * @return array{string, string}
      */
     #[\Override]
-    public function addColumnAttributes(string &$script): void
+    protected function getQualifiedAttributeTypes(): array
     {
-        $this->addDefaultColumnAttribute($script, 'resource');
-        $objectType = $this->getQualifiedTypeString() ?: 'object';
-        $this->addColumnAttributeUnserialized($script, $objectType);
+        return ['resource', $this->getQualifiedTypeString() ?: 'object'];
     }
 
     /**
@@ -28,10 +26,34 @@ class ObjectColumnCodeProducer extends ColumnCodeProducer
     public function getDefaultValueString(): string
     {
         $defaultValue = $this->column->getPhpDefaultValue();
+        if ($defaultValue === null) {
+            return 'null';
+        }
+        $constructor = $this->declareClass($this->column->getPhpType());
+        $defaultValueString = var_export($this->column->getPhpDefaultValue(), true);
 
-        return $defaultValue !== null
-            ? 'new ' . $this->column->getPhpType() . '(' . var_export($defaultValue, true) . ')'
-            : 'null';
+        return "new $constructor($defaultValueString)";
+    }
+
+    /**
+     * Build statement used in Model::hydrate()
+     *
+     * @see ObjectBuilder::addHydrateBody()}
+     *
+     * @param string $valueVariable
+     *
+     * @return string
+     */
+    #[\Override]
+    public function getHydrateStatement(string $valueVariable): string
+    {
+        $resourceAttribute = $this->getAttributeName();
+        $processValueStatement = $this->getPlatform()->hasStreamBlobImpl()
+            ? $valueVariable
+            : "\$this->writeResource($valueVariable)";
+
+        return "
+            $resourceAttribute = $processValueStatement;";
     }
 
     /**
@@ -45,22 +67,23 @@ class ObjectColumnCodeProducer extends ColumnCodeProducer
     protected function addAccessorBody(string &$script): void
     {
         $this->declareGlobalFunction('is_resource', 'stream_get_contents', 'unserialize');
-        $clo = $this->column->getLowercasedName();
-        $cloUnserialized = $clo . '_unserialized';
+        $resourceAttribute = $this->getAttributeName();
+        $objectAttribute = $this->getDeserializedAttributeName();
+
         $typeHint = $this->column->getTypeHint();
         $docHint = !$typeHint ? '' : "
-                /** @var $typeHint \$unserializedString */";
+                /** @var $typeHint \$deserializedString */";
 
         $script .= "
-        if (!\$this->$cloUnserialized && is_resource(\$this->$clo)) {
-            \$serialisedString = stream_get_contents(\$this->$clo);
-            if (\$serialisedString) {{$docHint}
-                \$unserializedString = unserialize(\$serialisedString);
-                \$this->$cloUnserialized = \$unserializedString;
+        if (!$objectAttribute && is_resource($resourceAttribute)) {
+            \$serializedString = stream_get_contents($resourceAttribute);
+            if (\$serializedString) {{$docHint}
+                \$deserializedString = unserialize(\$serializedString);
+                $objectAttribute = \$deserializedString;
             }
         }
 
-        return \$this->$cloUnserialized;";
+        return $objectAttribute;";
     }
 
     /**
@@ -76,16 +99,15 @@ class ObjectColumnCodeProducer extends ColumnCodeProducer
     protected function addMutatorBody(string &$script): void
     {
         $this->declareGlobalFunction('serialize', 'stream_get_contents');
-        $col = $this->column;
-        $clo = $col->getLowercasedName();
-        $cloUnserialized = $clo . '_unserialized';
-        $columnConstant = $this->builder->getColumnConstant($col);
+        $resourceAttribute = $this->getAttributeName();
+        $objectAttribute = $this->getDeserializedAttributeName();
+        $columnConstant = $this->builder->getColumnConstant($this->column);
 
         $script .= "
         \$serializedValue = serialize(\$v);
-        if (\$this->$clo === null || stream_get_contents(\$this->$clo) !== \$serializedValue) {
-            \$this->$cloUnserialized = \$v;
-            \$this->$clo = \$this->writeResource(\$serializedValue);
+        if ($resourceAttribute === null || stream_get_contents($resourceAttribute) !== \$serializedValue) {
+            $objectAttribute = \$v;
+            $resourceAttribute = \$this->writeResource(\$serializedValue);
             \$this->modifiedColumns[$columnConstant] = true;
         }\n";
     }

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/SetBinaryColumnCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/SetBinaryColumnCodeProducer.php
@@ -10,30 +10,21 @@ use Propel\Common\Util\SetColumnConverter;
 class SetBinaryColumnCodeProducer extends AbstractArrayColumnCodeProducer
 {
     /**
-     * @param string $script
+     * @see AbstractDeserializableColumnCodeProducer::DESERIALIZED_ATTRIBUTE_AFFIX
      *
-     * @return void
+     * @var string
      */
-    #[\Override]
-    public function addColumnAttributes(string &$script): void
-    {
-        $this->addDefaultColumnAttribute($script, 'int');
-        $this->addColumnAttributeConvertedDeclaration($script);
-    }
+    protected const DESERIALIZED_ATTRIBUTE_AFFIX = '_converted';
 
     /**
-     * @param string $script
+     * Get attribute types in order [database field type, deserialized type]
      *
-     * @return void
+     * @return array{string, string}
      */
-    protected function addColumnAttributeConvertedDeclaration(string &$script): void
+    #[\Override]
+    protected function getQualifiedAttributeTypes(): array
     {
-        $attributeName = '$' . $this->column->getLowercasedName() . '_converted';
-        $script .= "
-    /**
-     * @var array<string>|null
-     */
-    protected array|null $attributeName = null;\n";
+        return ['int', 'array<string>'];
     }
 
     /**
@@ -92,30 +83,29 @@ class SetBinaryColumnCodeProducer extends AbstractArrayColumnCodeProducer
     protected function addAccessorBody(string &$script): void
     {
         $this->declareClasses(
-            'Propel\Common\Util\SetColumnConverter',
-            'Propel\Common\Exception\SetColumnConverterException',
+            SetColumnConverter::class,
+            SetColumnConverterException::class,
         );
 
-        $clo = $this->column->getLowercasedName();
-        $cloConverted = $clo . '_converted';
-
+        $intAttribute = $this->getAttributeName();
+        $arrayAttribute = $this->getDeserializedAttributeName();
         $tableMapClassName = $this->getTableMapClassName();
         $columnConstantExpression = $this->builder->getColumnConstant($this->column);
 
         $script .= "
-        if (\$this->$cloConverted === null) {
-            \$this->$cloConverted = [];
+        if ($arrayAttribute === null) {
+            $arrayAttribute = [];
         }
-        if (!\$this->$cloConverted && \$this->$clo !== null) {
+        if (!$arrayAttribute && $intAttribute !== null) {
             \$valueSet = {$tableMapClassName}::getValueSet($columnConstantExpression);
             try {
-                \$this->$cloConverted = SetColumnConverter::convertBitmaskToArray(\$this->$clo, \$valueSet);
+                $arrayAttribute = SetColumnConverter::convertBitmaskToArray($intAttribute, \$valueSet);
             } catch (SetColumnConverterException \$e) {
                 throw new PropelException('Unknown stored set key: ' . \$e->getValue(), \$e->getCode(), \$e);
             }
         }
 
-        return \$this->$cloConverted;";
+        return $arrayAttribute;";
     }
 
     /**
@@ -142,13 +132,11 @@ class SetBinaryColumnCodeProducer extends AbstractArrayColumnCodeProducer
     {
         $clo = $this->column->getLowercasedName();
 
-        $orNull = $this->column->isNotNull() ? '' : '|null';
-
         $script .= "
     /**
      * Set the value of [$clo] column.{$this->getColumnDescriptionDoc()}
      *
-     * @param array{$orNull} \$v new value
+     * @param array|null \$v new value
      *
      * @throws \\Propel\\Runtime\\Exception\\PropelException
      *
@@ -172,21 +160,23 @@ class SetBinaryColumnCodeProducer extends AbstractArrayColumnCodeProducer
         );
         $this->declareGlobalFunction('array_diff', 'count', 'sprintf');
 
-        $col = $this->column;
-        $clo = $col->getLowercasedName();
-        $cloConverted = $clo . '_converted';
+        $intAttribute = $this->getAttributeName();
+        $arrayAttribute = $this->getDeserializedAttributeName();
+        $tableMapClassName = $this->getTableMapClassName();
+        $columnConstant = $this->builder->getColumnConstant($this->getColumn());
+
         $script .= "
-        if (\$this->$cloConverted === null || count(array_diff(\$this->$cloConverted, \$v)) > 0 || count(array_diff(\$v, \$this->$cloConverted)) > 0) {
-            \$valueSet = " . $this->getTableMapClassName() . '::getValueSet(' . $this->builder->getColumnConstant($col) . ");
+        if ($arrayAttribute === null || count(array_diff($arrayAttribute, \$v)) > 0 || count(array_diff(\$v, $arrayAttribute)) > 0) {
+            \$valueSet = {$tableMapClassName}::getValueSet($columnConstant);
             try {
                 \$v = SetColumnConverter::convertToBitmask(\$v, \$valueSet);
             } catch (SetColumnConverterException \$e) {
                 throw new PropelException(sprintf('Value \"%s\" is not accepted in this set column', \$e->getValue()), \$e->getCode(), \$e);
             }
-            if (\$this->$clo !== \$v) {
-                \$this->$cloConverted = null;
-                \$this->$clo = \$v;
-                \$this->modifiedColumns[" . $this->builder->getColumnConstant($col) . "] = true;
+            if ($intAttribute !== \$v) {
+                $arrayAttribute = null;
+                $intAttribute = \$v;
+                \$this->modifiedColumns[$columnConstant] = true;
             }
         }\n";
     }
@@ -201,7 +191,7 @@ class SetBinaryColumnCodeProducer extends AbstractArrayColumnCodeProducer
     #[\Override]
     public function buildCreateFromFilterValueExpression(string $valueExpression): string
     {
-        $this->declareClasses('Propel\Common\Util\SetColumnConverter');
+        $this->declareClasses(SetColumnConverter::class);
         $tableMapClassName = $this->getTableMapClassName();
         $columnConstant = $this->builder->getColumnConstant($this->column);
 

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/SetNativeColumnCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/SetNativeColumnCodeProducer.php
@@ -9,30 +9,21 @@ use function str_contains;
 class SetNativeColumnCodeProducer extends AbstractArrayColumnCodeProducer
 {
     /**
-     * @param string $script
+     * @see AbstractDeserializableColumnCodeProducer::DESERIALIZED_ATTRIBUTE_AFFIX
      *
-     * @return void
+     * @var string
      */
-    #[\Override]
-    public function addColumnAttributes(string &$script): void
-    {
-        $this->addDefaultColumnAttribute($script, 'string');
-        $this->addColumnAttributeConvertedDeclaration($script);
-    }
+    protected const DESERIALIZED_ATTRIBUTE_AFFIX = '_converted';
 
     /**
-     * @param string $script
+     * Get attribute types in order [database field type, deserialized type]
      *
-     * @return void
+     * @return array{string, string}
      */
-    protected function addColumnAttributeConvertedDeclaration(string &$script): void
+    #[\Override]
+    protected function getQualifiedAttributeTypes(): array
     {
-        $attributeName = '$' . $this->column->getLowercasedName() . '_converted';
-        $script .= "
-    /**
-     * @var array<string>|null
-     */
-    protected array|null $attributeName = null;\n";
+        return ['string', 'array<string>'];
     }
 
     /**
@@ -95,18 +86,18 @@ class SetNativeColumnCodeProducer extends AbstractArrayColumnCodeProducer
     #[\Override]
     protected function addAccessorBody(string &$script): void
     {
-        $clo = $this->column->getLowercasedName();
-        $cloConverted = $clo . '_converted';
+        $csvAttribute = $this->getAttributeName();
+        $arrayAttribute = $this->getDeserializedAttributeName();
 
         $script .= "
-        if (\$this->$cloConverted === null) {
-            \$this->$cloConverted = [];
+        if ($arrayAttribute === null) {
+            $arrayAttribute = [];
         }
-        if (!\$this->$cloConverted && \$this->$clo !== null) {
-            \$this->$cloConverted = explode(',', \$this->$clo);
+        if (!$arrayAttribute && $csvAttribute !== null) {
+            $arrayAttribute = explode(',', $csvAttribute);
         }
 
-        return \$this->$cloConverted;";
+        return $arrayAttribute;";
     }
 
     /**
@@ -133,15 +124,11 @@ class SetNativeColumnCodeProducer extends AbstractArrayColumnCodeProducer
     {
         $clo = $this->column->getLowercasedName();
 
-        $orNull = $this->column->isNotNull() ? '' : '|null';
-
         $script .= "
     /**
      * Set the value of [$clo] column.{$this->getColumnDescriptionDoc()}
      *
-     * @param array{$orNull} \$v new value
-     *
-     * @throws \\Propel\\Runtime\\Exception\\PropelException
+     * @param array<string>|null \$v new value
      *
      * @return \$this
      */";
@@ -157,23 +144,23 @@ class SetNativeColumnCodeProducer extends AbstractArrayColumnCodeProducer
     #[\Override]
     protected function addMutatorBody(string &$script): void
     {
-        $col = $this->column;
-        $clo = $col->getLowercasedName();
-        $cloConverted = $clo . '_converted';
-        $columnConstant = $this->builder->getColumnConstant($col);
-        $tableMapClassName = $this->getTableMapClassName();
         $this->declareClass('\Propel\Common\Util\SetColumnConverter');
 
+        $csvAttribute = $this->getAttributeName();
+        $arrayAttribute = $this->getDeserializedAttributeName();
+        $columnConstant = $this->builder->getColumnConstant($this->column);
+        $tableMapClassName = $this->getTableMapClassName();
+
         $script .= "
-        if (\$this->$cloConverted === null || array_diff(\$this->$cloConverted, \$v) || array_diff(\$v, \$this->$cloConverted)) {
+        if ($arrayAttribute === null || array_diff($arrayAttribute, \$v) || array_diff(\$v, $arrayAttribute)) {
             \$v = array_map('trim', \$v);
             \$valueSet = {$tableMapClassName}::getValueSet($columnConstant);
             SetColumnConverter::requireValuesInSet(\$v, \$valueSet);
             
-            if (\$this->$clo !== \$v) {
-                \$this->$cloConverted = null;
+            if ($csvAttribute !== \$v) {
+                $arrayAttribute = null;
                 \$orderedValues = SetColumnConverter::getItemsInOrder(\$v, \$valueSet);
-                \$this->$clo = !\$orderedValues ? null : implode(',', \$orderedValues);
+                $csvAttribute = !\$orderedValues ? null : implode(',', \$orderedValues);
                 \$this->modifiedColumns[$columnConstant] = true;
             }
         }\n";

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/TemporalColumnCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/TemporalColumnCodeProducer.php
@@ -10,14 +10,20 @@ use Exception;
 use Propel\Generator\Exception\EngineException;
 use Propel\Generator\Model\PropelTypes;
 use Propel\Generator\Platform\MysqlPlatform;
+use Propel\Runtime\Util\PropelDateTime;
 use function date_default_timezone_set;
 use function in_array;
 use function is_subclass_of;
 use function sprintf;
 use function var_export;
 
-class TemporalColumnCodeProducer extends ColumnCodeProducer
+class TemporalColumnCodeProducer extends AbstractDeserializableColumnCodeProducer
 {
+    /**
+     * @var string
+     */
+    protected const DESERIALIZED_ATTRIBUTE_AFFIX = '_date_object';
+
     /**
      * @return string
      */
@@ -28,6 +34,48 @@ class TemporalColumnCodeProducer extends ColumnCodeProducer
     }
 
     /**
+     * Get attribute types in order [database field type, deserialized type]
+     *
+     * @return array{string, string}
+     */
+    #[\Override]
+    protected function getQualifiedAttributeTypes(): array
+    {
+        return ['string', $this->getQualifiedTypeString()];
+    }
+
+    /**
+     * Build statement used in Model::hydrate()
+     *
+     * @see ObjectBuilder::addHydrateBody()}
+     *
+     * @param string $valueVariable
+     *
+     * @return string
+     */
+    #[\Override]
+    public function getHydrateStatement(string $valueVariable): string
+    {
+        $stringAttribute = $this->getAttributeName();
+        $objectAttribute = $this->getDeserializedAttributeName();
+
+        $mysqlInvalidDateString = !$this->getPlatform() instanceof MysqlPlatform ? null
+            : match ($this->column->getType()) {
+                PropelTypes::TIMESTAMP, PropelTypes::DATETIME => '0000-00-00 00:00:00',
+                PropelTypes::DATE => '0000-00-00',
+                default => null
+            };
+
+        $stringAttributeValueStatement = $mysqlInvalidDateString
+            ? "$valueVariable === '$mysqlInvalidDateString' ? null : $valueVariable"
+            : $valueVariable;
+
+        return "
+            $objectAttribute = null;
+            $stringAttribute = $stringAttributeValueStatement;";
+    }
+
+    /**
      * Build statement used in Model::applyDefaultValues()
      *
      * @return string
@@ -35,12 +83,13 @@ class TemporalColumnCodeProducer extends ColumnCodeProducer
     #[\Override]
     public function getApplyDefaultValueStatement(): string
     {
-        $clo = $this->column->getLowercasedName();
+        $stringAttribute = $this->getAttributeName();
+        $objectAttribute = $this->getDeserializedAttributeName();
         $defaultValue = $this->getDefaultValueString();
-        $dateTimeClass = $this->resolveColumnDateTimeClass($this->column);
 
         return "
-        \$this->{$clo} = PropelDateTime::newInstance($defaultValue, null, '$dateTimeClass');";
+        $objectAttribute = $stringAttribute === $defaultValue ? $objectAttribute : null;
+        $stringAttribute = $defaultValue;";
     }
 
     /**
@@ -64,7 +113,7 @@ class TemporalColumnCodeProducer extends ColumnCodeProducer
         try {
             if (
                 !($this->getPlatform() instanceof MysqlPlatform &&
-                ($val === '0000-00-00 00:00:00' || $val === '0000-00-00'))
+                    ($val === '0000-00-00 00:00:00' || $val === '0000-00-00'))
             ) {
                 // while technically this is not a default value of NULL,
                 // this seems to be closest in meaning.
@@ -79,6 +128,22 @@ class TemporalColumnCodeProducer extends ColumnCodeProducer
         }
 
         return $defaultValue;
+    }
+
+    /**
+     * Build statement to check if current value is the default value.
+     *
+     * @see ObjectBuilder::addHasOnlyDefaultValuesBody()
+     *
+     * @return string
+     */
+    #[\Override]
+    public function getIsDefaultValueStatement(): string
+    {
+        $stringAttribute = $this->getAttributeName();
+        $defaultValueString = $this->getDefaultValueString();
+
+        return "$stringAttribute === $defaultValueString";
     }
 
     /**
@@ -116,7 +181,7 @@ class TemporalColumnCodeProducer extends ColumnCodeProducer
 
         $script .= "
     /**
-     * Get the [optionally formatted] temporal [$clo] column value.{$this->getColumnDescriptionDoc()}
+     * Get the temporal [$clo] column value.{$this->getColumnDescriptionDoc()}
      *
      * @psalm-return (\$format is null ? {$dateTimeClass}|\DateTimeInterface|null : string|null)
      *
@@ -191,14 +256,16 @@ class TemporalColumnCodeProducer extends ColumnCodeProducer
     protected function addAccessorBody(string &$script): void
     {
         $this->declareClass('DateTimeInterface');
-        $clo = $this->column->getLowercasedName();
+        $stringAttribute = $this->getAttributeName();
+        $objectAttribute = $this->getDeserializedAttributeName();
+        $createInstanceStatement = $this->buildCreateInstanceStatement();
 
         $script .= "
-        if (\$format === null) {
-            return \$this->$clo;
-        } else {
-            return \$this->$clo instanceof DateTimeInterface ? \$this->{$clo}->format(\$format) : null;
-        }";
+        if (!$objectAttribute && $stringAttribute) {
+            $objectAttribute = $createInstanceStatement;
+        }
+
+        return \$format !== null ? {$objectAttribute}?->format(\$format) : $objectAttribute;";
     }
 
     /**
@@ -211,14 +278,12 @@ class TemporalColumnCodeProducer extends ColumnCodeProducer
     {
         $col = $this->column;
         $clo = $col->getLowercasedName();
-        $orNull = $col->isNotNull() ? '' : '|null';
 
         $script .= "
     /**
      * Sets the value of [$clo] column to a normalized version of the date/time value specified.{$this->getColumnDescriptionDoc()}
      *
-     * @param \DateTimeInterface|string|int{$orNull} \$v string, integer (timestamp), or \DateTimeInterface value.
-     *               Empty strings are treated as NULL.
+     * @param \DateTimeInterface|string|int|null \$v Empty strings are treated as null.
      *
      * @return \$this
      */";
@@ -236,48 +301,44 @@ class TemporalColumnCodeProducer extends ColumnCodeProducer
     #[\Override]
     protected function addMutatorBody(string &$script): void
     {
+        $this->declareClasses(DateTimeInterface::class);
+
         $col = $this->column;
-        $clo = $col->getLowercasedName();
+        $stringAttribute = $this->getAttributeName();
+        $objectAttribute = $this->getDeserializedAttributeName();
+        $columnConstant = $this->builder->getColumnConstant($col);
+        $createInstanceStatement = $this->buildCreateInstanceStatement('$v');
+        $dateFormat = $this->getPlatform()->getTemporalFormatter($col);
 
-        $dateTimeClass = $this->resolveColumnDateTimeClass($this->column);
-        $this->declareClasses('\Propel\Runtime\Util\PropelDateTime');
-
-        $fmt = var_export($this->getPlatformOrFail()->getTemporalFormatter($col), true);
-
-        $script .= "
-        \$dt = PropelDateTime::newInstance(\$v, null, '$dateTimeClass');
-        if (\$this->$clo !== null || \$dt !== null) {";
-
+        $additionalConditions = '';
         $def = $col->getDefaultValue();
         if ($def !== null && !$def->isExpression()) {
+            // special case: mark modified when default value is provided
             $defaultValue = $this->getDefaultValueString();
-            $script .= "
-            if (
-                \$dt !== \$this->{$clo} // normalized values don't match
-                || \$dt->format($fmt) === $defaultValue // or the entered value matches the default
-            ) {";
-        } else {
-            switch ($col->getType()) {
-                case 'DATE':
-                    $format = 'Y-m-d';
-
-                    break;
-                case 'TIME':
-                    $format = 'H:i:s.u';
-
-                    break;
-                default:
-                    $format = 'Y-m-d H:i:s.u';
-            }
-            $script .= "
-            if (\$this->{$clo} === null || \$dt === null || \$dt->format('$format') !== \$this->{$clo}->format('$format')) {";
+            $additionalConditions = " || \$newDateString === $defaultValue";
         }
 
         $script .= "
-                \$this->$clo = \$dt === null ? null : clone \$dt;
-                \$this->modifiedColumns[" . $this->builder->getColumnConstant($col) . "] = true;
-            }
-        } // if either are not null
-";
+        \$newDateObject = \$v instanceof DateTimeInterface ? \$v : $createInstanceStatement;
+        \$newDateString = \$newDateObject?->format('$dateFormat');
+        if ($stringAttribute !== \$newDateString{$additionalConditions}) {
+            $objectAttribute = \$newDateObject;
+            $stringAttribute = \$newDateString;
+            \$this->modifiedColumns[$columnConstant] = true;
+        }\n";
+    }
+
+    /**
+     * @param string|null $var
+     *
+     * @return string
+     */
+    protected function buildCreateInstanceStatement(string|null $var = null): string
+    {
+        $this->declareClasses(PropelDateTime::class);
+        $dateTimeClass = $this->resolveColumnDateTimeClass($this->column);
+        $var ??= $this->getAttributeName();
+
+        return "PropelDateTime::newInstance($var, null, '$dateTimeClass')";
     }
 }

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/TemporalColumnCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/TemporalColumnCodeProducer.php
@@ -176,8 +176,9 @@ class TemporalColumnCodeProducer extends AbstractDeserializableColumnCodeProduce
             // 00:00:00 is a valid time, so no need to check for that.
         }
 
-        $descriptionReturnValueNull = $column->isNotNull() ? '' : ', NULL if column is NULL';
+        $descriptionReturnValueNull = $column->isNotNull() ? '' : ', null if column is null';
         $descriptionReturnMysqlInvalidDate = $handleMysqlDate ? ", and 0 if column value is $mysqlInvalidDateString" : '';
+        $format = $this->getPlatform()->getTemporalFormatter($this->column);
 
         $script .= "
     /**
@@ -185,10 +186,11 @@ class TemporalColumnCodeProducer extends AbstractDeserializableColumnCodeProduce
      *
      * @psalm-return (\$format is null ? {$dateTimeClass}|\DateTimeInterface|null : string|null)
      *
-     * @param string|null \$format The date/time format string (either date()-style or strftime()-style).
-     *   If format is NULL, then the raw $dateTimeClass object will be returned.{$additionalParam}
+     * @param string|null \$format Datetime format string. If null, the method returns a $dateTimeClass object.
+     *                      For efficiency, storage format '$format' is returned without internal transformation.{$additionalParam}
      *
-     * @return {$dateTimeClass}{$orDateTimeInterface}|string|null Formatted date/time value as string or $dateTimeClass object (if format is NULL){$descriptionReturnValueNull}{$descriptionReturnMysqlInvalidDate}.
+     * @return {$dateTimeClass}{$orDateTimeInterface}|string|null Formatted date/time value as string or $dateTimeClass
+     *                  object (if format is null){$descriptionReturnValueNull}{$descriptionReturnMysqlInvalidDate}.
      */";
     }
 
@@ -259,8 +261,13 @@ class TemporalColumnCodeProducer extends AbstractDeserializableColumnCodeProduce
         $stringAttribute = $this->getAttributeName();
         $objectAttribute = $this->getDeserializedAttributeName();
         $createInstanceStatement = $this->buildCreateInstanceStatement();
+        $format = $this->getPlatform()->getTemporalFormatter($this->column);
 
         $script .= "
+        if (\$format === '$format') {
+            return $stringAttribute;
+        }
+
         if (!$objectAttribute && $stringAttribute) {
             $objectAttribute = $createInstanceStatement;
         }

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/TemporalColumnCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/TemporalColumnCodeProducer.php
@@ -131,6 +131,22 @@ class TemporalColumnCodeProducer extends AbstractDeserializableColumnCodeProduce
     }
 
     /**
+     * @see ObjectBuilder::addBuildCriteriaBody()}
+     * @see ObjectBuilder::addDoInsertBodyRaw()}
+     *
+     * @return string
+     */
+    #[\Override()]
+    public function getAccessValueStatement(): string
+    {
+        $stringAttribute = $this->getAttributeName();
+        $objectAttribute = $this->getDeserializedAttributeName();
+        $format = $this->getPlatform()->getTemporalFormatter($this->column);
+
+        return "{$objectAttribute}?->format('$format') ?? $stringAttribute"; // repeats old Propel behavior, changes to DateTime object propagate
+    }
+
+    /**
      * Build statement to check if current value is the default value.
      *
      * @see ObjectBuilder::addHasOnlyDefaultValuesBody()

--- a/src/Propel/Generator/Platform/DefaultPlatform.php
+++ b/src/Propel/Generator/Platform/DefaultPlatform.php
@@ -1584,10 +1584,7 @@ ALTER TABLE %s ADD
     public function getColumnBindingPHP(Column $column, string $identifier, string $columnValueAccessor, string $tab = '            '): string
     {
         $script = '';
-        if ($column->isTemporalType()) {
-            $formatter = $this->getTemporalFormatter($column);
-            $columnValueAccessor .= "?->format('$formatter')";
-        } elseif ($column->isLobType()) {
+        if ($column->isLobType()) {
             // we always need to make sure that the stream is rewound, otherwise nothing will
             // get written to database.
             $script .= "

--- a/src/Propel/Runtime/Adapter/AdapterInterface.php
+++ b/src/Propel/Runtime/Adapter/AdapterInterface.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Propel\Runtime\Adapter;
 
+use DateTimeInterface;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Map\ColumnMap;
@@ -171,12 +172,12 @@ interface AdapterInterface
     /**
      * Formats a temporal value before binding, given a ColumnMap object
      *
-     * @param mixed $value The temporal value
+     * @param \DateTimeInterface|string|int|null $value The temporal value
      * @param \Propel\Runtime\Map\ColumnMap $cMap
      *
-     * @return string The formatted temporal value
+     * @return string|null The formatted temporal value
      */
-    public function formatTemporalValue($value, ColumnMap $cMap): string;
+    public function formatTemporalValue(DateTimeInterface|string|int|null $value, ColumnMap $cMap): string|null;
 
     /**
      * Returns timestamp formatter string for use in date() function.

--- a/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Propel\Runtime\Adapter\Pdo;
 
+use DateTimeInterface;
 use PDO;
 use PDOException;
 use Propel\Generator\Model\PropelTypes;
@@ -372,36 +373,33 @@ abstract class PdoAdapter
     /**
      * Formats a temporal value before binding, given a ColumnMap object
      *
-     * @param mixed $value The temporal value
+     * @param \DateTimeInterface|string|int|null $value The temporal value
      * @param \Propel\Runtime\Map\ColumnMap $cMap
      *
-     * @return string The formatted temporal value
+     * @return string|null The formatted temporal value
      */
-    public function formatTemporalValue($value, ColumnMap $cMap): string
+    public function formatTemporalValue(DateTimeInterface|string|int|null $value, ColumnMap $cMap): string|null
     {
-        /** @var \Propel\Runtime\Util\PropelDateTime|null $dt */
-        $dt = PropelDateTime::newInstance($value);
-        if ($dt) {
-            switch ($cMap->getType()) {
-                case PropelTypes::TIMESTAMP:
-                case PropelTypes::BU_TIMESTAMP:
-                case PropelTypes::DATETIME:
-                    $value = $dt->format($this->getTimestampFormatter());
-
-                    break;
-                case PropelTypes::DATE:
-                case PropelTypes::BU_DATE:
-                    $value = $dt->format($this->getDateFormatter());
-
-                    break;
-                case PropelTypes::TIME:
-                    $value = $dt->format($this->getTimeFormatter());
-
-                    break;
-            }
+        if ($value === null || $value === '') {
+            return $value;
         }
+        /** @var \DateTimeInterface $dt */
+        $dt = $value instanceof DateTimeInterface ? $value : PropelDateTime::newInstance($value);
+        $format = match ($cMap->getType()) {
+            PropelTypes::DATE,
+            PropelTypes::BU_DATE
+                => $this->getDateFormatter(),
+            PropelTypes::TIME
+                => $this->getTimeFormatter(),
+            PropelTypes::TIMESTAMP,
+            PropelTypes::BU_TIMESTAMP,
+            PropelTypes::DATETIME,
+                => $this->getTimestampFormatter(),
+            default
+                => $this->getTimestampFormatter(),
+        };
 
-        return $value;
+        return $dt->format($format);
     }
 
     /**

--- a/src/Propel/Runtime/Util/PropelDateTime.php
+++ b/src/Propel/Runtime/Util/PropelDateTime.php
@@ -127,34 +127,35 @@ class PropelDateTime extends DateTime
     /**
      * Factory method to get a DateTime object from a temporal input
      *
-     * @param mixed $value The value to convert (can be a string, a timestamp, or another DateTime)
-     * @param \DateTimeZone|null $timeZone (optional) timezone
-     * @param class-string<\DateTimeInterface> $dateTimeClass The class of the object to create, defaults to DateTime
+     * @param \DateTimeInterface|string|int|null $value
+     * @param \DateTimeZone|null $timeZone
+     * @param class-string<\DateTimeInterface> $dateTimeClass Defaults to DateTime
      *
      * @throws \Propel\Runtime\Exception\PropelException
      *
      * @return \DateTimeInterface|null An instance of $dateTimeClass
      */
-    public static function newInstance($value, ?DateTimeZone $timeZone = null, string $dateTimeClass = DateTime::class): DateTimeInterface|null
-    {
+    public static function newInstance(
+        string|int|DateTimeInterface|null $value,
+        ?DateTimeZone $timeZone = null,
+        string $dateTimeClass = DateTime::class
+    ): DateTimeInterface|null {
         if ($value instanceof DateTimeInterface) {
-            return $value;
+            return clone $value;
         }
-        if ($value === false || $value === null || $value === '') {
+        if ($value === null || $value === '') {
             // '' is seen as NULL for temporal objects
             // because DateTime('') == DateTime('now') -- which is unexpected
             return null;
         }
 
         try {
-            $dateTimeObject = static::createDateTime($value, $timeZone, $dateTimeClass);
+            return static::createDateTime($value, $timeZone, $dateTimeClass);
         } catch (Exception $e) {
             $value = var_export($value, true);
 
-            throw new PropelException('Error parsing date/time value `' . $value . '`: ' . $e->getMessage(), 0, $e);
+            throw new PropelException("Error parsing date/time value `$value`: " . $e->getMessage(), 0, $e);
         }
-
-        return $dateTimeObject;
     }
 
     /**

--- a/tests/Propel/Tests/CompareGeneratedCodeTestCase.php
+++ b/tests/Propel/Tests/CompareGeneratedCodeTestCase.php
@@ -1,6 +1,11 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Propel\Tests;
+
+use Exception;
+use function sprintf;
 
 /**
  * Parent class for tests that compare code builder output against file content.
@@ -9,10 +14,14 @@ namespace Propel\Tests;
  */
 class CompareGeneratedCodeTestCase extends TestCase
 {
+    /**
+     * @var string
+     */
     public const HOW_TO_UPDATE_MESSAGE = 'Reference file does not match anymore. Update by calling `./tests/bin/rebuild-reference-files` (from Perpl root dir).';
 
     /**
      * Summary of generateCodeFileContent
+     *
      * @param mixed $obj
      * @param array<string> $methods
      *
@@ -33,5 +42,14 @@ class CompareGeneratedCodeTestCase extends TestCase
     public function buildCodeFileContent(string $header, string $code): string
     {
         return "\n\n$header:\n$code";
+    }
+
+    public function buildWithPossibleExceptionMessage(callable $buildCode)
+    {
+        try {
+            return $buildCode();
+        } catch (Exception $e) {
+            return sprintf('Threw %s: %s', $e::class, $e->getMessage());
+        }
     }
 }

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectTemporalColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectTemporalColumnTypeTest.php
@@ -119,31 +119,47 @@ EOF;
         $this->assertEquals(date('Y-m-d H:i'), $r->getDatetimecolumn('Y-m-d H:i'));
     }
     
-    public static function persistenceDataProvider()
+    public static function AccessStorageFormatDataProvider()
     {
+        $date = '2026-03-31';
+        $time = '11:04:32.123456';
+
         return [
-            // type description, column name , input date value, formatted input date, format
-            ['Date', 'Bar1', new DateTime('1999-12-20'), '1999-12-20', 'Y-m-d'],
-            ['Time', 'Bar2', strtotime('12:55'), '12:55', 'H:i'],
-            ['Timestamp', 'Bar3', new DateTime('1999-12-20 12:55'), '1999-12-20 12:55', 'Y-m-d H:i'],
-            ['Datetime', 'Datetimecolumn', new DateTime('2022-06-28 11:55'), '2022-06-28 11:55', 'Y-m-d H:i'],
+            // type description, column name, format, date/time string, optional input value 
+            ['Date', 'Bar1','Y-m-d', $date,  null],
+            ['Time', 'Bar2', 'H:i:s.u', $time, strtotime($time)],
+            ['Timestamp', 'Bar3', 'Y-m-d H:i:s.u', "$date $time", null],
+            ['Datetime', 'Datetimecolumn', 'Y-m-d H:i:s.u', "$date $time", null],
         ];
     }
     
-    #[\PHPUnit\Framework\Attributes\DataProvider('persistenceDataProvider')]
-    public function testPersistence($typeDescription, $columnName, $inputDateValue, $formattedDate, $format)
+    #[\PHPUnit\Framework\Attributes\DataProvider('AccessStorageFormatDataProvider')]
+    public function testAccessStorageFormatWithoutObjectInstantiation(string $typeDescription, string $columnName, string $format, string $formattedDate, int|null $inputValue)
     {
         $r = new ComplexColumnTypeEntity5();
-        $r->setByName($columnName, $inputDateValue);
-        $r->save();
-        ComplexColumnTypeEntity5TableMap::clearInstancePool();
-        $r1 = ComplexColumnTypeEntity5Query::create()->findPk($r->getId());
-        
-        $storedValue = $r1->getByName($columnName);
-        $this->assertInstanceOf(DateTime::class, $storedValue, "$typeDescription column should return DateTime objects");
-        
-        $formattedReturnValue = $storedValue->format($format);
-        $this->assertEquals($formattedDate, $formattedReturnValue, "$typeDescription column: persisted value should match");
+        $r->setByName($columnName, $inputDateValue ?? new DateTime($formattedDate))->save();
+        $r->reload();
+
+        $dateObjectPropertyName = strtolower($columnName) . '_date_object';
+        $dateObjectAfterClear = $this->getObjectPropertyValue($r, $dateObjectPropertyName);
+        $this->assertNull($dateObjectAfterClear, "internal object should be null after reload()");
+
+        $getter = "get$columnName";
+        $storedValue = $r->$getter($format);
+        $this->assertSame($formattedDate, $storedValue, "should return storage date");
+
+        $dateObjectAfterGetStorageFormat = $this->getObjectPropertyValue($r, $dateObjectPropertyName);
+        $this->assertNull($dateObjectAfterGetStorageFormat, "getting storage format should not instantiate DateTime object");
+
+        $dateTimeObject = $r->$getter();
+        $this->assertInstanceOf(DateTime::class, $dateTimeObject, "should return DateTime object");
+
+        $dateObjectAfterGetObject = $this->getObjectPropertyValue($r, $dateObjectPropertyName);
+        $this->assertInstanceOf(DateTime::class, $dateObjectAfterGetObject, "should have set internal DateTime field");
+
+        $rfcDate = $r->$getter('r');
+        $expectedDate = $dateObjectAfterGetObject->format('r');
+        $this->assertSame($expectedDate, $rfcDate, "should produce DateTime format output");
     }
 
     /**

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/ColumnCodeProducerTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/ColumnCodeProducerTest.php
@@ -68,21 +68,15 @@ EOT;
     }
 
     protected const generatorConfig = [
-        'propel' => [
-            'database' => [
-                'connections' => [
-                    'foo' => [
-                        'adapter' => 'mysql',
-                        'dsn' => 'mysql:foo',
-                        'user' => 'foo',
-                        'password' => 'foo'
-                    ],
-                ],
-            ],
-            'generator' => [
-                'defaultConnection' => 'foo',
-                'connections' => ['foo'],
-            ],
-        ]
+        'propel.database.connections.foo' => [
+            'adapter' => 'mysql',
+            'dsn' => 'mysql:foo',
+            'user' => 'foo',
+            'password' => 'foo'
+        ],
+        'propel.generator' => [
+            'defaultConnection' => 'foo',
+            'connections' => ['foo'],
+        ],
     ];
 }

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/ColumnCodeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/ColumnCodeTest.php
@@ -6,6 +6,7 @@ namespace Propel\Tests\Generator\Builder\Om\ObjectBuilder\ColumnTypes;
 
 use Propel\Generator\Builder\Om\AbstractOMBuilder;
 use Propel\Generator\Builder\Om\BuilderType;
+use Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes\ColumnCodeProducer;
 use Propel\Generator\Config\QuickGeneratorConfig;
 use Propel\Generator\Model\Column;
 use Propel\Generator\Platform\MysqlPlatform;
@@ -15,7 +16,7 @@ use Propel\Tests\CompareGeneratedCodeTestCase;
 
 class ColumnCodeTest extends CompareGeneratedCodeTestCase
 {
- /**
+    /**
      * @return array<array>
      */
     #[ComparesGeneratedFile(textBuilder: 'buildObjectClassCode')]
@@ -52,10 +53,7 @@ class ColumnCodeTest extends CompareGeneratedCodeTestCase
      */
     public function buildObjectClassCode(string $columnXml, array|null $config, PlatformInterface|null $platform): string
     {
-        /** @var \Propel\Generator\Builder\Om\ObjectBuilder $builder */
-        $builder = $this->buildCodeBuilder($columnXml, BuilderType::ObjectBase, $config, $platform);
-        /** @var \Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes\ColumnCodeProducer $builder */
-        $codeProducer = $this->getObjectPropertyValue($builder, 'columnCodeProducers')[0];
+        $codeProducer = $this->buildCodeProducer($columnXml, $config, $platform);
 
         $script = $this->generateCodeFileContentScript($codeProducer, [
             'addColumnAttributes',
@@ -65,8 +63,9 @@ class ColumnCodeTest extends CompareGeneratedCodeTestCase
         . $this->buildCodeFileContent('getDefaultValueString', $codeProducer->getDefaultValueString())
         . $this->buildCodeFileContent('getApplyDefaultValueStatement', $codeProducer->getApplyDefaultValueStatement())
         . $this->buildCodeFileContent('buildCreateFromFilterValueExpression', $codeProducer->buildCreateFromFilterValueExpression('$value'))
-        . $this->buildCodeFileContent('getHydrateStatement', $codeProducer->getHydrateStatement('$value'))
-        . $this->buildCodeFileContent('getAccessValueStatement', $codeProducer->getAccessValueStatement('$value'));
+        . $this->buildCodeFileContent('getHydrateStatement', $this->buildWithPossibleExceptionMessage(fn () => $codeProducer->getHydrateStatement('$value'))) // throws an exception on lazy-loaded columns
+        . $this->buildCodeFileContent('getAccessValueStatement', $codeProducer->getAccessValueStatement())
+        ;
 
         return $script;
     }
@@ -155,10 +154,18 @@ class ColumnCodeTest extends CompareGeneratedCodeTestCase
         array|null $extraConfig = null,
         PlatformInterface|null $platform = null
     ): AbstractOMBuilder {
-        $column = static::buildColumnFromSchema($columnXml);
+        $column = static::buildColumnFromSchema($columnXml, $extraConfig, $platform);
         $config = new QuickGeneratorConfig($extraConfig);
 
         return $config->loadConfiguredBuilder($column->getTable(), $builderType);
+    }
+
+    public function buildCodeProducer(string $columnXml, array|null $extraConfig = null, PlatformInterface|null $platform = null): ColumnCodeProducer
+    {
+        /** @var \Propel\Generator\Builder\Om\ObjectBuilder $builder */
+        $builder = $this->buildCodeBuilder($columnXml, BuilderType::ObjectBase, $extraConfig, $platform);
+
+        return $this->getObjectPropertyValue($builder, 'columnCodeProducers')[0];
     }
 
     /**

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/ColumnCodeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/ColumnCodeTest.php
@@ -33,11 +33,13 @@ class ColumnCodeTest extends CompareGeneratedCodeTestCase
             [['<column name="object_column" type="OBJECT"/>', null, null], __DIR__ . '/expected_column_code/object_model_reference.txt'],
             [['<column name="json_column" type="JSON"/>', null, null], __DIR__ . '/expected_column_code/json_model_reference.txt'],
             [['<column name="blob_column" type="BLOB"/>', null, null], __DIR__ . '/expected_column_code/lob_model_reference.txt'],
-            [['<column name="uuid_column" type="uuid"/>', null, null], __DIR__ . '/expected_column_code/uuid_model_reference.txt'],
+            [['<column name="uuid_column" type="UUID"/>', null, null], __DIR__ . '/expected_column_code/uuid_model_reference.txt'],
+            [['<column name="uuid_binary_column" type="UUID_BINARY"/>', null, null], __DIR__ . '/expected_column_code/uuid_binary_model_reference.txt'],
             [['<column name="bin_enum_column" type="ENUM_BINARY" valueSet="foo,bar"/>', null, null], __DIR__ . '/expected_column_code/enum_binary_model_reference.txt'],
             [['<column name="bin_set_column" type="SET_BINARY" valueSet="foo,bar"/>', null, null], __DIR__ . '/expected_column_code/set_binary_model_reference.txt'],
             [['<column name="native_enum_column" type="ENUM_NATIVE" valueSet="foo,bar"/>', null, $mysqlPlatform], __DIR__ . '/expected_column_code/enum_native_model_reference.txt'],
             [['<column name="native_set_column" type="SET_NATIVE" valueSet="foo,bar"/>', null, $mysqlPlatform], __DIR__ . '/expected_column_code/set_native_model_reference.txt'],
+            [['<column name="lazy_loaded_blob_column" type="BLOB" lazyLoad="true"/>', null, null], __DIR__ . '/expected_column_code/lazy_lob_model_reference.txt'],
         ];
     }
 
@@ -62,7 +64,9 @@ class ColumnCodeTest extends CompareGeneratedCodeTestCase
         ])
         . $this->buildCodeFileContent('getDefaultValueString', $codeProducer->getDefaultValueString())
         . $this->buildCodeFileContent('getApplyDefaultValueStatement', $codeProducer->getApplyDefaultValueStatement())
-        . $this->buildCodeFileContent('buildCreateFromFilterValueExpression', $codeProducer->buildCreateFromFilterValueExpression('$value'));
+        . $this->buildCodeFileContent('buildCreateFromFilterValueExpression', $codeProducer->buildCreateFromFilterValueExpression('$value'))
+        . $this->buildCodeFileContent('getHydrateStatement', $codeProducer->getHydrateStatement('$value'))
+        . $this->buildCodeFileContent('getAccessValueStatement', $codeProducer->getAccessValueStatement('$value'));
 
         return $script;
     }

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/array_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/array_model_reference.txt
@@ -4,16 +4,16 @@ Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes\ArrayColumnCodeProducer
 addColumnAttributes():
 
     /**
-     * The value for the array_column field.
+     * Value of [array_column] field.
      */
     protected string|null $array_column = null;
 
     /**
-     * The unserialized $array_column value.
+     * Deserialized value of [array_column] field.
      *
      * @var array<string>|null
      */
-    protected array|null $array_column_unserialized = null;
+    protected array|null $array_column_deserialized = null;
 
 
 addAccessor():
@@ -21,18 +21,15 @@ addAccessor():
     /**
      * Get the [array_column] column value.
      *
-     * @return array|null
+     * @return array<string>|null
      */
     public function getArrayColumn()
     {
-        if ($this->array_column_unserialized === null) {
-            $this->array_column_unserialized = [];
-        }
-        if (!$this->array_column_unserialized && $this->array_column !== null) {
-            $this->array_column_unserialized = static::unserializeArray($this->array_column);
+        if ($this->array_column_deserialized === null) {
+            $this->array_column_deserialized = !$this->array_column ? [] : static::unserializeArray($this->array_column);
         }
 
-        return $this->array_column_unserialized;
+        return $this->array_column_deserialized;
     }
 
 
@@ -41,14 +38,14 @@ addMutator():
     /**
      * Set the value of [array_column] column.
      *
-     * @param array|null $v New value
+     * @param array<string>|null $v New value
      *
      * @return $this
      */
     public function setArrayColumn($v)
     {
-        if ($this->array_column_unserialized !== $v) {
-            $this->array_column_unserialized = $v;
+        if ($this->array_column_deserialized !== $v) {
+            $this->array_column_deserialized = $v;
             $this->array_column = static::serializeArray($v);
             $this->modifiedColumns[TableTableMap::COL_ARRAY_COLUMN] = true;
         }

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/array_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/array_model_reference.txt
@@ -63,3 +63,11 @@ getApplyDefaultValueStatement:
 
 buildCreateFromFilterValueExpression:
 is_array($value) ? $value : static::unserializeArray($value)
+
+getHydrateStatement:
+
+            $this->array_column = $value;
+            $this->array_column_deserialized = null;
+
+getAccessValueStatement:
+$this->array_column

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/bool_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/bool_model_reference.txt
@@ -4,7 +4,7 @@ Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes\BoolColumnCodeProducer
 addColumnAttributes():
 
     /**
-     * The value for the bool_column field.
+     * Value of [bool_column] field.
      *
      * Note: this column has a database default value of: true
      */

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/bool_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/bool_model_reference.txt
@@ -74,3 +74,10 @@ getApplyDefaultValueStatement:
 
 buildCreateFromFilterValueExpression:
 $value
+
+getHydrateStatement:
+
+            $this->bool_column = $value !== null ? (bool)$value : null;
+
+getAccessValueStatement:
+$this->bool_column

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/enum_binary_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/enum_binary_model_reference.txt
@@ -72,3 +72,10 @@ getApplyDefaultValueStatement:
 
 buildCreateFromFilterValueExpression:
 TableTableMap::getValueSet(TableTableMap::COL_BIN_ENUM_COLUMN)[$value] ?? $value
+
+getHydrateStatement:
+
+            $this->bin_enum_column = $value !== null ? (int)$value : null;
+
+getAccessValueStatement:
+$this->bin_enum_column

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/enum_binary_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/enum_binary_model_reference.txt
@@ -4,7 +4,7 @@ Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes\EnumBinaryColumnCodeProduc
 addColumnAttributes():
 
     /**
-     * The value for the bin_enum_column field.
+     * Value of [bin_enum_column] field.
      */
     protected int|null $bin_enum_column = null;
 

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/enum_native_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/enum_native_model_reference.txt
@@ -4,7 +4,7 @@ Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes\ColumnCodeProducer
 addColumnAttributes():
 
     /**
-     * The value for the native_enum_column field.
+     * Value of [native_enum_column] field.
      */
     protected string|null $native_enum_column = null;
 

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/enum_native_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/enum_native_model_reference.txt
@@ -55,3 +55,10 @@ getApplyDefaultValueStatement:
 
 buildCreateFromFilterValueExpression:
 $value
+
+getHydrateStatement:
+
+            $this->native_enum_column = $value !== null ? (string)$value : null;
+
+getAccessValueStatement:
+$this->native_enum_column

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/integer_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/integer_model_reference.txt
@@ -4,7 +4,7 @@ Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes\ColumnCodeProducer
 addColumnAttributes():
 
     /**
-     * The value for the integer_column field.
+     * Value of [integer_column] field.
      *
      * Note: this column has a database default value of: 42
      */

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/integer_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/integer_model_reference.txt
@@ -57,3 +57,10 @@ getApplyDefaultValueStatement:
 
 buildCreateFromFilterValueExpression:
 $value
+
+getHydrateStatement:
+
+            $this->integer_column = $value !== null ? (int)$value : null;
+
+getAccessValueStatement:
+$this->integer_column

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/json_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/json_model_reference.txt
@@ -58,3 +58,10 @@ getApplyDefaultValueStatement:
 
 buildCreateFromFilterValueExpression:
 $value
+
+getHydrateStatement:
+
+            $this->json_column = $value !== null ? (string)$value : null;
+
+getAccessValueStatement:
+$this->json_column

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/json_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/json_model_reference.txt
@@ -4,7 +4,7 @@ Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes\JsonColumnCodeProducer
 addColumnAttributes():
 
     /**
-     * The value for the json_column field.
+     * Value of [json_column] field.
      */
     protected string|null $json_column = null;
 
@@ -16,7 +16,7 @@ addAccessor():
      *
      * @param bool $asArray Returns the JSON data as array instead of object
      *
-     * @return object|array|null
+     * @return object|array
      */
     public function getJsonColumn($asArray = true)
     {

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/lazy_lob_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/lazy_lob_model_reference.txt
@@ -106,8 +106,7 @@ buildCreateFromFilterValueExpression:
 $value
 
 getHydrateStatement:
-
-            $this->lazy_loaded_blob_column = $value;
+Threw LogicException: Lazy-load column should never be hydrated directly.
 
 getAccessValueStatement:
 $this->lazy_loaded_blob_column

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/lazy_lob_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/lazy_lob_model_reference.txt
@@ -1,0 +1,113 @@
+Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes\LazyLoadColumnCodeProducer
+
+
+addColumnAttributes():
+
+    /**
+     * Value of [lazy_loaded_blob_column] field.
+     *
+     * @var resource|string|null
+     */
+    protected $lazy_loaded_blob_column;
+
+    /**
+     * Whether the lazy-loaded $lazy_loaded_blob_column value has been loaded from database.
+     * This is necessary to avoid repeated lookups if $lazy_loaded_blob_column column is NULL in the db.
+     */
+    protected bool $lazy_loaded_blob_column_is_loaded = false;
+
+
+addAccessor():
+
+    /**
+     * Get the [lazy_loaded_blob_column] column value.
+     *
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con An optional ConnectionInterface connection to use for fetching this lazy-loaded column.
+     *
+     * @return resource|string|null
+     */
+    public function getLazyLoadedBlobColumn(?ConnectionInterface $con = null)
+    {
+        if (!$this->lazy_loaded_blob_column_is_loaded && $this->lazy_loaded_blob_column === null && !$this->isNew()) {
+            $this->loadLazyLoadedBlobColumn($con);
+        }
+
+        return $this->lazy_loaded_blob_column;
+    }
+
+    /**
+     * Load the value for the lazy-loaded [lazy_loaded_blob_column] column.
+     *
+     * This method performs an additional query to return the value for
+     * the [lazy_loaded_blob_column] column, since it is not populated by
+     * the hydrate() method.
+     *
+     * @param $con ConnectionInterface (optional) The ConnectionInterface connection to use.
+     *
+     * @throws \Propel\Runtime\Exception\PropelException - any underlying error will be wrapped and re-thrown.
+     *
+     * @return void
+     */
+    protected function loadLazyLoadedBlobColumn(?ConnectionInterface $con = null)
+    {
+        $c = $this->buildPkeyCriteria();
+        $c->addSelectColumn(TableTableMap::COL_LAZY_LOADED_BLOB_COLUMN);
+        try {
+            $dataFetcher = ChildTableQuery::create(null, $c)->fetch($con);
+            $row = $dataFetcher->fetch();
+            $dataFetcher->close();
+
+            $firstColumn = is_bool($row) ? null : current($row);
+
+            $this->lazy_loaded_blob_column = $this->writeResource($firstColumn);
+            $this->lazy_loaded_blob_column_is_loaded = true;
+        } catch (Exception $e) {
+            throw new PropelException('Error loading value for [lazy_loaded_blob_column] column on demand.', 0, $e);
+        }
+    }
+
+
+addMutator():
+
+    /**
+     * Set the value of [lazy_loaded_blob_column] column.
+     *
+     * @param resource|string|null $v New value
+     *
+     * @return $this
+     */
+    public function setLazyLoadedBlobColumn($v)
+    {
+        // explicitly set the is-loaded flag to true for this lazy load col;
+        // it doesn't matter if the value is actually set or not (logic below) as
+        // any attempt to set the value means that no db lookup should be performed
+        // when the getLazyLoadedBlobColumn() method is called.
+        $this->lazy_loaded_blob_column_is_loaded = true;
+
+        // Because BLOB columns are streams in PDO we have to assume that they are
+        // always modified when a new value is passed in.  For example, the contents
+        // of the stream itself may have changed externally.
+        $this->lazy_loaded_blob_column = $this->writeResource($v);
+
+        $this->modifiedColumns[TableTableMap::COL_LAZY_LOADED_BLOB_COLUMN] = true;
+
+        return $this;
+    }
+
+
+getDefaultValueString:
+null
+
+getApplyDefaultValueStatement:
+
+        $this->lazy_loaded_blob_column = null;
+
+buildCreateFromFilterValueExpression:
+$value
+
+getHydrateStatement:
+
+            $this->lazy_loaded_blob_column = $value;
+
+getAccessValueStatement:
+$this->lazy_loaded_blob_column

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/lazy_lob_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/lazy_lob_model_reference.txt
@@ -78,17 +78,9 @@ addMutator():
      */
     public function setLazyLoadedBlobColumn($v)
     {
-        // explicitly set the is-loaded flag to true for this lazy load col;
-        // it doesn't matter if the value is actually set or not (logic below) as
-        // any attempt to set the value means that no db lookup should be performed
-        // when the getLazyLoadedBlobColumn() method is called.
         $this->lazy_loaded_blob_column_is_loaded = true;
 
-        // Because BLOB columns are streams in PDO we have to assume that they are
-        // always modified when a new value is passed in.  For example, the contents
-        // of the stream itself may have changed externally.
         $this->lazy_loaded_blob_column = $this->writeResource($v);
-
         $this->modifiedColumns[TableTableMap::COL_LAZY_LOADED_BLOB_COLUMN] = true;
 
         return $this;

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/lob_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/lob_model_reference.txt
@@ -55,3 +55,10 @@ getApplyDefaultValueStatement:
 
 buildCreateFromFilterValueExpression:
 $value
+
+getHydrateStatement:
+
+            $this->blob_column = $this->writeResource($value);
+
+getAccessValueStatement:
+$this->blob_column

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/lob_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/lob_model_reference.txt
@@ -4,7 +4,7 @@ Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes\LobColumnCodeProducer
 addColumnAttributes():
 
     /**
-     * The value for the blob_column field.
+     * Value of [blob_column] field.
      *
      * @var resource|string|null
      */

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/lob_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/lob_model_reference.txt
@@ -35,11 +35,7 @@ addMutator():
      */
     public function setBlobColumn($v)
     {
-        // Because BLOB columns are streams in PDO we have to assume that they are
-        // always modified when a new value is passed in.  For example, the contents
-        // of the stream itself may have changed externally.
         $this->blob_column = $this->writeResource($v);
-
         $this->modifiedColumns[TableTableMap::COL_BLOB_COLUMN] = true;
 
         return $this;

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/manually_typed_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/manually_typed_model_reference.txt
@@ -53,3 +53,10 @@ getApplyDefaultValueStatement:
 
 buildCreateFromFilterValueExpression:
 $value
+
+getHydrateStatement:
+
+            $this->manually_typed_column = ($value === null) ? null : new ChildFooType($value);
+
+getAccessValueStatement:
+$this->manually_typed_column

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/manually_typed_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/manually_typed_model_reference.txt
@@ -4,7 +4,7 @@ Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes\ColumnCodeProducer
 addColumnAttributes():
 
     /**
-     * The value for the manually_typed_column field.
+     * Value of [manually_typed_column] field.
      *
      * Note: this column has a database default value of: '42'
      */

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/object_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/object_model_reference.txt
@@ -4,18 +4,18 @@ Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes\ObjectColumnCodeProducer
 addColumnAttributes():
 
     /**
-     * The value for the object_column field.
+     * Value of [object_column] field.
      *
      * @var resource|null
      */
     protected $object_column;
 
     /**
-     * The unserialized $object_column value.
+     * Deserialized value of [object_column] field.
      *
      * @var mixed|null
      */
-    protected $object_column_unserialized;
+    protected $object_column_deserialized;
 
 
 addAccessor():
@@ -27,15 +27,15 @@ addAccessor():
      */
     public function getObjectColumn()
     {
-        if (!$this->object_column_unserialized && is_resource($this->object_column)) {
-            $serialisedString = stream_get_contents($this->object_column);
-            if ($serialisedString) {
-                $unserializedString = unserialize($serialisedString);
-                $this->object_column_unserialized = $unserializedString;
+        if (!$this->object_column_deserialized && is_resource($this->object_column)) {
+            $serializedString = stream_get_contents($this->object_column);
+            if ($serializedString) {
+                $deserializedString = unserialize($serializedString);
+                $this->object_column_deserialized = $deserializedString;
             }
         }
 
-        return $this->object_column_unserialized;
+        return $this->object_column_deserialized;
     }
 
 
@@ -52,7 +52,7 @@ addMutator():
     {
         $serializedValue = serialize($v);
         if ($this->object_column === null || stream_get_contents($this->object_column) !== $serializedValue) {
-            $this->object_column_unserialized = $v;
+            $this->object_column_deserialized = $v;
             $this->object_column = $this->writeResource($serializedValue);
             $this->modifiedColumns[TableTableMap::COL_OBJECT_COLUMN] = true;
         }

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/object_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/object_model_reference.txt
@@ -70,3 +70,10 @@ getApplyDefaultValueStatement:
 
 buildCreateFromFilterValueExpression:
 $value
+
+getHydrateStatement:
+
+            $this->object_column = $this->writeResource($value);
+
+getAccessValueStatement:
+$this->object_column

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/set_binary_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/set_binary_model_reference.txt
@@ -83,3 +83,11 @@ getApplyDefaultValueStatement:
 
 buildCreateFromFilterValueExpression:
 SetColumnConverter::convertBitmaskToArray($value, TableTableMap::getValueSet(TableTableMap::COL_BIN_SET_COLUMN))
+
+getHydrateStatement:
+
+            $this->bin_set_column = $value;
+            $this->bin_set_column_converted = null;
+
+getAccessValueStatement:
+$this->bin_set_column

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/set_binary_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/set_binary_model_reference.txt
@@ -4,11 +4,13 @@ Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes\SetBinaryColumnCodeProduce
 addColumnAttributes():
 
     /**
-     * The value for the bin_set_column field.
+     * Value of [bin_set_column] field.
      */
     protected int|null $bin_set_column = null;
 
     /**
+     * Deserialized value of [bin_set_column] field.
+     *
      * @var array<string>|null
      */
     protected array|null $bin_set_column_converted = null;

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/set_native_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/set_native_model_reference.txt
@@ -4,11 +4,13 @@ Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes\SetNativeColumnCodeProduce
 addColumnAttributes():
 
     /**
-     * The value for the native_set_column field.
+     * Value of [native_set_column] field.
      */
     protected string|null $native_set_column = null;
 
     /**
+     * Deserialized value of [native_set_column] field.
+     *
      * @var array<string>|null
      */
     protected array|null $native_set_column_converted = null;
@@ -39,9 +41,7 @@ addMutator():
     /**
      * Set the value of [native_set_column] column.
      *
-     * @param array|null $v new value
-     *
-     * @throws \Propel\Runtime\Exception\PropelException
+     * @param array<string>|null $v new value
      *
      * @return $this
      */

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/set_native_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/set_native_model_reference.txt
@@ -73,3 +73,11 @@ getApplyDefaultValueStatement:
 
 buildCreateFromFilterValueExpression:
 SetColumnConverter::rawInputToSetItems($value, TableTableMap::getValueSet(TableTableMap::COL_NATIVE_SET_COLUMN))
+
+getHydrateStatement:
+
+            $this->native_set_column = $value;
+            $this->native_set_column_converted = null;
+
+getAccessValueStatement:
+$this->native_set_column

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/temporal_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/temporal_model_reference.txt
@@ -23,13 +23,18 @@ addAccessor():
      *
      * @psalm-return ($format is null ? \DateTime|\DateTimeInterface|null : string|null)
      *
-     * @param string|null $format The date/time format string (either date()-style or strftime()-style).
-     *   If format is NULL, then the raw \DateTime object will be returned.
+     * @param string|null $format Datetime format string. If null, the method returns a \DateTime object.
+     *                      For efficiency, storage format 'Y-m-d H:i:s' is returned without internal transformation.
      *
-     * @return \DateTime|\DateTimeInterface|string|null Formatted date/time value as string or \DateTime object (if format is NULL), NULL if column is NULL, and 0 if column value is 0000-00-00 00:00:00.
+     * @return \DateTime|\DateTimeInterface|string|null Formatted date/time value as string or \DateTime
+     *                  object (if format is null), null if column is null, and 0 if column value is 0000-00-00 00:00:00.
      */
     public function getTemporalColumn($format = null)
     {
+        if ($format === 'Y-m-d H:i:s') {
+            return $this->temporal_column;
+        }
+
         if (!$this->temporal_column_date_object && $this->temporal_column) {
             $this->temporal_column_date_object = PropelDateTime::newInstance($this->temporal_column, null, '\DateTime');
         }

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/temporal_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/temporal_model_reference.txt
@@ -83,4 +83,4 @@ getHydrateStatement:
             $this->temporal_column = $value === '0000-00-00 00:00:00' ? null : $value;
 
 getAccessValueStatement:
-$this->temporal_column
+$this->temporal_column_date_object?->format('Y-m-d H:i:s') ?? $this->temporal_column

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/temporal_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/temporal_model_reference.txt
@@ -71,3 +71,11 @@ getApplyDefaultValueStatement:
 
 buildCreateFromFilterValueExpression:
 $value
+
+getHydrateStatement:
+
+            $this->temporal_column_date_object = null;
+            $this->temporal_column = $value === '0000-00-00 00:00:00' ? null : $value;
+
+getAccessValueStatement:
+$this->temporal_column

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/temporal_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/temporal_model_reference.txt
@@ -4,17 +4,22 @@ Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes\TemporalColumnCodeProducer
 addColumnAttributes():
 
     /**
-     * The value for the temporal_column field.
+     * Value of [temporal_column] field.
      *
      * Note: this column has a database default value of: '2026-03-19 01:09:00'
      */
-    protected DateTimeInterface|null $temporal_column = null;
+    protected string|null $temporal_column = null;
+
+    /**
+     * Deserialized value of [temporal_column] field.
+     */
+    protected DateTimeInterface|null $temporal_column_date_object = null;
 
 
 addAccessor():
 
     /**
-     * Get the [optionally formatted] temporal [temporal_column] column value.
+     * Get the temporal [temporal_column] column value.
      *
      * @psalm-return ($format is null ? \DateTime|\DateTimeInterface|null : string|null)
      *
@@ -25,11 +30,11 @@ addAccessor():
      */
     public function getTemporalColumn($format = null)
     {
-        if ($format === null) {
-            return $this->temporal_column;
-        } else {
-            return $this->temporal_column instanceof DateTimeInterface ? $this->temporal_column->format($format) : null;
+        if (!$this->temporal_column_date_object && $this->temporal_column) {
+            $this->temporal_column_date_object = PropelDateTime::newInstance($this->temporal_column, null, '\DateTime');
         }
+
+        return $format !== null ? $this->temporal_column_date_object?->format($format) : $this->temporal_column_date_object;
     }
 
 
@@ -38,23 +43,19 @@ addMutator():
     /**
      * Sets the value of [temporal_column] column to a normalized version of the date/time value specified.
      *
-     * @param \DateTimeInterface|string|int|null $v string, integer (timestamp), or \DateTimeInterface value.
-     *               Empty strings are treated as NULL.
+     * @param \DateTimeInterface|string|int|null $v Empty strings are treated as null.
      *
      * @return $this
      */
     public function setTemporalColumn($v)
     {
-        $dt = PropelDateTime::newInstance($v, null, '\DateTime');
-        if ($this->temporal_column !== null || $dt !== null) {
-            if (
-                $dt !== $this->temporal_column // normalized values don't match
-                || $dt->format('Y-m-d H:i:s') === '2026-03-19 01:09:00' // or the entered value matches the default
-            ) {
-                $this->temporal_column = $dt === null ? null : clone $dt;
-                $this->modifiedColumns[TableTableMap::COL_TEMPORAL_COLUMN] = true;
-            }
-        } // if either are not null
+        $newDateObject = $v instanceof DateTimeInterface ? $v : PropelDateTime::newInstance($v, null, '\DateTime');
+        $newDateString = $newDateObject?->format('Y-m-d H:i:s');
+        if ($this->temporal_column !== $newDateString || $newDateString === '2026-03-19 01:09:00') {
+            $this->temporal_column_date_object = $newDateObject;
+            $this->temporal_column = $newDateString;
+            $this->modifiedColumns[TableTableMap::COL_TEMPORAL_COLUMN] = true;
+        }
 
         return $this;
     }
@@ -65,7 +66,8 @@ getDefaultValueString:
 
 getApplyDefaultValueStatement:
 
-        $this->temporal_column = PropelDateTime::newInstance('2026-03-19 01:09:00', null, '\DateTime');
+        $this->temporal_column_date_object = $this->temporal_column === '2026-03-19 01:09:00' ? $this->temporal_column_date_object : null;
+        $this->temporal_column = '2026-03-19 01:09:00';
 
 buildCreateFromFilterValueExpression:
 $value

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/uuid_binary_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/uuid_binary_model_reference.txt
@@ -1,0 +1,67 @@
+Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes\ColumnCodeProducer
+
+
+addColumnAttributes():
+
+    /**
+     * Value of [uuid_binary_column] field.
+     */
+    protected string|null $uuid_binary_column = null;
+
+
+addAccessor():
+
+    /**
+     * Get the [uuid_binary_column] column value.
+     *
+     * @return string|null
+     */
+    public function getUuidBinaryColumn()
+    {
+        return $this->uuid_binary_column;
+    }
+
+
+addMutator():
+
+    /**
+     * Set the value of [uuid_binary_column] column.
+     *
+     * @param string|null $v New value
+     *
+     * @return $this
+     */
+    public function setUuidBinaryColumn($v)
+    {
+        if ($v !== null) {
+            $v = (string)$v;
+        }
+
+        if ($this->uuid_binary_column !== $v) {
+            $this->uuid_binary_column = $v;
+            $this->modifiedColumns[TableTableMap::COL_UUID_BINARY_COLUMN] = true;
+        }
+
+        return $this;
+    }
+
+
+getDefaultValueString:
+null
+
+getApplyDefaultValueStatement:
+
+        $this->uuid_binary_column = null;
+
+buildCreateFromFilterValueExpression:
+$value
+
+getHydrateStatement:
+
+            if (is_resource($value)) {
+                $value = stream_get_contents($value);
+            }
+            $this->uuid_binary_column = UuidConverter::binToUuid($value, true);
+
+getAccessValueStatement:
+UuidConverter::uuidToBin($this->uuid_binary_column, true)

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/uuid_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/uuid_model_reference.txt
@@ -55,3 +55,13 @@ getApplyDefaultValueStatement:
 
 buildCreateFromFilterValueExpression:
 $value
+
+getHydrateStatement:
+
+            if (is_resource($value)) {
+                $value = stream_get_contents($value);
+            }
+            $this->uuid_column = UuidConverter::binToUuid($value, true);
+
+getAccessValueStatement:
+UuidConverter::uuidToBin($this->uuid_column, true)

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/uuid_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/uuid_model_reference.txt
@@ -4,7 +4,7 @@ Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes\ColumnCodeProducer
 addColumnAttributes():
 
     /**
-     * The value for the uuid_column field.
+     * Value of [uuid_column] field.
      */
     protected string|null $uuid_column = null;
 

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/varchar_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/varchar_model_reference.txt
@@ -57,3 +57,10 @@ getApplyDefaultValueStatement:
 
 buildCreateFromFilterValueExpression:
 $value
+
+getHydrateStatement:
+
+            $this->var_char_column = $value !== null ? (string)$value : null;
+
+getAccessValueStatement:
+$this->var_char_column

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/varchar_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilder/ColumnTypes/expected_column_code/varchar_model_reference.txt
@@ -4,7 +4,7 @@ Propel\Generator\Builder\Om\ObjectBuilder\ColumnTypes\ColumnCodeProducer
 addColumnAttributes():
 
     /**
-     * The value for the var_char_column field.
+     * Value of [var_char_column] field.
      *
      * Note: this column has a database default value of: 'Bar'
      */

--- a/tests/Propel/Tests/Generator/Builder/Om/expected_builder_code/simple_base_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/expected_builder_code/simple_base_model_reference.txt
@@ -75,7 +75,7 @@ abstract class IdTable implements ActiveRecordInterface
     protected array $virtualColumns = [];
 
     /**
-     * The value for the id field.
+     * Value of [id] field.
      */
     protected int|null $id = null;
 
@@ -396,8 +396,8 @@ abstract class IdTable implements ActiveRecordInterface
             $useNumericIndex = $indexType === TableMap::TYPE_NUM;
 
             $rowIndex = $useNumericIndex ? $startcol + 0 : IdTableTableMap::translateFieldName('Id', TableMap::TYPE_PHPNAME, $indexType);
-            $columnValue = $row[$rowIndex];
-            $this->id = $columnValue !== null ? (int)$columnValue : null;
+            $idValue = $row[$rowIndex];
+            $this->id = $idValue !== null ? (int)$idValue : null;
 
             $this->resetModified();
             $this->setNew(false);
@@ -459,9 +459,9 @@ abstract class IdTable implements ActiveRecordInterface
         if (!$row || $row === true) {
             throw new PropelException('Cannot find matching row in the database to reload object values.');
         }
-        $this->hydrate($row, 0, true, $dataFetcher->getIndexType()); // rehydrate
+        $this->hydrate($row, 0, true, $dataFetcher->getIndexType());
 
-        if ($deep) { // also de-associate any related objects?
+        if ($deep) {
         }
     }
 

--- a/tests/Propel/Tests/Generator/Builder/Om/expected_builder_code/simple_base_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/expected_builder_code/simple_base_model_reference.txt
@@ -733,8 +733,8 @@ abstract class IdTable implements ActiveRecordInterface
         $result = [
             $keys[0] => $this->getId(),
         ];
-        $virtualColumns = $this->virtualColumns;
-        foreach ($virtualColumns as $key => $virtualColumn) {
+
+        foreach ($this->virtualColumns as $key => $virtualColumn) {
             $result[$key] = $virtualColumn;
         }
 

--- a/tests/Propel/Tests/Generator/Platform/DefaultPlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/DefaultPlatformTest.php
@@ -11,19 +11,18 @@ namespace Propel\Tests\Generator\Platform;
 use Propel\Generator\Model\Column;
 use Propel\Generator\Model\PropelTypes;
 use Propel\Generator\Platform\DefaultPlatform;
-use Propel\Generator\Platform\PlatformInterface;
 use Propel\Tests\TestCase;
 
 class DefaultPlatformTest extends TestCase
 {
-    protected static PlatformInterface|null $platform = null;
+    protected static DefaultPlatform|null $platform = null;
 
     /**
      * Get the Platform object for this class
      *
-     * @return \Propel\Generator\Platform\PlatformInterface
+     * @return \Propel\Generator\Platform\DefaultPlatform
      */
-    protected static function getPlatform(): PlatformInterface
+    protected static function getPlatform(): DefaultPlatform
     {
         static::$platform ??= new DefaultPlatform();
         
@@ -164,11 +163,7 @@ class DefaultPlatformTest extends TestCase
     public static function getColumnBindingDataProvider(): array
     {
         return [
-            [static::createColumn(PropelTypes::DATE, '2020-02-03'), '$stmt->bindValue(ID, ACCESSOR?->format(\'Y-m-d\'), PDO::PARAM_STR);'],
-            [static::createColumn(PropelTypes::TIME, '11:01:03'), '$stmt->bindValue(ID, ACCESSOR?->format(\'H:i:s\'), PDO::PARAM_STR);'],
-            [static::createColumn(PropelTypes::TIMESTAMP, '2020-02-03 11:01:03'), '$stmt->bindValue(ID, ACCESSOR?->format(\'Y-m-d H:i:s\'), PDO::PARAM_STR);'],
-            [static::createColumn(PropelTypes::DATETIME, '2022-06-28 11:01:03'), '$stmt->bindValue(ID, ACCESSOR?->format(\'Y-m-d H:i:s\'), PDO::PARAM_STR);'],
-            [static::createColumn(PropelTypes::DATETIME, '2022-06-28 11:01:03', 6), '$stmt->bindValue(ID, ACCESSOR?->format(\'Y-m-d H:i:s.u\'), PDO::PARAM_STR);'],
+            [static::createColumn(PropelTypes::DATE, '2020-02-03'), '$stmt->bindValue(ID, ACCESSOR, PDO::PARAM_STR);'],
             [static::createColumn(PropelTypes::BLOB, 'BLOB'), '$stmt->bindValue(ID, ACCESSOR, PDO::PARAM_LOB);'],
         ];
     }


### PR DESCRIPTION
Currently, temporal columns are stored as `DateTimeInterface` objects, which are created when the model object is hydrated.

This PR stores the value as `string`, the `DateTimeInterface` object is only created on access and stored in a second object property. Using the date string as default means fewer object have to be created (as long as the date field is not accessed), and it provides a value for binding to prepared statements without having to call `DateTimeInterface::format()`.

Splitting database fields into a raw value and a deserialized value attribute is used for all columns with serialization (like types `OBJECT`, `BINARY_SET`, `ARRAY`), and I used the occasion to unify that code into a new `AbstractDeserializableColumnCodeProducer`, which all those CodeProducers extend now.

Changing the way time columns work affected code in ObjectBuilder, which I split up and moved into the corresponding CodeProducers (like `ObjectBuilder::addClear()`, `ObjectBuilder::addHydrateBody()`).

Also, the ColumnCodeProducers now use a method that creates the whole variable access string (`'$this->my_field'`), which makes template code much more readable:
```php
        $stringAttribute = $this->getAttributeName();
        $arrayAttribute = $this->getDeserializedAttributeName();

        $script .= "
        if ($arrayAttribute === null) {
            $arrayAttribute = !$stringAttribute ? [] : static::unserializeArray($stringAttribute);
        }";
```
instead of
```php
        $clo = $this->column->getLowercasedName();
        $cloUnserialized = $clo . '_unserialized';

        $script .= "
        if (!\$this->$cloUnserialized && \$this->$clo !== null) {
            \$this->$cloUnserialized = !\$this->$clo ? [] : static::unserializeArray(\$this->$clo);
        }";
```

<hr/>

I disabled a broken sniffer rule from Spryker, it does not recognize that a param `string|null $param` is nullable (only `?string $param` is considered nullable). This is an issue in `spryker/code-sniffer/Spryker/Sniffs/Commenting/DocBlockParamAllowDefaultValueSniff.php`.