### PR TITLE
update github CI actions

### DIFF
--- a/.github/actions/setup-php/action.yml
+++ b/.github/actions/setup-php/action.yml
@@ -29,7 +29,7 @@ runs:
           echo "cache_files_dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
     - name: Composer cache
-      uses: actions/cache@v4.2.0
+      uses: actions/cache@v5
       with:
           path: ${{ steps.composer-cache.outputs.cache_files_dir }}
           key: ${{ runner.os }}-composer-php:${{ inputs.php-version }}-symfony:${{ inputs.symfony-version }}-${{ inputs.cache-key-suffix }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
                     --health-retries=3
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v5
 
             - id: build-container
               uses: ./.github/actions/setup-php
@@ -104,10 +104,10 @@ jobs:
 
             - name: Code Coverage Report
               if: success() && matrix.php-version == '8.1' && matrix.symfony-version == '6-max'
-              uses: codecov/codecov-action@v1
+              uses: codecov/codecov-action@v6
               with:
                   flags: ${{ matrix.php-version }}, ${{ matrix.db-type }}, ${{ matrix.symfony-version }}
-                  file: tests/coverage.xml
+                  files: tests/coverage.xml
 
     static-analysis:
         name: 'Stan & Psalm'
@@ -121,7 +121,7 @@ jobs:
               - php-version: '8.5'
                 symfony-version: '8-max'
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v5
             - id: build-container
               uses: ./.github/actions/setup-php
               with:
@@ -139,7 +139,7 @@ jobs:
         name: 'Code Style (PHPCS)'
         runs-on: ubuntu-24.04
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v5
             - id: build-container
               uses: ./.github/actions/setup-php
               with:
@@ -169,7 +169,7 @@ jobs:
                 file-pattern: 'Map/*TableMap.php'
         name: '${{ matrix.check }} on ${{ matrix.type }} code'
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v5
             - id: build-container
               uses: ./.github/actions/setup-php
               with:


### PR DESCRIPTION
## Issue
Github CI shows lots of warnings because of outdated actions:

<img width="800" alt="Screenshot_2026-03-29_20-28-40" src="https://github.com/user-attachments/assets/050064cf-4422-4767-a5c2-15e277e499ad" />



## Changes
Updated actions to current version.


## Implementation Details
Codecov is still broken (as it was before and has been for a while):

> error - 2026-03-29 18:40:31,143 -- Upload queued for processing failed: {"message":"Token required because branch is protected"}

Not sure if I miss it tbh.

## Test strategy
CI is running.