### PR TITLE
Add enum phpType support and enum migrations for PostgreSQL

### DIFF
--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -2627,7 +2627,7 @@ $indent};";
         }
 
         if ($column->isPhpBackedEnumType()) {
-            return "\$this->$columnName?->value";
+            return '$this->' . $columnName . '?->value';
         }
 
         return "\$this->$columnName";

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -842,6 +842,9 @@ abstract class {$this->getUnqualifiedClassName()}$parentClass implements ActiveR
             if ($col->isPhpBackedEnumType()) {
                 $assumedClassName = $this->declareClass($col->getPhpType());
                 $defaultValueString = "$assumedClassName::from($defaultValueString)";
+            } elseif ($col->isPhpUnitEnumType()) {
+                $assumedClassName = $this->declareClass($col->getPhpType());
+                $defaultValueString = "constant($assumedClassName::class . '::' . $defaultValueString)";
             } elseif ($col->isPhpObjectType()) {
                 $assumedClassName = $this->declareClass($col->getPhpType());
                 $defaultValueString = "new $assumedClassName($defaultValueString)";
@@ -1025,6 +1028,13 @@ abstract class {$this->getUnqualifiedClassName()}$parentClass implements ActiveR
                 $assumedClassName = $this->declareClass($col->getPhpType());
                 $script .= "
             \$this->$clo = (\$columnValue === null) ? null : $assumedClassName::from(\$columnValue);";
+            } elseif ($col->isPhpUnitEnumType()) {
+                $assumedClassName = $this->declareClass($col->getPhpType());
+                $script .= "
+            if (\$columnValue !== null && !defined($assumedClassName::class . '::' . \$columnValue)) {
+                throw new \\Propel\\Runtime\\Exception\\PropelException(sprintf('Unknown enum case \"%s\" for %s', \$columnValue, $assumedClassName::class));
+            }
+            \$this->$clo = (\$columnValue === null) ? null : constant($assumedClassName::class . '::' . \$columnValue);";
             } elseif ($col->isPhpObjectType()) {
                 $assumedClassName = $this->declareClass($col->getPhpType());
                 $script .= "
@@ -2628,6 +2638,10 @@ $indent};";
 
         if ($column->isPhpBackedEnumType()) {
             return '$this->' . $columnName . '?->value';
+        }
+
+        if ($column->isPhpUnitEnumType()) {
+            return '$this->' . $columnName . '?->name';
         }
 
         return "\$this->$columnName";

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -839,7 +839,10 @@ abstract class {$this->getUnqualifiedClassName()}$parentClass implements ActiveR
             }
             $notEquals = '!==';
             $defaultValueString = ColumnCodeProducerFactory::create($col, $this)->getDefaultValueString();
-            if ($col->isPhpObjectType()) {
+            if ($col->isPhpBackedEnumType()) {
+                $assumedClassName = $this->declareClass($col->getPhpType());
+                $defaultValueString = "$assumedClassName::from($defaultValueString)";
+            } elseif ($col->isPhpObjectType()) {
                 $assumedClassName = $this->declareClass($col->getPhpType());
                 $defaultValueString = "new $assumedClassName($defaultValueString)";
             }
@@ -1018,6 +1021,10 @@ abstract class {$this->getUnqualifiedClassName()}$parentClass implements ActiveR
                 $script .= "
             \$this->$clo = \$columnValue;
             \$this->$cloConverted = null;";
+            } elseif ($col->isPhpBackedEnumType()) {
+                $assumedClassName = $this->declareClass($col->getPhpType());
+                $script .= "
+            \$this->$clo = (\$columnValue === null) ? null : $assumedClassName::from(\$columnValue);";
             } elseif ($col->isPhpObjectType()) {
                 $assumedClassName = $this->declareClass($col->getPhpType());
                 $script .= "
@@ -2617,6 +2624,10 @@ $indent};";
             $uuidSwapFlag = $this->getUuidSwapFlagLiteral();
 
             return "UuidConverter::uuidToBin(\$this->$columnName, $uuidSwapFlag)";
