### PR TITLE
Chainable methods fix

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -21,6 +21,8 @@
         <exclude name="Spryker.Internal.SprykerNoDemoshop"/>
         <exclude name="Spryker.Internal.SprykerPreferStaticOverSelf"/>
         <exclude name="Spryker.Commenting.DocBlockApiAnnotation"/> <!-- Another Spryker internal function. -->
+        <exclude name="Spryker.Commenting.DocBlockReturnSelf.InvalidChainable"/> <!-- methods with "@return $this" must end with "return $this", but cannot return $this through another method -->
+        <exclude name="Spryker.Commenting.DocBlockParamAllowDefaultValue.Typehint"/> <!-- fails to recognize array shapes (like `array{int, string})`-->
     </rule>
 
     <rule ref="Spryker.Internal.SprykerDisallowFunctions">

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -2086,11 +2086,11 @@ $indent};";
      *
      * @param $ctype|null \$key Primary key.
      *
-     * @return void
+     * @return \$this
      */
-    public function setPrimaryKey(?$ctype \$key = null): void
+    public function setPrimaryKey(?$ctype \$key = null)
     {
-        \$this->set{$phpName}(\$key);
+        return \$this->set{$phpName}(\$key);
     }\n";
     }
 
@@ -2103,25 +2103,25 @@ $indent};";
      */
     protected function addSetPrimaryKeyMultiPK(string &$script): void
     {
+        $docType = $this->getTable()->getPrimaryKeyDocType(false);
         $script .= "
     /**
      * Set the [composite] primary key.
      *
-     * @param array \$keys The elements of the composite key (order must match the order in XML file).
+     * @param $docType \$keys The elements of the composite key (order must match the order in XML file).
      *
-     * @return void
+     * @return \$this
      */
-    public function setPrimaryKey(array \$keys): void
-    {";
-        $i = 0;
+    public function setPrimaryKey(array \$keys)
+    {
+        return \$this";
         foreach ($this->getTable()->getPrimaryKey() as $i => $pk) {
             $phpName = $pk->getPhpName();
             $script .= "
-        \$this->set{$phpName}(\$keys[$i]);";
+            ->set{$phpName}(\$keys[$i])";
         }
-        $script .= "
-    }
-";
+        $script .= ";
+    }\n";
     }
 
     /**

--- a/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
@@ -133,7 +133,7 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
      *
      * @throws \Propel\Runtime\Exception\InvalidArgumentException
      *
-     * @return static
+     * @return $this
      */
     public function setFormatter($formatter)
     {

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -798,7 +798,7 @@ class Criteria
      * @param mixed $value
      * @param string|int|null $comparison A String.
      *
-     * @return static A modified Criteria object.
+     * @return $this
      */
     public function add($columnOrClause, $value = null, $comparison = null)
     {
@@ -841,7 +841,7 @@ class Criteria
      * @param mixed $value
      * @param int|null $pdoType
      *
-     * @return static
+     * @return $this
      */
     public function setUpdateValue($columnIdentifierOrMap, $value, $pdoType = null)
     {
@@ -872,7 +872,7 @@ class Criteria
      * @param mixed $values Must match number of placeholders (`?`) in $expression.
      * @param mixed $pdoTypes Must match number of values. If null, resolved ColumnMap will be used to determine type (and possibly unwrap value).
      *
-     * @return static
+     * @return $this
      */
     public function setUpdateExpression($columnIdentifierOrMap, string $expression, $values = null, $pdoTypes = null)
     {
@@ -906,7 +906,7 @@ class Criteria
      *
      * @throws \Propel\Runtime\Exception\PropelException
      *
-     * @return static A modified Criteria object.
+     * @return $this
      */
     public function addJoin($left, $right, ?string $joinType = null)
     {
@@ -1124,7 +1124,7 @@ class Criteria
      * Adds a DISTINCT clause to the query
      * Alias for Criteria::setDistinct()
      *
-     * @return static
+     * @return $this
      */
     public function distinct()
     {
@@ -1289,7 +1289,7 @@ class Criteria
      *
      * @param string|int $limit Maximum number of results to return by the query
      *
-     * @return static
+     * @return $this
      */
     public function limit($limit)
     {
@@ -1326,7 +1326,7 @@ class Criteria
      *
      * @param string|int $offset Offset of the first result to return
      *
-     * @return static
+     * @return $this
      */
     public function offset($offset)
     {
@@ -1783,7 +1783,7 @@ class Criteria
      *
      * @throws \Propel\Runtime\Exception\PropelException
      *
-     * @return $this A modified Criteria object.
+     * @return $this
      */
     public function addHaving($columnOrClause, $value = null, $comparison = null, ?int $pdoType = null)
     {
@@ -1877,7 +1877,7 @@ class Criteria
      * @param mixed|null $condition
      * @param bool $preferColumnCondition
      *
-     * @return static A modified Criteria object.
+     * @return $this
      */
     public function addAnd($columnOrClause, $value = null, $condition = null, bool $preferColumnCondition = true)
     {
@@ -1900,7 +1900,7 @@ class Criteria
      * @param mixed $condition
      * @param bool $preferColumnCondition
      *
-     * @return static A modified Criteria object.
+     * @return $this
      */
     public function addOr($columnOrClause, $value = null, $condition = null, bool $preferColumnCondition = true)
     {
@@ -1914,7 +1914,7 @@ class Criteria
      * @param string|int|null $condition
      * @param bool $preferColumnCondition
      *
-     * @return static
+     * @return $this
      */
     protected function addFilterWithConjunction(string $andOr, $columnOrClause, $value = null, $condition = null, bool $preferColumnCondition = true)
     {
@@ -1931,7 +1931,7 @@ class Criteria
      *
      * @param string|null $andOr Default Operator to combine filters.
      *
-     * @return static
+     * @return $this
      */
     public function combineFilters(?string $andOr = null)
     {
@@ -1947,7 +1947,7 @@ class Criteria
      *
      * Call {@see static::combineFilters()} to open parentheses.
      *
-     * @return static
+     * @return $this
      */
     public function endCombineFilters()
     {
@@ -1967,7 +1967,7 @@ class Criteria
      * (necessary for Propel 1.4 compatibility).
      * If false, the condition is combined with the last existing condition.
      *
-     * @return static A modified Criteria object.
+     * @return $this
      */
     public function addUsingOperator($columnOrClause, $value = null, ?string $operator = null, bool $preferColumnCondition = true)
     {
@@ -2416,7 +2416,7 @@ class Criteria
      *
      * @param bool $doAutoAdd
      *
-     * @return static
+     * @return $this
      */
     public function setAutoAddTable(bool $doAutoAdd)
     {

--- a/src/Propel/Runtime/ActiveQuery/FilterExpression/ClauseList.php
+++ b/src/Propel/Runtime/ActiveQuery/FilterExpression/ClauseList.php
@@ -27,7 +27,7 @@ class ClauseList
      *
      * @var array<int, \Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface>
      */
-    protected $clauses = [];
+    protected array $clauses = [];
 
     /**
      * Operators for connected filters
@@ -35,7 +35,7 @@ class ClauseList
      *
      * @var array<int, string>
      */
-    protected $conjunctions = [];
+    protected array $conjunctions = [];
 
     /**
      * Get the list of clauses in this Filter.
@@ -63,7 +63,7 @@ class ClauseList
      * @param \Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface $filter
      * @param string $conjunction
      *
-     * @return static
+     * @return $this
      */
     public function addFilter(ColumnFilterInterface $filter, string $conjunction = self::AND_OPERATOR_LITERAL)
     {
@@ -82,9 +82,7 @@ class ClauseList
      */
     public function addAnd(ColumnFilterInterface $filter)
     {
-        $this->addFilter($filter, self::AND_OPERATOR_LITERAL);
-
-        return $this;
+        return $this->addFilter($filter, self::AND_OPERATOR_LITERAL);
     }
 
     /**
@@ -96,9 +94,7 @@ class ClauseList
      */
     public function addOr(ColumnFilterInterface $filter)
     {
-        $this->addFilter($filter, self::OR_OPERATOR_LITERAL);
-
-        return $this;
+        return $this->addFilter($filter, self::OR_OPERATOR_LITERAL);
     }
 
     /**

--- a/src/Propel/Runtime/ActiveQuery/FilterExpression/ColumnFilterInterface.php
+++ b/src/Propel/Runtime/ActiveQuery/FilterExpression/ColumnFilterInterface.php
@@ -86,21 +86,21 @@ interface ColumnFilterInterface
      * @param \Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface $filter
      * @param string $conjunction
      *
-     * @return static
+     * @return $this
      */
     public function addFilter(ColumnFilterInterface $filter, string $conjunction = ClauseList::AND_OPERATOR_LITERAL);
 
     /**
      * @param \Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface $filter
      *
-     * @return static
+     * @return $this
      */
     public function addAnd(ColumnFilterInterface $filter);
 
     /**
      * @param \Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface $filter
      *
-     * @return static
+     * @return $this
      */
     public function addOr(ColumnFilterInterface $filter);
 

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -152,7 +152,7 @@ class ModelCriteria extends BaseModelCriteria
      * @param mixed $value A value for the condition
      * @param string|null $comparison What to use for the column comparison, defaults to Criteria::EQUAL or Criteria::IN for subqueries
      *
-     * @return static
+     * @return $this
      */
     public function filterBy(string $columnPhpName, $value, ?string $comparison = null)
     {
@@ -211,7 +211,7 @@ class ModelCriteria extends BaseModelCriteria
      * @param mixed $value A value for the condition
      * @param int|null $bindingType
      *
-     * @return static
+     * @return $this
      */
     public function where($clause, $value = null, ?int $bindingType = null)
     {
@@ -243,7 +243,7 @@ class ModelCriteria extends BaseModelCriteria
      * @param \Propel\Runtime\ActiveQuery\ModelCriteria $existsQueryCriteria the query object used in the EXISTS statement
      * @param string $operator Either ExistsQueryCriterion::TYPE_EXISTS or ExistsQueryCriterion::TYPE_NOT_EXISTS. Defaults to EXISTS
      *
-     * @return static
+     * @return $this
      */
     public function whereExists(ActiveQueryModelCriteria $existsQueryCriteria, string $operator = ExistsQueryCriterion::TYPE_EXISTS)
     {
@@ -257,7 +257,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @param \Propel\Runtime\ActiveQuery\ModelCriteria $existsQueryCriteria
      *
-     * @return static
+     * @return $this
      */
     public function whereNotExists(ActiveQueryModelCriteria $existsQueryCriteria)
     {
@@ -283,7 +283,7 @@ class ModelCriteria extends BaseModelCriteria
      * @param mixed $value A value for the condition
      * @param int|null $bindingType
      *
-     * @return static
+     * @return $this
      */
     public function having($clause, $value = null, ?int $bindingType = null)
     {
@@ -313,7 +313,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @throws \Propel\Runtime\Exception\UnexpectedValueException
      *
-     * @return static
+     * @return $this
      */
     public function orderBy(string $columnName, string $order = Criteria::ASC)
     {
@@ -321,14 +321,12 @@ class ModelCriteria extends BaseModelCriteria
         $qualifiedColumnName = $resolvedColumn->getColumnExpressionInQuery();
 
         $order = strtoupper($order);
-        switch ($order) {
-            case Criteria::ASC:
-                return $this->addAscendingOrderByColumn($qualifiedColumnName);
-            case Criteria::DESC:
-                return $this->addDescendingOrderByColumn($qualifiedColumnName);
-            default:
-                throw new UnexpectedValueException('ModelCriteria::orderBy() only accepts Criteria::ASC or Criteria::DESC as argument');
-        }
+
+        return match ($order) {
+            Criteria::ASC => $this->addAscendingOrderByColumn($qualifiedColumnName),
+            Criteria::DESC => $this->addDescendingOrderByColumn($qualifiedColumnName),
+            default => throw new UnexpectedValueException('ModelCriteria::orderBy() only accepts Criteria::ASC or Criteria::DESC as argument'),
+        };
     }
 
     /**
@@ -1026,7 +1024,7 @@ class ModelCriteria extends BaseModelCriteria
      * @param \Propel\Runtime\ActiveQuery\ModelCriteria $criteria The primary criteria
      * @param \Propel\Runtime\ActiveQuery\Join|null $previousJoin The previousJoin for this ModelCriteria
      *
-     * @return static
+     * @return $this
      */
     public function setPrimaryCriteria(ModelCriteria $criteria, ?Join $previousJoin)
     {
@@ -1099,7 +1097,7 @@ class ModelCriteria extends BaseModelCriteria
     * @param string|null $alias alias for the subQuery
     * @param bool $addAliasAndSelectColumns Set to false if you want to manually add the aliased select columns
     *
-    * @return static
+    * @return $this
     */
     public function addSelectQuery(Criteria $subQueryCriteria, ?string $alias = null, bool $addAliasAndSelectColumns = true)
     {

--- a/tests/Propel/Tests/Generator/Builder/Om/expected_builder_code/simple_base_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/expected_builder_code/simple_base_model_reference.txt
@@ -913,11 +913,11 @@ abstract class IdTable implements ActiveRecordInterface
      *
      * @param int|null $key Primary key.
      *
-     * @return void
+     * @return $this
      */
-    public function setPrimaryKey(?int $key = null): void
+    public function setPrimaryKey(?int $key = null)
     {
-        $this->setId($key);
+        return $this->setId($key);
     }
 
     /**

--- a/tests/bin/rebuild-reference-files
+++ b/tests/bin/rebuild-reference-files
@@ -53,15 +53,17 @@ function updateFile(TestCase $comparingTest, ComparesGeneratedFile $attribute, a
 $fileNames = findTestFileNames();
 $reflectionClasses = createTestFileReflectionsWithAttribute($fileNames);
 
+$findComparingMethods = fn(ReflectionMethod $m) => $m->getAttributes(ComparesGeneratedFile::class);
+
 foreach ($reflectionClasses as $reflection) {
-    $fileComparisonMethods = array_filter($reflection->getMethods(), fn(ReflectionMethod $m) => $m->getAttributes(ComparesGeneratedFile::class));
-    if (!$fileComparisonMethods) {
+    $referenceComparingMethods = array_filter($reflection->getMethods(), $findComparingMethods);
+    if (!$referenceComparingMethods) {
         continue;
     }
     /** @var \Propel\Tests\TestCase $comparingTest */
-    $comparingTest = $reflection->newInstance();
+    $comparingTest = $reflection->newInstanceWithoutConstructor();
 
-    foreach ($fileComparisonMethods as $method) {
+    foreach ($referenceComparingMethods as $method) {
         $dataProvider = $method->getName();
         /** @var ComparesGeneratedFile $attribute */
         $attribute = $method->getAttributes(ComparesGeneratedFile::class)[0]->newInstance();


### PR DESCRIPTION
## Issue
Methods `Model::setPrimaryKey()`/`Model::setPrimaryKeys()` return void and are not chainable, even though everything else is.

## Changes
Methods return `$this` now. This made some Spryker sniffs complain, so I removed them.
Also, the script rebuilding reference files had to be adjusted for phpunit 10.

## Implementation Details

First removed sniff required methods with `@return $this` to explicitly do `return $this;`. Returning `$this` through another method (i.e. `return $this->returnThis();`) caused an error.  This leads to unnecessarily elongated methods , and overall is something type checkers should handle, not linters.
I remembered previously changing types from `@return $this` to `@return static` because of this rule. I went back and adjusted those, now that the "correct" type can be used.

Second removed sniff failed to recognize the array in `@param array{int, string}`:
>Possible doc block error: `array{int, string} $keys` seems to be missing type `array`. (Spryker.Commenting.DocBlockParamAllowDefaultValue.Typehint) 

Having array shapes seems more beneficial than what the rule checks, and I think this kind of error is detected by type checkers.

## Test strategy
Via reference file and lint/stan.