### PR TITLE
fix wrong @method return type

### DIFF
--- a/src/Propel/Generator/Builder/Om/QueryBuilder/templates/classHeaderTemplate.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder/templates/classHeaderTemplate.php
@@ -33,31 +33,31 @@
  *
 <?php endif; ?>
 <?php foreach($columns as $column):?>
- * @method static orderBy<?= $column->getPhpName() ?>($order = \Propel\Runtime\ActiveQuery\Criteria::ASC) Order by the <?= $column->getName() ?> column
+ * @method $this orderBy<?= $column->getPhpName() ?>($order = \Propel\Runtime\ActiveQuery\Criteria::ASC) Order by the <?= $column->getName() ?> column
 <?php endforeach;?>
  *
 <?php foreach($columns as $column):?>
- * @method static groupBy<?= $column->getPhpName() ?>() Group by the <?= $column->getName() ?> column
+ * @method $this groupBy<?= $column->getPhpName() ?>() Group by the <?= $column->getName() ?> column
 <?php endforeach;?>
  *
- * @method static leftJoin($relation) Adds a LEFT JOIN clause to the query
- * @method static rightJoin($relation) Adds a RIGHT JOIN clause to the query
- * @method static innerJoin($relation) Adds a INNER JOIN clause to the query
+ * @method $this leftJoin($relation) Adds a LEFT JOIN clause to the query
+ * @method $this rightJoin($relation) Adds a RIGHT JOIN clause to the query
+ * @method $this innerJoin($relation) Adds a INNER JOIN clause to the query
  *
- * @method static leftJoinWith($relation) Adds a LEFT JOIN clause and with to the query
- * @method static rightJoinWith($relation) Adds a RIGHT JOIN clause and with to the query
- * @method static innerJoinWith($relation) Adds a INNER JOIN clause and with to the query
+ * @method $this leftJoinWith($relation) Adds a LEFT JOIN clause and with to the query
+ * @method $this rightJoinWith($relation) Adds a RIGHT JOIN clause and with to the query
+ * @method $this innerJoinWith($relation) Adds a INNER JOIN clause and with to the query
  *
 <?php foreach($relationNames as $relationName):?>
- * @method static leftJoin<?= $relationName ?>($relationAlias = null) Adds a LEFT JOIN clause to the query using the <?= $relationName ?> relation
- * @method static rightJoin<?= $relationName ?>($relationAlias = null) Adds a RIGHT JOIN clause to the query using the <?= $relationName ?> relation
- * @method static innerJoin<?= $relationName ?>($relationAlias = null) Adds a INNER JOIN clause to the query using the <?= $relationName ?> relation
+ * @method $this leftJoin<?= $relationName ?>($relationAlias = null) Adds a LEFT JOIN clause to the query using the <?= $relationName ?> relation
+ * @method $this rightJoin<?= $relationName ?>($relationAlias = null) Adds a RIGHT JOIN clause to the query using the <?= $relationName ?> relation
+ * @method $this innerJoin<?= $relationName ?>($relationAlias = null) Adds a INNER JOIN clause to the query using the <?= $relationName ?> relation
  *
- * @method static joinWith<?= $relationName ?>($joinType = \Propel\Runtime\ActiveQuery\Criteria::INNER_JOIN) Adds a join clause and with to the query using the <?= $relationName ?> relation
+ * @method $this joinWith<?= $relationName ?>($joinType = \Propel\Runtime\ActiveQuery\Criteria::INNER_JOIN) Adds a join clause and with to the query using the <?= $relationName ?> relation
  *
- * @method static leftJoinWith<?= $relationName ?>() Adds a LEFT JOIN clause and with to the query using the <?= $relationName ?> relation
- * @method static rightJoinWith<?= $relationName ?>() Adds a RIGHT JOIN clause and with to the query using the <?= $relationName ?> relation
- * @method static innerJoinWith<?= $relationName ?>() Adds a INNER JOIN clause and with to the query using the <?= $relationName ?> relation
+ * @method $this leftJoinWith<?= $relationName ?>() Adds a LEFT JOIN clause and with to the query using the <?= $relationName ?> relation
+ * @method $this rightJoinWith<?= $relationName ?>() Adds a RIGHT JOIN clause and with to the query using the <?= $relationName ?> relation
+ * @method $this innerJoinWith<?= $relationName ?>() Adds a INNER JOIN clause and with to the query using the <?= $relationName ?> relation
  *
 <?php endforeach; ?>
  * @method <?= $modelClass ?>|null findOne(\Propel\Runtime\Connection\ConnectionInterface|null $con = null) Return the first <?= $modelClass ?> matching the query

--- a/tests/Propel/Tests/Generator/Builder/Om/expected_builder_code/simple_base_query_reference.txt
+++ b/tests/Propel/Tests/Generator/Builder/Om/expected_builder_code/simple_base_query_reference.txt
@@ -20,17 +20,17 @@ use function sprintf;
 /**
  * Base class that represents a query for the `id_table` table.
  *
- * @method static orderById($order = \Propel\Runtime\ActiveQuery\Criteria::ASC) Order by the id column
+ * @method $this orderById($order = \Propel\Runtime\ActiveQuery\Criteria::ASC) Order by the id column
  *
- * @method static groupById() Group by the id column
+ * @method $this groupById() Group by the id column
  *
- * @method static leftJoin($relation) Adds a LEFT JOIN clause to the query
- * @method static rightJoin($relation) Adds a RIGHT JOIN clause to the query
- * @method static innerJoin($relation) Adds a INNER JOIN clause to the query
+ * @method $this leftJoin($relation) Adds a LEFT JOIN clause to the query
+ * @method $this rightJoin($relation) Adds a RIGHT JOIN clause to the query
+ * @method $this innerJoin($relation) Adds a INNER JOIN clause to the query
  *
- * @method static leftJoinWith($relation) Adds a LEFT JOIN clause and with to the query
- * @method static rightJoinWith($relation) Adds a RIGHT JOIN clause and with to the query
- * @method static innerJoinWith($relation) Adds a INNER JOIN clause and with to the query
+ * @method $this leftJoinWith($relation) Adds a LEFT JOIN clause and with to the query
+ * @method $this rightJoinWith($relation) Adds a RIGHT JOIN clause and with to the query
+ * @method $this innerJoinWith($relation) Adds a INNER JOIN clause and with to the query
  *
  * @method \IdTable|null findOne(\Propel\Runtime\Connection\ConnectionInterface|null $con = null) Return the first \IdTable matching the query
  * @method \IdTable findOneOrCreate(\Propel\Runtime\Connection\ConnectionInterface|null $con = null) Return the first \IdTable matching the query, or a new \IdTable object populated from the query conditions when no match is found


### PR DESCRIPTION
## Issue
Chainable `@method` declarations in query use `static` as return type:
```php
 @method static leftJoin($relation) Adds a LEFT JOIN clause to the query
```
However, at least VSCode reads this as static method without return type, breaking auto-completion.


## Changes
Use `$this` instead of `static`


## Test strategy
Tested via reference file.


## Notes
Adding the generic class parameter (`static<ParentClass>`) also seems to work.