### PR TITLE
Fix pdo type of column type `NUMERIC`

### DIFF
--- a/src/Propel/Generator/Model/PropelTypes.php
+++ b/src/Propel/Generator/Model/PropelTypes.php
@@ -482,7 +482,7 @@ class PropelTypes
         self::LONGVARCHAR => PDO::PARAM_STR,
         self::CLOB => PDO::PARAM_STR,
         self::CLOB_EMU => PDO::PARAM_STR,
-        self::NUMERIC => PDO::PARAM_INT,
+        self::NUMERIC => PDO::PARAM_STR,
         self::DECIMAL => PDO::PARAM_STR,
         self::TINYINT => PDO::PARAM_INT,
         self::SMALLINT => PDO::PARAM_INT,

--- a/tests/Fixtures/bookstore/schema.xml
+++ b/tests/Fixtures/bookstore/schema.xml
@@ -165,6 +165,7 @@
         <column name="job_title" type="VARCHAR" size="32" description="Employee job title"/>
         <column name="supervisor_id" type="INTEGER" description="Fkey to supervisor."/>
         <column name="photo" type="BLOB" lazyLoad="true"/>
+        <column name="salary" type="NUMERIC" size="12" scale="2"/>
         <foreign-key foreignTable="bookstore_employee" phpName="Supervisor" refPhpName="Subordinate" onDelete="setnull">
             <reference local="supervisor_id" foreign="id"/>
         </foreign-key>

--- a/tests/Fixtures/bookstore/types-schema.xml
+++ b/tests/Fixtures/bookstore/types-schema.xml
@@ -14,4 +14,10 @@
         </foreign-key>
     </table>
 
+    <table name="type_numeric" identifierQuoting="true">
+        <column name="id" type="INTEGER" primaryKey="true" autoIncrement="true"/>
+        <column name="numeric" type="NUMERIC" size="12" scale="4"/>
+        <column name="decimal" type="DECIMAL" size="12" scale="4"/>
+    </table>
+
 </database>

--- a/tests/Propel/Tests/Generator/Model/ColumnTest.php
+++ b/tests/Propel/Tests/Generator/Model/ColumnTest.php
@@ -451,7 +451,7 @@ class ColumnTest extends ModelTestCase
             ['LONGVARCHAR', PDO::PARAM_STR],
             ['CLOB', PDO::PARAM_STR],
             ['CLOB_EMU', PDO::PARAM_STR],
-            ['NUMERIC', PDO::PARAM_INT],
+            ['NUMERIC', PDO::PARAM_STR],
             ['DECIMAL', PDO::PARAM_STR],
             ['TINYINT', PDO::PARAM_INT],
             ['SMALLINT', PDO::PARAM_INT],

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
@@ -1126,7 +1126,7 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c->join('sup.Subordinate sub');
         $c->where('sub.Name = ?', 'Foo');
         $employees = BookstoreEmployeeQuery::create(null, $c)->find($con);
-        $expectedSQL = $this->getSql("SELECT bookstore_employee.id, bookstore_employee.class_key, bookstore_employee.name, bookstore_employee.job_title, bookstore_employee.supervisor_id FROM bookstore_employee INNER JOIN bookstore_employee sup ON (bookstore_employee.supervisor_id=sup.id) INNER JOIN bookstore_employee sub ON (sup.id=sub.supervisor_id) WHERE sub.name = 'Foo'");
+        $expectedSQL = $this->getSql("SELECT bookstore_employee.id, bookstore_employee.class_key, bookstore_employee.name, bookstore_employee.job_title, bookstore_employee.supervisor_id, bookstore_employee.salary FROM bookstore_employee INNER JOIN bookstore_employee sup ON (bookstore_employee.supervisor_id=sup.id) INNER JOIN bookstore_employee sub ON (sup.id=sub.supervisor_id) WHERE sub.name = 'Foo'");
         $this->assertEquals($expectedSQL, $con->getLastExecutedQuery(), 'join() allows the use of relation alias in further joins()');
     }
 