+        }
+
+        if ($column->isPhpBackedEnumType()) {
+            return "\$this->$columnName?->value";
         }
 
         return "\$this->$columnName";

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/ColumnCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/ColumnCodeProducer.php
@@ -158,7 +158,10 @@ class ColumnCodeProducer extends ObjectCodeProducer
     {
         $clo = $this->column->getLowercasedName();
         $defaultValue = $this->getDefaultValueString();
-        if ($this->column->isPhpObjectType()) {
+        if ($this->column->isPhpBackedEnumType()) {
+            $assumedClassName = $this->declareClass($this->column->getPhpType());
+            $defaultValue = "$assumedClassName::from($defaultValue)";
+        } elseif ($this->column->isPhpObjectType()) {
             $assumedClassName = $this->declareClass($this->column->getPhpType());
             $defaultValue = "new $assumedClassName($defaultValue )";
         }

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/ColumnCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/ColumnTypes/ColumnCodeProducer.php
@@ -161,6 +161,9 @@ class ColumnCodeProducer extends ObjectCodeProducer
         if ($this->column->isPhpBackedEnumType()) {
             $assumedClassName = $this->declareClass($this->column->getPhpType());
             $defaultValue = "$assumedClassName::from($defaultValue)";
+        } elseif ($this->column->isPhpUnitEnumType()) {
+            $assumedClassName = $this->declareClass($this->column->getPhpType());
+            $defaultValue = "constant($assumedClassName::class . '::' . $defaultValue)";
         } elseif ($this->column->isPhpObjectType()) {
             $assumedClassName = $this->declareClass($this->column->getPhpType());
             $defaultValue = "new $assumedClassName($defaultValue )";

--- a/src/Propel/Generator/Model/Column.php
+++ b/src/Propel/Generator/Model/Column.php
@@ -1741,6 +1741,18 @@ class Column extends MappingModel
     }
 
     /**
+     * Returns whether this column's phpType is a UnitEnum (non-backed).
+     *
+     * @see PropelTypes::isPhpUnitEnumType()
+     *
+     * @return bool
+     */
+    public function isPhpUnitEnumType(): bool
+    {
+        return PropelTypes::isPhpUnitEnumType($this->getPhpType());
+    }
+
+    /**
      * Returns an instance of PlatformInterface interface.
      *
      * @return \Propel\Generator\Platform\PlatformInterface|null

--- a/src/Propel/Generator/Model/Column.php
+++ b/src/Propel/Generator/Model/Column.php
@@ -1729,6 +1729,18 @@ class Column extends MappingModel
     }
 
     /**
+     * Returns whether the column PHP type is a backed enum.
+     *
+     * @see PropelTypes::isPhpBackedEnumType()
+     *
+     * @return bool
+     */
+    public function isPhpBackedEnumType(): bool
+    {
+        return PropelTypes::isPhpBackedEnumType($this->getPhpType());
+    }
+
+    /**
      * Returns an instance of PlatformInterface interface.
      *
      * @return \Propel\Generator\Platform\PlatformInterface|null

--- a/src/Propel/Generator/Model/PropelTypes.php
+++ b/src/Propel/Generator/Model/PropelTypes.php
@@ -6,6 +6,7 @@ namespace Propel\Generator\Model;
 
 use BackedEnum;
 use PDO;
+use UnitEnum;
 use function in_array;
 use function is_subclass_of;
 use function strtoupper;
@@ -730,6 +731,18 @@ class PropelTypes
     public static function isPhpBackedEnumType(string $phpType): bool
     {
         return is_subclass_of($phpType, BackedEnum::class);
+    }
+
+    /**
+     * Convenience method to indicate whether a passed-in PHP type is a UnitEnum (non-backed).
+     *
+     * @param string $phpType
+     *
+     * @return bool
+     */
+    public static function isPhpUnitEnumType(string $phpType): bool
+    {
+        return is_subclass_of($phpType, UnitEnum::class) && !is_subclass_of($phpType, BackedEnum::class);
     }
 
     /**

--- a/src/Propel/Generator/Model/PropelTypes.php
+++ b/src/Propel/Generator/Model/PropelTypes.php
@@ -4,8 +4,10 @@ declare(strict_types = 1);
 
 namespace Propel\Generator\Model;
 
+use BackedEnum;
 use PDO;
 use function in_array;
+use function is_subclass_of;
 use function strtoupper;
 
 /**
@@ -727,7 +729,7 @@ class PropelTypes
      */
     public static function isPhpBackedEnumType(string $phpType): bool
     {
-        return is_subclass_of($phpType, \BackedEnum::class);
+        return is_subclass_of($phpType, BackedEnum::class);
     }
 
     /**

--- a/src/Propel/Generator/Model/PropelTypes.php
+++ b/src/Propel/Generator/Model/PropelTypes.php
@@ -719,6 +719,18 @@ class PropelTypes
     }
 
     /**
+     * Returns whether a passed-in PHP type is a backed enum.
+     *
+     * @param string $phpType
+     *
+     * @return bool
+     */
+    public static function isPhpBackedEnumType(string $phpType): bool
+    {
+        return is_subclass_of($phpType, \BackedEnum::class);
+    }
+
+    /**
      * Convenience method to indicate whether a passed-in PHP type is an array.
      *
      * @param string $phpType The PHP type to check

--- a/src/Propel/Generator/Platform/PgsqlPlatform.php
+++ b/src/Propel/Generator/Platform/PgsqlPlatform.php
@@ -39,6 +39,13 @@ class PgsqlPlatform extends DefaultPlatform
     protected $createOrDropSequences = '';
 
     /**
+     * Tracks enum type names already emitted in the current DDL generation run.
+     *
+     * @var array<string, true>
+     */
+    protected array $createdEnumTypes = [];
+
+    /**
      * Initializes db specific domain mapping.
      *
      * @return void
@@ -72,8 +79,9 @@ class PgsqlPlatform extends DefaultPlatform
 
     /**
      * PostgreSQL uses named enum types created via CREATE TYPE, not inline ENUM() syntax.
-     * Returns VARCHAR as the SQL type since PDO handles PG enum values as strings.
-     * Use the `sqlType` schema attribute to specify the actual PG enum type name if needed.
+     * Returns VARCHAR as fallback when `sqlType` is not explicitly set.
+     * Set the `sqlType` schema attribute to specify the PostgreSQL enum type name
+     * for CREATE TYPE generation in migrations.
      *
      * @param \Propel\Generator\Model\Column $column
      *
@@ -308,6 +316,60 @@ SET search_path TO public;
     }
 
     /**
+     * Scans all tables for native enum columns and generates CREATE TYPE DDL.
+     * Deduplicates by type name — shared enum types are only created once.
+     *
+     * @param \Propel\Generator\Model\Database $database
+     *
+     * @return string
+     */
+    protected function getCreateEnumTypesDDL(Database $database): string
+    {
+        $ret = '';
+
+        foreach ($database->getTablesForSql() as $table) {
+            foreach ($table->getColumns() as $column) {
+                $ret .= $this->getCreateEnumTypeDDLForColumn($column);
+            }
+        }
+
+        return $ret;
+    }
+
+    /**
+     * Generates a CREATE TYPE DDL for a native enum column, if not already emitted.
+     *
+     * @param \Propel\Generator\Model\Column $column
+     *
+     * @return string
+     */
+    protected function getCreateEnumTypeDDLForColumn(Column $column): string
+    {
+        if (!in_array($column->getType(), [PropelTypes::ENUM_NATIVE, PropelTypes::SET_NATIVE], true)) {
+            return '';
+        }
+
+        // Only generate CREATE TYPE when sqlType is explicitly set
+        if (!$column->getAttribute('sqlType')) {
+            return '';
+        }
+
+        $typeName = $column->getDomain()->getSqlType();
+        if (isset($this->createdEnumTypes[$typeName])) {
+            return '';
+        }
+
+        $valuesCsv = implode(', ', array_map(
+            fn (string $value): string => "'" . $value . "'",
+            $column->getValueSet(),
+        ));
+
+        $this->createdEnumTypes[$typeName] = true;
+
+        return sprintf("\nCREATE TYPE %s AS ENUM (%s);\n", $this->quoteIdentifier($typeName), $valuesCsv);
+    }
+
+    /**
      * @param \Propel\Generator\Model\Database $database
      *
      * @return string
@@ -315,7 +377,10 @@ SET search_path TO public;
     #[\Override]
     public function getAddTablesDDL(Database $database): string
     {
+        $this->createdEnumTypes = [];
+
         $ret = $this->getAddSchemasDDL($database);
+        $ret .= $this->getCreateEnumTypesDDL($database);
 
         foreach ($database->getTablesForSql() as $table) {
             $this->normalizeTable($table);
@@ -403,7 +468,12 @@ COMMIT;
     #[\Override]
     public function getAddTableDDL(Table $table): string
     {
-        $ret = $this->getUseSchemaDDL($table);
+        $ret = '';
+        foreach ($table->getColumns() as $column) {
+            $ret .= $this->getCreateEnumTypeDDLForColumn($column);
+        }
+
+        $ret .= $this->getUseSchemaDDL($table);
         $ret .= $this->getAddSequenceDDL($table);
 
         $lines = [];
@@ -502,7 +572,35 @@ DROP TABLE IF EXISTS %s CASCADE;
 ";
         $ret .= sprintf($pattern, $this->quoteIdentifier($table->getName()));
         $ret .= $this->getDropSequenceDDL($table);
+        $ret .= $this->getDropEnumTypesDDL($table);
         $ret .= $this->getResetSchemaDDL($table);
+
+        return $ret;
+    }
+
+    /**
+     * Generates DROP TYPE IF EXISTS DDL for native enum columns on a table.
+     *
+     * @param \Propel\Generator\Model\Table $table
+     *
+     * @return string
+     */
+    protected function getDropEnumTypesDDL(Table $table): string
+    {
+        $ret = '';
+
+        foreach ($table->getColumns() as $column) {
+            if (!in_array($column->getType(), [PropelTypes::ENUM_NATIVE, PropelTypes::SET_NATIVE], true)) {
+                continue;
+            }
+
+            if (!$column->getAttribute('sqlType')) {
+                continue;
+            }
+
+            $typeName = $column->getDomain()->getSqlType();
+            $ret .= sprintf("\nDROP TYPE IF EXISTS %s;\n", $this->quoteIdentifier($typeName));
+        }
 
         return $ret;
     }
@@ -668,11 +766,70 @@ ALTER TABLE %s RENAME TO %s;
     {
         $ret = parent::getModifyTableDDL($tableDiff);
 
+        $prefix = $this->getAlterEnumTypesDDL($tableDiff);
+
         if ($this->createOrDropSequences) {
-            $ret = $this->createOrDropSequences . $ret;
+            $prefix .= $this->createOrDropSequences;
+            $this->createOrDropSequences = '';
         }
 
-        $this->createOrDropSequences = '';
+        return $prefix . $ret;
+    }
+
+    /**
+     * Compares enum valueSets between from/to tables and generates ALTER TYPE ADD VALUE DDL.
+     *
+     * @param \Propel\Generator\Model\Diff\TableDiff $tableDiff
+     *
+     * @throws \Propel\Generator\Exception\EngineException
+     *
+     * @return string
+     */
+    protected function getAlterEnumTypesDDL(TableDiff $tableDiff): string
+    {
+        $ret = '';
+        $fromTable = $tableDiff->getFromTable();
+        $toTable = $tableDiff->getToTable();
+
+        foreach ($toTable->getColumns() as $toColumn) {
+            if (!in_array($toColumn->getType(), [PropelTypes::ENUM_NATIVE, PropelTypes::SET_NATIVE], true)) {
+                continue;
+            }
+
+            if (!$toColumn->getAttribute('sqlType') || !$toColumn->getValueSet()) {
+                continue;
+            }
+
+            $fromColumn = $fromTable->hasColumn($toColumn->getName())
+                ? $fromTable->getColumn($toColumn->getName())
+                : null;
+
+            if (!$fromColumn || !$fromColumn->getValueSet()) {
+                continue;
+            }
+
+            $typeName = $toColumn->getDomain()->getSqlType();
+
+            $removedValues = array_diff($fromColumn->getValueSet(), $toColumn->getValueSet());
+            if ($removedValues) {
+                throw new EngineException(sprintf(
+                    "Column '%s' on table '%s': PostgreSQL does not support removing values from an enum type. "
+                    . "Values removed: %s. This must be handled manually.",
+                    $toColumn->getName(),
+                    $toTable->getName(),
+                    implode(', ', $removedValues),
+                ));
+            }
+
+            $newValues = array_diff($toColumn->getValueSet(), $fromColumn->getValueSet());
+            foreach ($newValues as $value) {
+                $ret .= sprintf(
+                    "\nALTER TYPE %s ADD VALUE IF NOT EXISTS '%s';\n",
+                    $this->quoteIdentifier($typeName),
+                    $value,
+                );
+            }
+        }
 
         return $ret;
     }
@@ -895,12 +1052,17 @@ DROP SEQUENCE %s CASCADE;
     #[\Override]
     public function getAddColumnsDDL(array $columns): string
     {
+        $enumDDL = '';
+        foreach ($columns as $column) {
+            $enumDDL .= $this->getCreateEnumTypeDDLForColumn($column);
+        }
+
         $ret = '';
         foreach ($columns as $column) {
             $ret .= $this->getAddColumnDDL($column);
         }
 
-        return $ret;
+        return $enumDDL . $ret;
     }
 
     /**

--- a/src/Propel/Generator/Platform/PgsqlPlatform.php
+++ b/src/Propel/Generator/Platform/PgsqlPlatform.php
@@ -17,6 +17,8 @@ use Propel\Generator\Model\Index;
 use Propel\Generator\Model\PropelTypes;
 use Propel\Generator\Model\Table;
 use Propel\Generator\Model\Unique;
+use function array_diff;
+use function array_map;
 use function filter_var;
 use function implode;
 use function in_array;
@@ -813,8 +815,8 @@ ALTER TABLE %s RENAME TO %s;
             $removedValues = array_diff($fromColumn->getValueSet(), $toColumn->getValueSet());
             if ($removedValues) {
                 throw new EngineException(sprintf(
-                    "Column '%s' on table '%s': PostgreSQL does not support removing values from an enum type. "
-                    . "Values removed: %s. This must be handled manually.",
+                    'Column \'%s\' on table \'%s\': PostgreSQL does not support removing values from an enum type. '
+                    . 'Values removed: %s. This must be handled manually.',
                     $toColumn->getName(),
                     $toTable->getName(),
                     implode(', ', $removedValues),

--- a/src/Propel/Generator/Platform/PgsqlPlatform.php
+++ b/src/Propel/Generator/Platform/PgsqlPlatform.php
@@ -318,27 +318,6 @@ SET search_path TO public;
     }
 
     /**
-     * Scans all tables for native enum columns and generates CREATE TYPE DDL.
-     * Deduplicates by type name — shared enum types are only created once.
-     *
-     * @param \Propel\Generator\Model\Database $database
-     *
-     * @return string
-     */
-    protected function getCreateEnumTypesDDL(Database $database): string
-    {
-        $ret = '';
-
-        foreach ($database->getTablesForSql() as $table) {
-            foreach ($table->getColumns() as $column) {
-                $ret .= $this->getCreateEnumTypeDDLForColumn($column);
-            }
-        }
-
-        return $ret;
-    }
-
-    /**
      * Generates a CREATE TYPE DDL for a native enum column, if not already emitted.
      *
      * @param \Propel\Generator\Model\Column $column
@@ -382,7 +361,6 @@ SET search_path TO public;
         $this->createdEnumTypes = [];
 
         $ret = $this->getAddSchemasDDL($database);
-        $ret .= $this->getCreateEnumTypesDDL($database);
 
         foreach ($database->getTablesForSql() as $table) {
             $this->normalizeTable($table);
@@ -470,12 +448,12 @@ COMMIT;
     #[\Override]
     public function getAddTableDDL(Table $table): string
     {
-        $ret = '';
+        $ret = $this->getUseSchemaDDL($table);
+
         foreach ($table->getColumns() as $column) {
             $ret .= $this->getCreateEnumTypeDDLForColumn($column);
         }
 
-        $ret .= $this->getUseSchemaDDL($table);
         $ret .= $this->getAddSequenceDDL($table);
 
         $lines = [];

--- a/src/Propel/Generator/Platform/PgsqlPlatform.php
+++ b/src/Propel/Generator/Platform/PgsqlPlatform.php
@@ -67,7 +67,22 @@ class PgsqlPlatform extends DefaultPlatform
         $this->setSchemaDomainMapping(new Domain(PropelTypes::UUID, 'uuid'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::UUID_BINARY, 'BYTEA'));
 
-        $this->setSetTypesMapping(false);
+        $this->setSetTypesMapping(true);
+    }
+
+    /**
+     * PostgreSQL uses named enum types created via CREATE TYPE, not inline ENUM() syntax.
+     * Returns VARCHAR as the SQL type since PDO handles PG enum values as strings.
+     * Use the `sqlType` schema attribute to specify the actual PG enum type name if needed.
+     *
+     * @param \Propel\Generator\Model\Column $column
+     *
+     * @return string
+     */
+    #[\Override]
+    public function buildNativeEnumeratedColumnSqlType(Column $column): string
+    {
+        return 'VARCHAR';
     }
 
     /**

--- a/src/Propel/Generator/Platform/PgsqlPlatform.php
+++ b/src/Propel/Generator/Platform/PgsqlPlatform.php
@@ -318,6 +318,26 @@ SET search_path TO public;
     }
 
     /**
+     * Prepends the table's schema name to an identifier, following the same
+     * pattern as Table::getName() for schema-qualified names.
+     *
+     * @param string $name The unqualified name
+     * @param \Propel\Generator\Model\Table|null $table The table providing schema context
+     *
+     * @return string The schema-qualified name, or the original name if no schema
+     */
+    protected function getSchemaQualifiedName(string $name, ?Table $table): string
+    {
+        if ($table === null || strpos($name, '.') !== false) {
+            return $name;
+        }
+
+        $schemaName = $table->guessSchemaName();
+
+        return $schemaName ? $schemaName . '.' . $name : $name;
+    }
+
+    /**
      * Generates a CREATE TYPE DDL for a native enum column, if not already emitted.
      *
      * @param \Propel\Generator\Model\Column $column
@@ -340,14 +360,19 @@ SET search_path TO public;
             return '';
         }
 
+        $qualifiedTypeName = $this->getSchemaQualifiedName($typeName, $column->getTable());
+        if (isset($this->createdEnumTypes[$qualifiedTypeName])) {
+            return '';
+        }
+
         $valuesCsv = implode(', ', array_map(
             fn (string $value): string => "'" . $value . "'",
             $column->getValueSet(),
         ));
 
-        $this->createdEnumTypes[$typeName] = true;
+        $this->createdEnumTypes[$qualifiedTypeName] = true;
 
-        return sprintf("\nCREATE TYPE %s AS ENUM (%s);\n", $this->quoteIdentifier($typeName), $valuesCsv);
+        return sprintf("\nCREATE TYPE %s AS ENUM (%s);\n", $this->quoteIdentifier($qualifiedTypeName), $valuesCsv);
     }
 
     /**
@@ -578,7 +603,7 @@ DROP TABLE IF EXISTS %s CASCADE;
                 continue;
             }
 
-            $typeName = $column->getDomain()->getSqlType();
+            $typeName = $this->getSchemaQualifiedName($column->getDomain()->getSqlType(), $table);
             $ret .= sprintf("\nDROP TYPE IF EXISTS %s;\n", $this->quoteIdentifier($typeName));
         }
 
@@ -610,6 +635,11 @@ DROP TABLE IF EXISTS %s CASCADE;
 
         $ddl = [$this->quoteIdentifier($col->getName())];
         $sqlType = $domain->getSqlType();
+
+        // Schema-qualify native enum type references
+        if (in_array($col->getType(), [PropelTypes::ENUM_NATIVE, PropelTypes::SET_NATIVE], true) && $col->getAttribute('sqlType')) {
+            $sqlType = $this->getSchemaQualifiedName($sqlType, $col->getTable());
+        }
         $table = $col->getTable();
         if ($col->isAutoIncrement() && $table && $table->getIdMethodParameters() == null) {
             $sqlType = $col->getType() === PropelTypes::BIGINT ? 'bigserial' : 'serial';
@@ -788,7 +818,7 @@ ALTER TABLE %s RENAME TO %s;
                 continue;
             }
 
-            $typeName = $toColumn->getDomain()->getSqlType();
+            $qualifiedTypeName = $this->getSchemaQualifiedName($toColumn->getDomain()->getSqlType(), $toTable);
 
             $removedValues = array_diff($fromColumn->getValueSet(), $toColumn->getValueSet());
             if ($removedValues) {
@@ -805,7 +835,7 @@ ALTER TABLE %s RENAME TO %s;
             foreach ($newValues as $value) {
                 $ret .= sprintf(
                     "\nALTER TYPE %s ADD VALUE IF NOT EXISTS '%s';\n",
-                    $this->quoteIdentifier($typeName),
+                    $this->quoteIdentifier($qualifiedTypeName),
                     $value,
                 );
             }

--- a/src/Propel/Generator/Reverse/PgsqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/PgsqlSchemaParser.php
@@ -272,7 +272,8 @@ class PgsqlSchemaParser extends AbstractSchemaParser
             is_nullable,
             numeric_precision,
             numeric_scale,
-            character_maximum_length
+            character_maximum_length,
+            udt_name
         FROM information_schema.columns
         WHERE
             table_schema IN ($searchPath) AND table_name = ?
@@ -304,6 +305,17 @@ class PgsqlSchemaParser extends AbstractSchemaParser
             }
 
             $autoincrement = null;
+            $enumValues = null;
+            $enumTypeName = null;
+
+            // Detect PostgreSQL native enum types (USER-DEFINED with enum values)
+            if (strtoupper($type) === 'USER-DEFINED' && isset($row['udt_name'])) {
+                $enumValues = $this->getEnumValues($row['udt_name'], $table->getSchema() ?: 'public');
+                if ($enumValues !== null) {
+                    $enumTypeName = $row['udt_name'];
+                    $type = 'enum';
+                }
+            }
 
             // if column has a default
 
@@ -318,10 +330,14 @@ class PgsqlSchemaParser extends AbstractSchemaParser
                 $default = null;
             }
 
-            $propelType = $this->getMappedPropelType($type);
-            if (!$propelType) {
-                $propelType = Column::DEFAULT_TYPE;
-                $this->warn('Column [' . $table->getName() . '.' . $name . '] has a column type (' . $type . ') that Propel does not support.');
+            if ($enumTypeName !== null) {
+                $propelType = PropelTypes::ENUM_NATIVE;
+            } else {
+                $propelType = $this->getMappedPropelType($type);
+                if (!$propelType) {
+                    $propelType = Column::DEFAULT_TYPE;
+                    $this->warn('Column [' . $table->getName() . '.' . $name . '] has a column type (' . $type . ') that Propel does not support.');
+                }
             }
 
             if (isset(static::$defaultTypeSizes[$type]) && $size == static::$defaultTypeSizes[$type]) {
@@ -341,6 +357,13 @@ class PgsqlSchemaParser extends AbstractSchemaParser
                 $column->getDomain()->replaceScale($scale);
             }
 
+            if ($enumTypeName !== null) {
+                $column->getDomain()->replaceSqlType($enumTypeName);
+                if ($enumValues) {
+                    $column->setValueSet($enumValues);
+                }
+            }
+
             if ($default !== null) {
                 $isExpression = $this->isColumnDefaultExpression($default);
                 if (!$isExpression) {
@@ -354,6 +377,35 @@ class PgsqlSchemaParser extends AbstractSchemaParser
 
             $table->addColumn($column);
         }
+    }
+
+    /**
+     * Queries pg_enum to retrieve enum values for a PostgreSQL enum type.
+     *
+     * @param string $typeName The enum type name (udt_name)
+     * @param string $schema The schema containing the type
+     *
+     * @return array<string>|null Enum values in sort order, or null if not an enum type
+     */
+    protected function getEnumValues(string $typeName, string $schema): ?array
+    {
+        $stmt = $this->dbh->prepare("
+            SELECT e.enumlabel
+            FROM pg_enum e
+            JOIN pg_type t ON e.enumtypid = t.oid
+            JOIN pg_namespace n ON t.typnamespace = n.oid
+            WHERE t.typname = ? AND n.nspname = ?
+            ORDER BY e.enumsortorder
+        ");
+
+        if ($stmt === false) {
+            return null;
+        }
+
+        $stmt->execute([$typeName, $schema]);
+        $values = $stmt->fetchAll(PDO::FETCH_COLUMN, 0);
+
+        return $values ?: null;
     }
 
     /**

--- a/src/Propel/Generator/Reverse/PgsqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/PgsqlSchemaParser.php
@@ -310,7 +310,8 @@ class PgsqlSchemaParser extends AbstractSchemaParser
 
             // Detect PostgreSQL native enum types (USER-DEFINED with enum values)
             if (strtoupper($type) === 'USER-DEFINED' && isset($row['udt_name'])) {
-                $enumValues = $this->getEnumValues($row['udt_name'], $table->getSchema() ?: 'public');
+                $enumSchema = $table->getSchema() ?: $table->getDatabase()->getSchema() ?: 'public';
+                $enumValues = $this->getEnumValues($row['udt_name'], $enumSchema);
                 if ($enumValues !== null) {
                     $enumTypeName = $row['udt_name'];
                     $type = 'enum';

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectEnumNativeColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectEnumNativeColumnTypeTest.php
@@ -4,17 +4,22 @@ declare(strict_types = 1);
 
 namespace Propel\Tests\Generator\Builder\Om;
 
-use EnumNativeEntity;
-use EnumNativeEntityQuery;
-use Map\EnumNativeEntityTableMap;
+use EnumNativeBackedEntity;
+use EnumNativeBackedEntityQuery;
+use EnumNativeUnitEntity;
+use EnumNativeUnitEntityQuery;
+use Map\EnumNativeBackedEntityTableMap;
+use Map\EnumNativeUnitEntityTableMap;
 use Propel\Generator\Platform\PgsqlPlatform;
 use Propel\Generator\Util\QuickBuilder;
 use Propel\Runtime\Adapter\Pdo\PgsqlAdapter;
+use Propel\Runtime\Exception\PropelException;
 use Propel\Tests\Helpers\ColorsBackedEnum;
+use Propel\Tests\Helpers\ColorsBasicEnum;
 use Propel\Tests\TestCase;
 
 /**
- * Tests runtime behavior of ENUM_NATIVE columns with PHP backed enums on PostgreSQL.
+ * Tests runtime behavior of ENUM_NATIVE columns with PHP enums on PostgreSQL.
  *
  * @group pgsql
  * @group database
@@ -33,13 +38,19 @@ class GeneratedObjectEnumNativeColumnTypeTest extends TestCase
             return;
         }
 
-        $enumClass = ColorsBackedEnum::class;
+        $backedEnumClass = ColorsBackedEnum::class;
+        $unitEnumClass = ColorsBasicEnum::class;
         $schema = <<<EOF
 <database name="enum_native_test">
-    <table name="enum_native_entity">
+    <table name="enum_native_backed_entity">
         <column name="id" primaryKey="true" type="INTEGER" autoIncrement="true"/>
-        <column name="color" type="ENUM_NATIVE" valueSet="red,blue,yellow" sqlType="enum_native_entity_color" phpType="$enumClass"/>
-        <column name="nullable_color" type="ENUM_NATIVE" valueSet="red,blue,yellow" sqlType="enum_native_entity_color" phpType="$enumClass" required="false"/>
+        <column name="color" type="ENUM_NATIVE" valueSet="red,blue,yellow" sqlType="enum_native_backed_color" phpType="$backedEnumClass"/>
+        <column name="nullable_color" type="ENUM_NATIVE" valueSet="red,blue,yellow" sqlType="enum_native_backed_color" phpType="$backedEnumClass" required="false"/>
+    </table>
+    <table name="enum_native_unit_entity">
+        <column name="id" primaryKey="true" type="INTEGER" autoIncrement="true"/>
+        <column name="color" type="ENUM_NATIVE" valueSet="Red,Blue,Yellow" sqlType="enum_native_unit_color" phpType="$unitEnumClass"/>
+        <column name="nullable_color" type="ENUM_NATIVE" valueSet="Red,Blue,Yellow" sqlType="enum_native_unit_color" phpType="$unitEnumClass" required="false"/>
     </table>
 </database>
 EOF;
@@ -59,72 +70,149 @@ EOF;
         self::$built = true;
     }
 
-    public function testInsertAndHydrateEnum(): void
+    // --- BackedEnum tests ---
+
+    public function testBackedEnumInsertAndHydrate(): void
     {
-        $entity = new EnumNativeEntity();
+        $entity = new EnumNativeBackedEntity();
         $entity->setColor(ColorsBackedEnum::Red);
         $entity->save();
 
-        EnumNativeEntityTableMap::clearInstancePool();
+        EnumNativeBackedEntityTableMap::clearInstancePool();
 
-        $fetched = EnumNativeEntityQuery::create()->findOneById($entity->getId());
+        $fetched = EnumNativeBackedEntityQuery::create()->findOneById($entity->getId());
         $this->assertNotNull($fetched);
         $this->assertSame(ColorsBackedEnum::Red, $fetched->getColor());
     }
 
-    public function testUpdateEnum(): void
+    public function testBackedEnumUpdate(): void
     {
-        $entity = new EnumNativeEntity();
+        $entity = new EnumNativeBackedEntity();
         $entity->setColor(ColorsBackedEnum::Blue);
         $entity->save();
 
         $entity->setColor(ColorsBackedEnum::Yellow);
         $entity->save();
 
-        EnumNativeEntityTableMap::clearInstancePool();
+        EnumNativeBackedEntityTableMap::clearInstancePool();
 
-        $fetched = EnumNativeEntityQuery::create()->findOneById($entity->getId());
+        $fetched = EnumNativeBackedEntityQuery::create()->findOneById($entity->getId());
         $this->assertSame(ColorsBackedEnum::Yellow, $fetched->getColor());
     }
 
-    public function testNullableEnumColumn(): void
+    public function testBackedEnumNullable(): void
     {
-        $entity = new EnumNativeEntity();
+        $entity = new EnumNativeBackedEntity();
         $entity->setColor(ColorsBackedEnum::Red);
         $entity->setNullableColor(null);
         $entity->save();
 
-        EnumNativeEntityTableMap::clearInstancePool();
+        EnumNativeBackedEntityTableMap::clearInstancePool();
 
-        $fetched = EnumNativeEntityQuery::create()->findOneById($entity->getId());
+        $fetched = EnumNativeBackedEntityQuery::create()->findOneById($entity->getId());
         $this->assertNull($fetched->getNullableColor());
     }
 
-    public function testFilterByEnumColumn(): void
+    public function testBackedEnumFilter(): void
     {
-        // Clear existing data
-        EnumNativeEntityQuery::create()->deleteAll();
+        EnumNativeBackedEntityQuery::create()->deleteAll();
 
-        $e1 = new EnumNativeEntity();
+        $e1 = new EnumNativeBackedEntity();
         $e1->setColor(ColorsBackedEnum::Red);
         $e1->save();
 
-        $e2 = new EnumNativeEntity();
+        $e2 = new EnumNativeBackedEntity();
         $e2->setColor(ColorsBackedEnum::Blue);
         $e2->save();
 
-        $e3 = new EnumNativeEntity();
+        $e3 = new EnumNativeBackedEntity();
         $e3->setColor(ColorsBackedEnum::Red);
         $e3->save();
 
-        $count = EnumNativeEntityQuery::create()
-            ->filterByColor('red')
-            ->count();
-        $this->assertEquals(2, $count);
+        $this->assertEquals(2, EnumNativeBackedEntityQuery::create()->filterByColor('red')->count());
+        $this->assertEquals(1, EnumNativeBackedEntityQuery::create()->filterByColor('blue')->count());
+    }
 
-        $count = EnumNativeEntityQuery::create()
-            ->filterByColor('blue')
-            ->count();
-        $this->assertEquals(1, $count);
+    // --- UnitEnum tests ---
+
+    public function testUnitEnumInsertAndHydrate(): void
+    {
+        $entity = new EnumNativeUnitEntity();
+        $entity->setColor(ColorsBasicEnum::Red);
+        $entity->save();
+
+        EnumNativeUnitEntityTableMap::clearInstancePool();
+
+        $fetched = EnumNativeUnitEntityQuery::create()->findOneById($entity->getId());
+        $this->assertNotNull($fetched);
+        $this->assertSame(ColorsBasicEnum::Red, $fetched->getColor());
+    }
+
+    public function testUnitEnumUpdate(): void
+    {
+        $entity = new EnumNativeUnitEntity();
+        $entity->setColor(ColorsBasicEnum::Blue);
+        $entity->save();
+
+        $entity->setColor(ColorsBasicEnum::Yellow);
+        $entity->save();
+
+        EnumNativeUnitEntityTableMap::clearInstancePool();
+
+        $fetched = EnumNativeUnitEntityQuery::create()->findOneById($entity->getId());
+        $this->assertSame(ColorsBasicEnum::Yellow, $fetched->getColor());
+    }
+
+    public function testUnitEnumNullable(): void
+    {
+        $entity = new EnumNativeUnitEntity();
+        $entity->setColor(ColorsBasicEnum::Red);
+        $entity->setNullableColor(null);
+        $entity->save();
+
+        EnumNativeUnitEntityTableMap::clearInstancePool();
+
+        $fetched = EnumNativeUnitEntityQuery::create()->findOneById($entity->getId());
+        $this->assertNull($fetched->getNullableColor());
+    }
+
+    public function testUnitEnumFilter(): void
+    {
+        EnumNativeUnitEntityQuery::create()->deleteAll();
+
+        $e1 = new EnumNativeUnitEntity();
+        $e1->setColor(ColorsBasicEnum::Red);
+        $e1->save();
+
+        $e2 = new EnumNativeUnitEntity();
+        $e2->setColor(ColorsBasicEnum::Blue);
+        $e2->save();
+
+        $e3 = new EnumNativeUnitEntity();
+        $e3->setColor(ColorsBasicEnum::Red);
+        $e3->save();
+
+        $this->assertEquals(2, EnumNativeUnitEntityQuery::create()->filterByColor('Red')->count());
+        $this->assertEquals(1, EnumNativeUnitEntityQuery::create()->filterByColor('Blue')->count());
+    }
+
+    public function testUnitEnumInvalidValueThrowsException(): void
+    {
+        $this->expectException(PropelException::class);
+        $this->expectExceptionMessage('Unknown enum case');
+
+        $entity = new EnumNativeUnitEntity();
+        $entity->setColor(ColorsBasicEnum::Red);
+        $entity->save();
+
+        EnumNativeUnitEntityTableMap::clearInstancePool();
+
+        // Write an invalid enum case name directly to the database
+        $con = \Propel\Runtime\Propel::getConnection('enum_native_test');
+        $stmt = $con->prepare("UPDATE enum_native_unit_entity SET color = 'InvalidCase' WHERE id = ?");
+        $stmt->execute([$entity->getId()]);
+
+        // Hydrating should throw PropelException
+        EnumNativeUnitEntityQuery::create()->findOneById($entity->getId());
     }
 }

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectEnumNativeColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectEnumNativeColumnTypeTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Propel\Tests\Generator\Builder\Om;
+
+use EnumNativeEntity;
+use EnumNativeEntityQuery;
+use Map\EnumNativeEntityTableMap;
+use Propel\Generator\Platform\PgsqlPlatform;
+use Propel\Generator\Util\QuickBuilder;
+use Propel\Runtime\Adapter\Pdo\PgsqlAdapter;
+use Propel\Tests\Helpers\ColorsBackedEnum;
+use Propel\Tests\TestCase;
+
+/**
+ * Tests runtime behavior of ENUM_NATIVE columns with PHP backed enums on PostgreSQL.
+ *
+ * @group pgsql
+ * @group database
+ */
+class GeneratedObjectEnumNativeColumnTypeTest extends TestCase
+{
+    private static bool $built = false;
+
+    public function setUp(): void
+    {
+        if (strtolower(getenv('DB') ?: '') !== 'pgsql') {
+            $this->markTestSkipped('Test requires PostgreSQL (set DB=pgsql).');
+        }
+
+        if (self::$built) {
+            return;
+        }
+
+        $enumClass = ColorsBackedEnum::class;
+        $schema = <<<EOF
+<database name="enum_native_test">
+    <table name="enum_native_entity">
+        <column name="id" primaryKey="true" type="INTEGER" autoIncrement="true"/>
+        <column name="color" type="ENUM_NATIVE" valueSet="red,blue,yellow" sqlType="enum_native_entity_color" phpType="$enumClass"/>
+        <column name="nullable_color" type="ENUM_NATIVE" valueSet="red,blue,yellow" sqlType="enum_native_entity_color" phpType="$enumClass" required="false"/>
+    </table>
+</database>
+EOF;
+
+        $host = getenv('DB_HOSTNAME') ?: '127.0.0.1';
+        $dbName = getenv('DB_NAME') ?: 'test';
+        $dsn = "pgsql:host=$host;dbname=$dbName";
+        $user = getenv('DB_USER') ?: null;
+        $pass = getenv('DB_PW') ?: null;
+
+        $builder = new QuickBuilder();
+        $builder->setSchema($schema);
+        $builder->setPlatform(new PgsqlPlatform());
+
+        $builder->build($dsn, $user, $pass, new PgsqlAdapter());
+
+        self::$built = true;
+    }
+
+    public function testInsertAndHydrateEnum(): void
+    {
+        $entity = new EnumNativeEntity();
+        $entity->setColor(ColorsBackedEnum::Red);
+        $entity->save();
+
+        EnumNativeEntityTableMap::clearInstancePool();
+
+        $fetched = EnumNativeEntityQuery::create()->findOneById($entity->getId());
+        $this->assertNotNull($fetched);
+        $this->assertSame(ColorsBackedEnum::Red, $fetched->getColor());
+    }
+
+    public function testUpdateEnum(): void
+    {
+        $entity = new EnumNativeEntity();
+        $entity->setColor(ColorsBackedEnum::Blue);
+        $entity->save();
+
+        $entity->setColor(ColorsBackedEnum::Yellow);
+        $entity->save();
+
+        EnumNativeEntityTableMap::clearInstancePool();
+
+        $fetched = EnumNativeEntityQuery::create()->findOneById($entity->getId());
+        $this->assertSame(ColorsBackedEnum::Yellow, $fetched->getColor());
+    }
+
+    public function testNullableEnumColumn(): void
+    {
+        $entity = new EnumNativeEntity();
+        $entity->setColor(ColorsBackedEnum::Red);
+        $entity->setNullableColor(null);
+        $entity->save();
+
+        EnumNativeEntityTableMap::clearInstancePool();
+
+        $fetched = EnumNativeEntityQuery::create()->findOneById($entity->getId());
+        $this->assertNull($fetched->getNullableColor());
+    }
+
+    public function testFilterByEnumColumn(): void
+    {
+        // Clear existing data
+        EnumNativeEntityQuery::create()->deleteAll();
+
+        $e1 = new EnumNativeEntity();
+        $e1->setColor(ColorsBackedEnum::Red);
+        $e1->save();
+
+        $e2 = new EnumNativeEntity();
+        $e2->setColor(ColorsBackedEnum::Blue);
+        $e2->save();
+
+        $e3 = new EnumNativeEntity();
+        $e3->setColor(ColorsBackedEnum::Red);
+        $e3->save();
+
+        $count = EnumNativeEntityQuery::create()
+            ->filterByColor('red')
+            ->count();
+        $this->assertEquals(2, $count);
+
+        $count = EnumNativeEntityQuery::create()
+            ->filterByColor('blue')
+            ->count();
+        $this->assertEquals(1, $count);
+    }
+}

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectEnumNativeColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectEnumNativeColumnTypeTest.php
@@ -13,7 +13,6 @@ use Map\EnumNativeUnitEntityTableMap;
 use Propel\Generator\Platform\PgsqlPlatform;
 use Propel\Generator\Util\QuickBuilder;
 use Propel\Runtime\Adapter\Pdo\PgsqlAdapter;
-use Propel\Runtime\Exception\PropelException;
 use Propel\Tests\Helpers\ColorsBackedEnum;
 use Propel\Tests\Helpers\ColorsBasicEnum;
 use Propel\Tests\TestCase;
@@ -196,23 +195,7 @@ EOF;
         $this->assertEquals(1, EnumNativeUnitEntityQuery::create()->filterByColor('Blue')->count());
     }
 
-    public function testUnitEnumInvalidValueThrowsException(): void
-    {
-        $this->expectException(PropelException::class);
-        $this->expectExceptionMessage('Unknown enum case');
-
-        $entity = new EnumNativeUnitEntity();
-        $entity->setColor(ColorsBasicEnum::Red);
-        $entity->save();
-
-        EnumNativeUnitEntityTableMap::clearInstancePool();
-
-        // Write an invalid enum case name directly to the database
-        $con = \Propel\Runtime\Propel::getConnection('enum_native_test');
-        $stmt = $con->prepare("UPDATE enum_native_unit_entity SET color = 'InvalidCase' WHERE id = ?");
-        $stmt->execute([$entity->getId()]);
-
-        // Hydrating should throw PropelException
-        EnumNativeUnitEntityQuery::create()->findOneById($entity->getId());
-    }
+    // Note: invalid enum value test is not possible with ENUM_NATIVE because
+    // PostgreSQL enforces valid values at the database level. The PropelException
+    // for unknown UnitEnum cases applies to non-native columns (e.g., VARCHAR with phpType).
 }

--- a/tests/Propel/Tests/Generator/Migration/BaseTest.php
+++ b/tests/Propel/Tests/Generator/Migration/BaseTest.php
@@ -9,6 +9,7 @@
 namespace Propel\Tests\Generator\Migration;
 
 use Propel\Generator\Model\PropelTypes;
+use Propel\Generator\Platform\PgsqlPlatform;
 
 /**
  * @group database
@@ -361,11 +362,15 @@ class BaseTest extends MigrationTestCase
             return $this->markTestSkipped('Test requires native SET/ENUM type.');
         }
 
+        $isPgsql = $this->getPlatform() instanceof PgsqlPlatform;
+        $enumSqlType = $isPgsql ? ' sqlType="migration_test_enum_type"' : '';
+        $setSqlType = $isPgsql ? ' sqlType="migration_test_set_type"' : '';
+
         $originXml = '
 <database>
     <table name="migration_test_enum">
-        <column name="enum_column" type="ENUM_NATIVE" valueSet="foo,bar"/>
-        <column name="set_column" type="SET_NATIVE" valueSet="foo,bar"/>
+        <column name="enum_column" type="ENUM_NATIVE" valueSet="foo,bar"' . $enumSqlType . '/>
+        <column name="set_column" type="SET_NATIVE" valueSet="foo,bar"' . $setSqlType . '/>
     </table>
 </database>
 ';
@@ -373,8 +378,8 @@ class BaseTest extends MigrationTestCase
         $targetXml = '
 <database>
     <table name="migration_test_enum">
-        <column name="enum_column" type="ENUM_NATIVE" valueSet="baz,foo,bar"/>
-        <column name="set_column" type="SET_NATIVE" valueSet="baz,foo,bar"/>
+        <column name="enum_column" type="ENUM_NATIVE" valueSet="baz,foo,bar"' . $enumSqlType . '/>
+        <column name="set_column" type="SET_NATIVE" valueSet="baz,foo,bar"' . $setSqlType . '/>
     </table>
 </database>
 ';

--- a/tests/Propel/Tests/Generator/Platform/EnumeratedColumnTypesTest.php
+++ b/tests/Propel/Tests/Generator/Platform/EnumeratedColumnTypesTest.php
@@ -73,7 +73,12 @@ class EnumeratedColumnTypesTest extends TestCase
      */
     public function testEnumAliasOnPlatform(string $platformClass, bool $defaultToNative, string $columnType, string $expectedColumnType): void
     {
-        $columnXml = '<column name="column" type="' . $columnType . '" valueSet="A,B"/>';
+        $sqlTypeAttr = (
+            $platformClass === PgsqlPlatform::class
+            && in_array($columnType, [PropelTypes::ENUM, PropelTypes::SET], true)
+            && $defaultToNative
+        ) ? ' sqlType="column_type"' : '';
+        $columnXml = '<column name="column" type="' . $columnType . '" valueSet="A,B"' . $sqlTypeAttr . '/>';
         $column = $this->buildColumnFromSchema(new $platformClass, $defaultToNative, $columnXml);
         $actualColumnType = $column->getType();
 
@@ -228,7 +233,16 @@ class EnumeratedColumnTypesTest extends TestCase
         $this->assertTrue($column->isPhpObjectType());
     }
 
-    public function testPgsqlEnumNativeUsesVarchar(): void
+    public function testPgsqlEnumNativeUsesSqlType(): void
+    {
+        $columnXml = '<column name="status" type="ENUM_NATIVE" valueEnum="' . ColorsBackedEnum::class . '" sqlType="status_type"/>';
+        $platform = new PgsqlPlatform();
+        $column = $this->buildColumnFromSchema($platform, false, $columnXml);
+
+        $this->assertSame('status_type', $column->getDomain()->getSqlType());
+    }
+
+    public function testPgsqlEnumNativeWithoutSqlTypeFallsBackToVarchar(): void
     {
         $columnXml = '<column name="status" type="ENUM_NATIVE" valueEnum="' . ColorsBackedEnum::class . '"/>';
         $platform = new PgsqlPlatform();

--- a/tests/Propel/Tests/Generator/Platform/EnumeratedColumnTypesTest.php
+++ b/tests/Propel/Tests/Generator/Platform/EnumeratedColumnTypesTest.php
@@ -233,6 +233,24 @@ class EnumeratedColumnTypesTest extends TestCase
         $this->assertTrue($column->isPhpObjectType());
     }
 
+    public function testIsPhpUnitEnumType(): void
+    {
+        $this->assertTrue(PropelTypes::isPhpUnitEnumType(ColorsBasicEnum::class));
+        $this->assertFalse(PropelTypes::isPhpUnitEnumType(ColorsBackedEnum::class));
+        $this->assertFalse(PropelTypes::isPhpUnitEnumType('string'));
+        $this->assertFalse(PropelTypes::isPhpUnitEnumType(\stdClass::class));
+    }
+
+    public function testColumnWithPhpTypeUnitEnum(): void
+    {
+        $columnXml = '<column name="color" type="VARCHAR" size="16" phpType="' . ColorsBasicEnum::class . '"/>';
+        $column = $this->buildColumnFromSchema(new DefaultPlatform(), false, $columnXml);
+
+        $this->assertTrue($column->isPhpUnitEnumType());
+        $this->assertFalse($column->isPhpBackedEnumType());
+        $this->assertTrue($column->isPhpObjectType());
+    }
+
     public function testPgsqlEnumNativeUsesSqlType(): void
     {
         $columnXml = '<column name="status" type="ENUM_NATIVE" valueEnum="' . ColorsBackedEnum::class . '" sqlType="status_type"/>';

--- a/tests/Propel/Tests/Generator/Platform/EnumeratedColumnTypesTest.php
+++ b/tests/Propel/Tests/Generator/Platform/EnumeratedColumnTypesTest.php
@@ -36,12 +36,12 @@ class EnumeratedColumnTypesTest extends TestCase
             DefaultPlatform::class,
             MssqlPlatform::class,
             OraclePlatform::class,
-            PgsqlPlatform::class,
             SqlitePlatform::class,
         ];
 
         $platformsWithNativeType = [
             MysqlPlatform::class,
+            PgsqlPlatform::class,
         ];
 
         $data = [];
@@ -200,6 +200,41 @@ class EnumeratedColumnTypesTest extends TestCase
         $ddl = $platform->getColumnDDL($column);
 
         $this->assertEquals($expectedColumnDdl, $ddl);
+    }
+
+    public function testIsPhpBackedEnumType(): void
+    {
+        $this->assertTrue(PropelTypes::isPhpBackedEnumType(ColorsBackedEnum::class));
+        $this->assertFalse(PropelTypes::isPhpBackedEnumType(ColorsBasicEnum::class));
+        $this->assertFalse(PropelTypes::isPhpBackedEnumType('string'));
+        $this->assertFalse(PropelTypes::isPhpBackedEnumType(\stdClass::class));
+    }
+
+    public function testColumnWithPhpTypeBackedEnum(): void
+    {
+        $columnXml = '<column name="color" type="VARCHAR" size="16" phpType="' . ColorsBackedEnum::class . '"/>';
+        $column = $this->buildColumnFromSchema(new DefaultPlatform(), false, $columnXml);
+
+        $this->assertTrue($column->isPhpBackedEnumType());
+        $this->assertTrue($column->isPhpObjectType());
+    }
+
+    public function testColumnWithPhpTypeRegularClassIsNotBackedEnum(): void
+    {
+        $columnXml = '<column name="amount" type="DECIMAL" phpType="\stdClass"/>';
+        $column = $this->buildColumnFromSchema(new DefaultPlatform(), false, $columnXml);
+
+        $this->assertFalse($column->isPhpBackedEnumType());
+        $this->assertTrue($column->isPhpObjectType());
+    }
+
+    public function testPgsqlEnumNativeUsesVarchar(): void
+    {
+        $columnXml = '<column name="status" type="ENUM_NATIVE" valueEnum="' . ColorsBackedEnum::class . '"/>';
+        $platform = new PgsqlPlatform();
+        $column = $this->buildColumnFromSchema($platform, false, $columnXml);
+
+        $this->assertSame('VARCHAR', $column->getDomain()->getSqlType());
     }
 
     /**


### PR DESCRIPTION
## Summary

- Adds `BackedEnum` detection for `phpType` columns: hydration generates `EnumClass::from($value)` instead of `new EnumClass($value)`, and PDO binding extracts `->value` for scalar storage
- Enables PostgreSQL native enum support (`ENUM_NATIVE`) by passing `true` to `setSetTypesMapping()` in `PgsqlPlatform` and overriding `buildNativeEnumeratedColumnSqlType()` to return `VARCHAR` (PG enums are named types created via `CREATE TYPE`, not inline `ENUM()` syntax — PDO handles them as strings)

### Changes

**Backed enum `phpType` support** (`PropelTypes`, `Column`, `ObjectBuilder`, `ColumnCodeProducer`):
- `PropelTypes::isPhpBackedEnumType()` / `Column::isPhpBackedEnumType()` — detects PHP backed enums via `is_subclass_of(BackedEnum::class)`
- Hydration: `ClassName::from($columnValue)` instead of `new ClassName($columnValue)`
- PDO binding: `$this->column?->value` extracts the scalar backing value
- Default values: `ClassName::from($default)` in `applyDefaultValues()` and `hasOnlyDefaultValues()`

**PostgreSQL `ENUM_NATIVE`** (`PgsqlPlatform`):
- `setSetTypesMapping(true)` — enables native enum type support
- `buildNativeEnumeratedColumnSqlType()` returns `VARCHAR` since PG enum columns are read/written as strings via PDO

### Usage

```xml
<column name="role_type" type="ENUM_NATIVE" required="false" phpType="\App\Model\RoleType" />
```

Where `RoleType` is a PHP backed string enum:
```php
enum RoleType: string {
    case Admin = 'admin';
    case Manager = 'manager';
}
```

Generated code:
```php
// Property
protected RoleType|null $role_type = null;

// Hydration
$this->role_type = ($columnValue === null) ? null : RoleType::from($columnValue);

// PDO binding
$stmt->bindValue($identifier, $this->role_type?->value, PDO::PARAM_STR);
```