--- a/tests/Propel/Tests/Runtime/TypeTests/TypeTest.php
+++ b/tests/Propel/Tests/Runtime/TypeTests/TypeTest.php
@@ -8,19 +8,29 @@
 
 namespace Propel\Tests\Runtime\TypeTests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Propel\Tests\Bookstore\Map\TypeObjectTableMap;
+use Propel\Tests\Bookstore\TypeNumeric;
+use Propel\Tests\Bookstore\TypeNumericQuery;
 use Propel\Tests\Bookstore\TypeObject;
 use Propel\Tests\Bookstore\TypeObjectQuery;
 use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
 use Propel\Tests\Runtime\TypeTests\DummyObjectClass;
-use Propel\Tests\Runtime\TypeTests\TypeObjectInterface;
 use ReflectionClass;
 
 /**
+ * NOTE: Uses classes from bookstore/types-schema.xml.
+ *
  * @group database
  */
 class TypeTest extends BookstoreTestBase
 {
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        TypeNumericQuery::create()->deleteAll();
+    }
+
     /**
      * @return void
      */
@@ -44,20 +54,6 @@ class TypeTest extends BookstoreTestBase
         $param = $method->getParameters()[0];
 
         $this->assertTrue($param->getType() && $param->getType()->getName() === 'array');
-        $this->assertTrue($param->allowsNull());
-    }
-
-    /**
-     * @return void
-     */
-    public function testInterface()
-    {
-        $this->markTestSkipped('Setting interface on fk-relations was removed');
-        $reflection = new ReflectionClass(TypeObject::class);
-        $method = $reflection->getMethod('setTypeObject');
-        $param = $method->getParameters()[0];
-
-        $this->assertEquals(TypeObjectInterface::class, $param->getType()->getName());
         $this->assertTrue($param->allowsNull());
     }
 
@@ -127,5 +123,35 @@ class TypeTest extends BookstoreTestBase
         $typeObjectEntity = TypeObjectQuery::create()->findOne();
 
         $this->assertEquals($q, $typeObjectEntity->getDetails());
+    }
+
+    public static function DecimalValuesDataProvider(): array
+    {
+        $values = [ // string $inputValue, string $storedValue
+            ['12345.333', '12345.3330'],
+            ['12345', '12345.0000'],
+        ];
+
+        return [ // string $columnName, string $inputValue, string $storedValue
+            ...array_map(fn ($dataSet) => ['Decimal', ...$dataSet], $values),
+            ...array_map(fn ($dataSet) => ['Numeric', ...$dataSet], $values),
+        ];
+    }
+
+    #[DataProvider('DecimalValuesDataProvider')]
+    public function testDecimalType(string $columnName, string $inputValue, string $storedValue): void
+    {
+        if (static::runningOnSQLite()) {
+            $this->markTestSkipped('Sqlite stores decimals as strings.');
+        }
+
+        $o = new TypeNumeric();
+        $o->setByName($columnName, $inputValue)->save();
+
+        $o->reload();
+        $this->assertSame($storedValue, $o->getByName($columnName));
+
+        $foundValue = TypeNumericQuery::create()->filterBy($columnName, $storedValue)->findOne();
+        $this->assertSame($o, $foundValue);
     }
 }


### PR DESCRIPTION
## Issue
The column type `NUMERIC`, Propel's fixed precision number type (`DECIMAL`) correctly uses string in PHP, but binds parameter to PDO statments as int, which cuts off the fractional part.  


## Changes
PDO type is changed to string, matching `DECIMAL` type.

## Implementation Details
All vendors use `NUMERIC` as alias for `DECIMAL` (or the corresponding type on that platform), so using a different PDO type between `NUMERIC` and `DECIMAL` has to be a bug.

## Test strategy
Added simple read and write test for `NUMERIC` and `DECIMAL`.
Also added a DECIMAL column to the bookstore schema, to have at least one of them linted and analyzed. 