### PR TITLE
added behavior code reference tests

### DIFF
--- a/src/Propel/Generator/Behavior/Delegate/DelegateBehavior.php
+++ b/src/Propel/Generator/Behavior/Delegate/DelegateBehavior.php
@@ -246,16 +246,16 @@ if (method_exists({$ARFQCN}::class, \$name)) {
             foreach ($this->delegates + [$table->getName() => 1] as $key => $value) {
                 $delegateTable = $this->getDelegateTable($key);
                 foreach ($delegateTable->getColumns() as $columnDelegated) {
-                    if (isset($this->doubleDefined[$columnDelegated->getName()])) {
-                        $this->doubleDefined[$columnDelegated->getName()]++;
-                    } else {
-                        $this->doubleDefined[$columnDelegated->getName()] = 1;
+                    $columnName = $columnDelegated->getName();
+                    if (!isset($this->doubleDefined[$columnName])) {
+                        $this->doubleDefined[$columnName] = 0;
                     }
+                    $this->doubleDefined[$columnName]++;
                 }
             }
         }
 
-        if (1 < $this->doubleDefined[$column->getName()]) {
+        if ($this->doubleDefined[$column->getName()] > 1) {
             return true;
         }
 

--- a/src/Propel/Generator/Behavior/I18n/I18nBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/I18n/I18nBehaviorObjectBuilderModifier.php
@@ -271,7 +271,6 @@ class I18nBehaviorObjectBuilderModifier
         $localeColumnName = $this->behavior->getLocaleColumn()->getPhpName();
         $pattern = '/public function add' . $i18nTablePhpName . '.*[\r\n]\s*\{/';
 
-        $matches = [];
         $argGroupPattern = '/public function add' . $i18nTablePhpName . '\(\w+ (\$\w+)\)/';
         preg_match($argGroupPattern, $script, $matches);
         $inputVar = $matches[1];

--- a/src/Propel/Generator/Model/Table.php
+++ b/src/Propel/Generator/Model/Table.php
@@ -1650,13 +1650,7 @@ class Table extends ScopedMappingModel implements IdMethod
      */
     public function hasValueSetColumns(): bool
     {
-        foreach ($this->columns as $col) {
-            if ($col->isValueSetType()) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($this->columns, fn (Column $col) => $col->isValueSetType());
     }
 
     /**

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/BehaviorCodeTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/BehaviorCodeTest.php
@@ -1,0 +1,462 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Tests\Generator\Behavior\BehaviorCodeTest;
+
+use Propel\Generator\Builder\Om\AbstractOMBuilder;
+use Propel\Generator\Builder\Om\BuilderType;
+use Propel\Generator\Builder\Om\ObjectBuilder;
+use Propel\Generator\Config\QuickGeneratorConfig;
+use Propel\Generator\Platform\PlatformInterface;
+use Propel\Tests\Attributes\ComparesGeneratedFile;
+use Propel\Tests\CompareGeneratedCodeTestCase;
+use RuntimeException;
+
+class BehaviorCodeTest extends CompareGeneratedCodeTestCase
+{
+    /**
+     * @return array<array<string>>
+     */
+    #[ComparesGeneratedFile(textBuilder: 'buildBehaviorCode')]
+    public static function BehaviorDataProvider(): array
+    {
+        $refDir = __DIR__ . '/expected_behavior_code';
+        $accessor = new CompareGeneratedCodeTestCase('');
+
+        return [ // [schema, array{fileName, builder}]
+            [
+                [static::AGGREGATE_COLUMN_SCHEMA, 'aggregated_table', BuilderType::ObjectBase,],
+                "$refDir/aggregate_column---target_model_reference.txt",
+            ],
+            [
+                [static::AGGREGATE_COLUMN_SCHEMA, 'source_table', BuilderType::ObjectBase,[
+                    'objectFilter' => fn(ObjectBuilder $builder, string &$script) => $accessor->getObjectPropertyValue($builder, 'fkRelationCodeProducers')[0]->addMethods($script)
+                ]],
+                "$refDir/aggregate_column---source_model_reference.txt",
+            ],
+            [
+                [static::AGGREGATE_MULTIPLE_COLUMNS_SCHEMA, 'aggregated_table', BuilderType::ObjectBase,],
+                "$refDir/aggregate_multiple_columns---target_model_reference.txt",
+            ],
+            [
+                [static::ARCHIVABLE_SCHEMA, 'table', BuilderType::ObjectBase,],
+                "$refDir/archivable---model_reference.txt",
+            ],
+            [
+                [static::ARCHIVABLE_SCHEMA, 'table', BuilderType::QueryBase,],
+                "$refDir/archivable---query_reference.txt",
+            ],
+            [
+                [static::CONCRETE_INHERITANCE_SCHEMA, 'parent', BuilderType::ObjectBase,],
+                "$refDir/concrete-inheritance---parent-model_reference.txt",
+            ],
+            [
+                [static::CONCRETE_INHERITANCE_SCHEMA, 'child', BuilderType::ObjectBase,],
+                "$refDir/concrete-inheritance---child-model_reference.txt",
+            ],
+            [
+                [static::DELEGATE_SCHEMA, 'delegator', BuilderType::ObjectBase, [
+                    'objectFilter' => fn(ObjectBuilder $builder, string &$script) => $accessor->callMethod($builder, 'addToArray', [&$script])
+                ]],
+                "$refDir/delegate---delegator-model_reference.txt",
+            ],
+            [
+                [static::DELEGATE_SCHEMA, 'delegator', BuilderType::QueryBase,],
+                "$refDir/delegate---delegator-query_reference.txt",
+            ],
+            [
+                [static::I18N_SCHEMA, 'table', BuilderType::ObjectBase, [
+                    'objectFilter' => fn(ObjectBuilder $builder, string &$script) => $accessor->getObjectPropertyValue($builder, 'incomingRelationCodeProducers')[0]->addMethods($script)
+                ]],
+                "$refDir/i18n---object_reference.txt",
+            ],
+            [
+                [static::I18N_SCHEMA, 'table', BuilderType::QueryBase,],
+                "$refDir/i18n---query_reference.txt",
+            ],
+            [
+                [static::NESTED_SET_SCHEMA, 'table', BuilderType::ObjectBase,],
+                "$refDir/nested_set---object_reference.txt",
+            ],
+            [
+                [static::NESTED_SET_SCHEMA, 'table', BuilderType::QueryBase,],
+                "$refDir/nested_set---query_reference.txt",
+            ],
+            [
+                [static::OUTPUT_GROUP_SCHEMA, 'table', BuilderType::ObjectBase,],
+                "$refDir/output_group---object_reference.txt",
+            ],
+            [
+                [static::OUTPUT_GROUP_SCHEMA, 'table', BuilderType::TableMap,],
+                "$refDir/output_group---tablemap_reference.txt",
+            ],
+            [
+                [static::QUERY_CACHE_SCHEMA, 'table', BuilderType::QueryBase,],
+                "$refDir/query_cache---query_reference.txt",
+            ],
+            [
+                [static::SLUGGABLE_SCHEMA, 'table', BuilderType::ObjectBase,],
+                "$refDir/sluggable---model_reference.txt",
+            ],
+            [
+                [static::SLUGGABLE_SCHEMA, 'table', BuilderType::QueryBase,],
+                "$refDir/sluggable---query_reference.txt",
+            ],
+            [
+                [static::SORTABLE_SCHEMA, 'table', BuilderType::ObjectBase,],
+                "$refDir/sortable---object_reference.txt",
+            ],
+            [
+                [static::SORTABLE_SCHEMA, 'table', BuilderType::QueryBase,],
+                "$refDir/sortable---query_reference.txt",
+            ],
+            [
+                [static::SORTABLE_SCHEMA, 'table', BuilderType::TableMap,],
+                "$refDir/sortable---tablemap_reference.txt",
+            ],
+            [
+                [static::TIMESTAMPABLE_SCHEMA, 'table', BuilderType::ObjectBase,],
+                "$refDir/timestampable---object_reference.txt",
+            ],
+            [
+                [static::TIMESTAMPABLE_SCHEMA, 'table', BuilderType::QueryBase,],
+                "$refDir/timestampable---query_reference.txt",
+            ],
+            [
+                [static::VALIDATEABLE_SCHEMA, 'table', BuilderType::ObjectBase,],
+                "$refDir/validateable---object_reference.txt",
+            ],
+            [
+                [static::VERSIONABLE_SCHEMA, 'table', BuilderType::ObjectBase,],
+                "$refDir/versionable---object_reference.txt",
+            ],
+            [
+                [static::VERSIONABLE_SCHEMA, 'table', BuilderType::QueryBase,],
+                "$refDir/versionable---query_reference.txt",
+            ],
+        ];
+    }
+
+    /**
+     * @param string $schemaXml
+     * @param array $config
+     * @param \Propel\Generator\Platform\PlatformInterface $platform
+     *
+     * @return string
+     */
+    public function buildBehaviorCode(string $schemaXml, string $tableName, BuilderType $builderType, array $hookInput = []): string
+    {
+        $builder = $this->buildCodeBuilder($schemaXml, $builderType, $tableName);
+        $code = '';
+
+        foreach (static::getHooks($builderType) as $hook) {
+            $script = '';
+            if (array_key_exists($hook, $hookInput)) {
+                $hookInput[$hook]($builder, $script);
+            }
+            $builder->applyBehaviorModifier($hook, $script, '');
+            if (!$script) {
+                continue;
+            }
+            $code .= $this->buildCodeFileContent($hook, $script);
+        }
+
+        return $code;
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('BehaviorDataProvider')]
+    public function testEnumeratedColumnQueryCode(array $builderArgs, string $fileName): void
+    {
+        $code = $this->buildBehaviorCode(...$builderArgs);
+        $this->assertStringEqualsFile($fileName, $code, CompareGeneratedCodeTestCase::HOW_TO_UPDATE_MESSAGE);
+    }
+
+    /**
+     * @param string $schemaXml
+     * @param \Propel\Generator\Builder\Om\BuilderType $builderType
+     *
+     * @return \Propel\Generator\Builder\Om\AbstractOMBuilder
+     */
+    public function buildCodeBuilder(
+        string $schemaXml,
+        BuilderType $builderType,
+        string $tableName,
+        array|null $extraConfig = null,
+        PlatformInterface|null $platform = null
+    ): AbstractOMBuilder {
+        $database = static::buildDatabaseFromSchema($schemaXml, $extraConfig, $platform);
+        $config = new QuickGeneratorConfig($extraConfig);
+        $table = $database->getTable($tableName);
+
+        return $config->loadConfiguredBuilder($table, $builderType);
+    }
+
+    public static function getHooks(BuilderType $builderType): array
+    {
+        return match ($builderType) {
+            BuilderType::ObjectBase => [
+                'objectMethods',
+                'objectFilter',
+                'objectAttributes',
+                'postHydrate',
+                'preDelete',
+                'postDelete',
+                'preSave',
+                'preInsert',
+                'preUpdate',
+                'postSave',
+                'postUpdate',
+                'postInsert',
+                'objectClearReferences',
+                'objectCall',
+            ],
+            BuilderType::QueryBase => [
+                'queryAttributes',
+                'staticConstants',
+                'staticAttributes',
+                'staticMethods',
+                'queryAttributes',
+                'queryMethods',
+                'queryFilter',
+                'preSelectQuery',
+                'preDeleteQuery',
+                'postDeleteQuery',
+                'preUpdateQuery',
+                'postUpdateQuery',
+            ],
+            BuilderType::TableMap => [
+                'staticConstants',
+                'staticAttributes',
+                'staticMethods',
+                'tableMapFilter',
+            ],
+            BuilderType::QueryStub => [
+                'extensionQueryFilter'
+            ],
+            BuilderType::ObjectStub => [
+                'extensionObjectFilter'
+            ],
+            BuilderType::Collection => [
+                'addObjectCollectionMethods',
+
+            ],
+            default => throw new RuntimeException("Builder type not registered: " . $builderType->name)
+        };
+    }
+
+    protected const AGGREGATE_COLUMN_SCHEMA = <<<XML
+    <database>
+        <table name="aggregated_table">
+            <column name="id" primaryKey="true" type="INTEGER"/>
+            <behavior name="aggregate_column">
+                <parameter name="foreign_table" value="source_table"/>
+                <parameter name="name" value="related_entries"/>
+                <parameter name="expression" value="COUNT(id)"/>
+            </behavior>
+        </table>
+
+        <table name="source_table">
+            <column name="id" primaryKey="true" type="INTEGER"/>
+            <column name="fk" type="INTEGER"/>
+            <foreign-key foreignTable="aggregated_table">
+                <reference local="fk" foreign="id"/>
+            </foreign-key>
+        </table>
+    </database>
+XML;
+
+    protected const AGGREGATE_MULTIPLE_COLUMNS_SCHEMA = <<<XML
+    <database>
+        <table name="aggregated_table">
+            <column name="id" primaryKey="true" type="INTEGER"/>
+            <behavior name="aggregate_multiple_columns">
+                <parameter name="foreign_table" value="source_table"/>
+                <parameter-list name="columns">
+                    <parameter-list-item>
+                        <parameter name="column_name" value="total_score" />
+                        <parameter name="expression" value="SUM(score)" />
+                    </parameter-list-item>
+                    <parameter-list-item>
+                        <parameter name="column_name" value="number_of_scores" />
+                        <parameter name="expression" value="COUNT(score)" />
+                    </parameter-list-item>
+                </parameter-list>
+            </behavior>
+        </table>
+
+        <table name="source_table">
+            <column name="id" primaryKey="true" type="INTEGER"/>
+            <column name="score" type="INTEGER"/>
+            <column name="fk" type="INTEGER"/>
+            <foreign-key foreignTable="aggregated_table">
+                <reference local="fk" foreign="id"/>
+            </foreign-key>
+        </table>
+    </database>
+XML;
+
+    protected const ARCHIVABLE_SCHEMA = <<<XML
+    <database>
+        <table name="table">
+            <column name="id" primaryKey="true" type="INTEGER"/>
+            <column name="title" type="VARCHAR" size="100" primaryString="true"/>
+            <behavior name="archivable">
+                <parameter name="archive_table" value="table_archive"/>
+                <parameter name="archive_on_insert" value="true"/>
+                <parameter name="archive_on_update" value="true"/>
+                <parameter name="archive_on_delete" value="true"/>
+            </behavior>
+        </table>
+    </database>
+XML;
+
+    protected const CONCRETE_INHERITANCE_SCHEMA = <<<XML
+    <database>
+        <table name="parent">
+            <column name="id" primaryKey="true" type="INTEGER"/>
+            <column name="title" type="VARCHAR" size="100"/>
+        </table>
+        <table name="child">
+            <behavior name="concrete_inheritance">
+                <parameter name="extends" value="parent"/>
+            </behavior>
+        </table>
+    </database>
+XML;
+
+    protected const DELEGATE_SCHEMA = <<<XML
+    <database>
+        <table name="resolver">
+            <column name="id" primaryKey="true" type="INTEGER"/>
+            <column name="delegated_column" type="INTEGER"/>
+        </table>
+
+        <table name="delegator">
+            <column name="id" primaryKey="true" type="INTEGER"/>
+            <behavior name="delegate">
+                <parameter name="to" value="resolver"/>
+            </behavior>
+        </table>
+    </database>
+XML;
+
+    protected const I18N_SCHEMA = <<<XML
+    <database>
+        <table name="table">
+            <column name="id" primaryKey="true" type="INTEGER"/>
+            <column name="bar" type="VARCHAR" size="100"/>
+            <behavior name="i18n">
+                <parameter name="i18n_columns" value="bar"/>
+                <parameter name="locale_column" value="language"/>
+                <parameter name="locale_alias" value="culture"/>
+            </behavior>
+        </table>
+    </database>
+XML;
+
+    protected const NESTED_SET_SCHEMA = <<<XML
+    <database>
+        <table name="table">
+            <column name="id" required="true" primaryKey="true" type="INTEGER"/>
+            <column name="title" type="VARCHAR" size="100"/>
+
+            <behavior name="nested_set"/>
+        </table>
+    </database>
+XML;
+
+    protected const OUTPUT_GROUP_SCHEMA = <<<XML
+    <database>
+        <behavior name="output_group"/>
+
+        <table name="table">
+            <column name="col0" />
+            <column name="col1" outputGroup="group2"/>
+            <column name="col2" outputGroup="group1"/>
+            <column name="col3" outputGroup="group1,group2"/>
+        </table>
+    </database>
+XML;
+
+    protected const QUERY_CACHE_SCHEMA = <<<XML
+    <database>
+        <table name="table">
+            <column name="id" required="true" primaryKey="true" type="INTEGER"/>
+            <column name="title" type="VARCHAR" size="100" primaryString="true"/>
+
+            <behavior name="query_cache">
+                <parameter name="backend" value="array"/>
+            </behavior>
+        </table>
+    </database>
+XML;
+
+    protected const SLUGGABLE_SCHEMA = <<<XML
+    <database>
+        <table name="table">
+            <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER"/>
+            <column name="title" type="VARCHAR" size="100" primaryString="true"/>
+            <column name="url" type="VARCHAR" size="100"/>
+            <behavior name="sluggable">
+                <parameter name="slug_column" value="url"/>
+                <parameter name="slug_pattern" value="/foo/{Title}/bar"/>
+                <parameter name="replace_pattern" value="/[^\w\/]+/"/>
+                <parameter name="separator" value="/"/>
+                <parameter name="permanent" value="true"/>
+            </behavior>
+        </table>
+    </database>
+XML;
+
+    protected const SORTABLE_SCHEMA = <<<XML
+    <database>
+        <table name="table">
+            <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER"/>
+            <column name="title" type="VARCHAR" size="100" primaryString="true"/>
+
+            <behavior name="sortable"/>
+        </table>
+    </database>
+XML;
+
+    protected const TIMESTAMPABLE_SCHEMA = <<<XML
+    <database>
+        <table name="table">
+            <column name="id" type="INTEGER" primaryKey="true"/>
+            <behavior name="timestampable"/>
+        </table>
+    </database>
+XML;
+
+    protected const VALIDATEABLE_SCHEMA = <<<XML
+    <database>
+        <table name="table">
+            <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER"/>
+            <column name="name" type="VARCHAR"/>
+            <column name="website" type="VARCHAR" size="24"/>
+            <behavior name="validate">
+                <parameter name="uniqueName" value="{column: name, validator: Unique}"/>
+                <parameter name="sebsiteIsUrl" value="{column: website, validator: Url}"/>
+            </behavior>
+        </table>
+    </database>
+XML;
+
+    protected const VERSIONABLE_SCHEMA = <<<XML
+    <database>
+        <table name="table">
+            <column name="id" primaryKey="true" type="INTEGER" autoIncrement="true"/>
+            <column name="bar" type="INTEGER"/>
+
+            <behavior name="versionable">
+                <parameter name="version_column" value="CustomVersion"/>
+            </behavior>
+        </table>
+    </database>
+XML;
+}

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/aggregate_column---source_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/aggregate_column---source_model_reference.txt
@@ -1,0 +1,85 @@
+
+
+objectMethods:
+
+// aggregate_column_relation_aggregate_column behavior
+
+/**
+ * Update the aggregate column in the related AggregatedTable object
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con A connection object
+ */
+protected function updateRelatedAggregatedTableRelatedEntries(ConnectionInterface $con)
+{
+    if ($aggregatedTable = $this->getAggregatedTable()) {
+        $aggregatedTable->updateRelatedEntries($con);
+    }
+    if ($this->oldAggregatedTableRelatedEntries) {
+        $this->oldAggregatedTableRelatedEntries->updateRelatedEntries($con);
+        $this->oldAggregatedTableRelatedEntries = null;
+    }
+}
+
+
+objectFilter:
+
+    /**
+     * Declares an association between this object and a ChildAggregatedTable object.
+     *
+     * @param \AggregatedTable|null $aggregatedTable
+     *
+     * @return $this
+     */
+    public function setAggregatedTable(?ChildAggregatedTable $aggregatedTable = null)
+    {
+        // aggregate_column_relation behavior
+        if ($this->aAggregatedTable !== null && $aggregatedTable !== $this->aAggregatedTable) {
+            $this->oldAggregatedTableRelatedEntries = $this->aAggregatedTable;
+        }
+        $fk = $aggregatedTable ? $aggregatedTable->getId() : null;
+        $this->setFk($fk);
+
+        $this->aAggregatedTable = $aggregatedTable;
+        assert($this instanceof ChildSourceTable);
+        $aggregatedTable?->addSourceTable($this);
+
+        return $this;
+    }
+
+    /**
+     * Get the associated AggregatedTable object
+     *
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con Optional Connection object.
+     *
+     * @return \AggregatedTable|null
+     */
+    public function getAggregatedTable(?ConnectionInterface $con = null)
+    {
+        if ($this->aAggregatedTable === null && ($this->fk !== null && $this->fk !== 0)) {
+            $this->aAggregatedTable = ChildAggregatedTableQuery::create()->findPk($this->fk, $con);
+            /* The following can be used additionally to
+                guarantee the related object contains a reference
+                to this object.  This level of coupling may, however, be
+                undesirable since it could result in an only partially populated collection
+                in the referenced object.
+                $this->aAggregatedTable->addSourceTables($this);
+             */
+        }
+
+        return $this->aAggregatedTable;
+    }
+
+
+objectAttributes:
+
+// aggregate_column_relation_aggregate_column behavior
+/**
+ * @var ChildAggregatedTable
+ */
+protected $oldAggregatedTableRelatedEntries;
+
+
+postSave:
+
+// aggregate_column_relation_aggregate_column behavior
+$this->updateRelatedAggregatedTableRelatedEntries($con);

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/aggregate_column---target_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/aggregate_column---target_model_reference.txt
@@ -1,0 +1,30 @@
+
+
+objectMethods:
+
+// aggregate_column behavior
+
+/**
+ * Computes the value of the aggregate column related_entries *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con A connection object
+ *
+ * @return mixed The scalar result from the aggregate query
+ */
+public function computeRelatedEntries(ConnectionInterface $con)
+{
+    $stmt = $con->prepare('SELECT COUNT(id) FROM source_table WHERE source_table.FK = :p1');
+    $stmt->bindValue(':p1', $this->getId());
+    $stmt->execute();
+
+    return $stmt->fetchColumn();
+}
+
+/**
+ * Updates the aggregate column related_entries *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con A connection object
+ */
+public function updateRelatedEntries(ConnectionInterface $con)
+{
+    $this->setRelatedEntries($this->computeRelatedEntries($con));
+    $this->save($con);
+}

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/aggregate_multiple_columns---target_model_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/aggregate_multiple_columns---target_model_reference.txt
@@ -1,0 +1,33 @@
+
+
+objectMethods:
+
+// aggregate_multiple_columns behavior
+
+/**
+ * Computes the value of the aggregate columns defined as AggregatedColumnsFromSourceTable ?>
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con A connection object
+ *
+ * @return array The result row from the aggregate query
+ */
+public function computeAggregatedColumnsFromSourceTable(ConnectionInterface $con)
+{
+    $stmt = $con->prepare('SELECT SUM(score) AS TotalScore, COUNT(score) AS NumberOfScores FROM source_table WHERE source_table.FK = :p1');
+    $stmt->bindValue(':p1', $this->getId());
+    $stmt->execute();
+
+    return $stmt->fetch(\PDO::FETCH_NUM);
+}
+
+/**
+ * Updates the aggregate columns defined as AggregatedColumnsFromSourceTable *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con A connection object
+ */
+public function updateAggregatedColumnsFromSourceTable(ConnectionInterface $con)
+{
+    $aggregatedValues = $this->computeAggregatedColumnsFromSourceTable($con);
+    $this->setTotalScore($aggregatedValues[0]);
+    $this->setNumberOfScores($aggregatedValues[1]);
+    $this->save($con);
+}

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/archivable---model_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/archivable---model_reference.txt
@@ -1,0 +1,160 @@
+
+
+objectMethods:
+
+// archivable behavior
+
+/**
+ * Get an archived version of the current object.
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface|null $con Optional connection object
+ *
+ * @return ChildTableArchive An archive object, or null if the current object was never archived
+ */
+public function getArchive(?ConnectionInterface $con = null)
+{
+    if ($this->isNew()) {
+        return null;
+    }
+    $archive = ChildTableArchiveQuery::create()
+        ->filterByPrimaryKey($this->getPrimaryKey())
+        ->findOne($con);
+
+    return $archive;
+}
+/**
+ * Copy the data of the current object into a $archiveTablePhpName archive object.
+ * The archived object is then saved.
+ * If the current object has already been archived, the archived object
+ * is updated and not duplicated.
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface|null $con Optional connection object
+ *
+ * @throws \Propel\Runtime\Exception\PropelException If the object is new
+ *
+ * @return ChildTableArchive The archive object based on this object
+ */
+public function archive(?ConnectionInterface $con = null)
+{
+    if ($this->isNew()) {
+        throw new PropelException('New objects cannot be archived. You must save the current object before calling archive().');
+    }
+    $archive = $this->getArchive($con);
+    if (!$archive) {
+        $archive = new ChildTableArchive();
+        $archive->setPrimaryKey($this->getPrimaryKey());
+    }
+    $this->copyInto($archive, $deepCopy = false, $makeNew = false);
+    $archive->setArchivedAt(time());
+    $archive->save($con);
+
+    return $archive;
+}
+
+/**
+ * Revert the the current object to the state it had when it was last archived.
+ * The object must be saved afterwards if the changes must persist.
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface|null $con Optional connection object
+ *
+ * @throws \Propel\Runtime\Exception\PropelException If the object has no corresponding archive.
+ *
+ * @return $this The current object (for fluent API support)
+ */
+public function restoreFromArchive(?ConnectionInterface $con = null)
+{
+    $archive = $this->getArchive($con);
+    if (!$archive) {
+        throw new PropelException('The current object has never been archived and cannot be restored');
+    }
+    $this->populateFromArchive($archive);
+
+    return $this;
+}
+
+/**
+ * Populates the the current object based on a $archiveTablePhpName archive object.
+ *
+ * @param ChildTableArchive $archive An archived object based on the same class
+  *
+ * @return ChildTable The current object (for fluent API support)
+ */
+public function populateFromArchive($archive)
+{
+    $this->setId($archive->getId());
+    $this->setTitle($archive->getTitle());
+
+    return $this;
+}
+
+/**
+ * Persists the object to the database without archiving it.
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface|null $con Optional connection object
+ *
+ * @return $this|ChildTable The current object (for fluent API support)
+ */
+public function saveWithoutArchive(?ConnectionInterface $con = null)
+{
+    if ($this->isNew()) {
+        $this->archiveOnInsert = false;
+    } else {
+        $this->archiveOnUpdate = false;
+    }
+
+    return $this->save($con);
+}
+
+/**
+ * Removes the object from the database without archiving it.
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface|null $con Optional connection object
+ *
+ * @return $this|ChildTable The current object (for fluent API support)
+ */
+public function deleteWithoutArchive(?ConnectionInterface $con = null)
+{
+    $this->archiveOnDelete = false;
+
+    return $this->delete($con);
+}
+
+
+objectAttributes:
+
+// archivable behavior
+protected $archiveOnInsert = true;
+protected $archiveOnUpdate = true;
+protected $archiveOnDelete = true;
+
+
+preDelete:
+
+// archivable behavior
+if ($ret) {
+    if ($this->archiveOnDelete) {
+        // do nothing yet. The object will be archived later when calling ChildTableQuery::delete().
+    } else {
+        $deleteQuery->setArchiveOnDelete(false);
+        $this->archiveOnDelete = true;
+    }
+}
+
+
+postUpdate:
+
+// archivable behavior
+if ($this->archiveOnUpdate) {
+    $this->archive($con);
+} else {
+    $this->archiveOnUpdate = true;
+}
+
+postInsert:
+
+// archivable behavior
+if ($this->archiveOnInsert) {
+    $this->archive($con);
+} else {
+    $this->archiveOnInsert = true;
+}

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/archivable---query_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/archivable---query_reference.txt
@@ -1,0 +1,144 @@
+
+
+queryAttributes:
+
+// archivable behavior
+protected $archiveOnUpdate = true;
+protected $archiveOnDelete = true;
+
+
+queryAttributes:
+
+// archivable behavior
+protected $archiveOnUpdate = true;
+protected $archiveOnDelete = true;
+
+
+queryMethods:
+
+// archivable behavior
+
+/**
+ * Copy the data of the objects satisfying the query into ChildTableArchive archive objects.
+ * The archived objects are then saved.
+ * If any of the objects has already been archived, the archived object
+ * is updated and not duplicated.
+ * Warning: This termination methods issues 2n+1 queries.
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface|null $con    Connection to use.
+ * @param bool $useLittleMemory Whether to use OnDemandFormatter to retrieve objects.
+ *               Set to false if the identity map matters.
+ *               Set to true (default) to use less memory.
+ *
+ * @return int the number of archived objects
+ */
+public function archive($con = null, $useLittleMemory = true)
+{
+    $criteria = clone $this;
+    // prepare the query
+    $criteria->setWith([]);
+    if ($useLittleMemory) {
+        $criteria->setFormatter(ModelCriteria::FORMAT_ON_DEMAND);
+    }
+    if ($con === null) {
+        $con = Propel::getServiceContainer()->getWriteConnection(TableTableMap::DATABASE_NAME);
+    }
+
+    return $con->transaction(function () use ($con, $criteria) {
+        $totalArchivedObjects = 0;
+
+        // archive all results one by one
+        foreach ($criteria->find($con) as $object) {
+            $object->archive($con);
+            $totalArchivedObjects++;
+        }
+
+        return $totalArchivedObjects;
+    });
+}
+
+/**
+ * Enable/disable auto-archiving on update for the next query.
+ *
+ * @param bool True if the query must archive updated objects, false otherwise.
+ */
+public function setArchiveOnUpdate(bool $archiveOnUpdate)
+{
+    $this->archiveOnUpdate = $archiveOnUpdate;
+}
+
+/**
+ * Delete records matching the current query without archiving them.
+ *
+ * @param array $values Associative array of keys and values to replace
+ * @param \Propel\Runtime\Connection\ConnectionInterface|null $con an optional connection object
+ * @param bool $forceIndividualSaves If false (default), the resulting call is a Criteria::doUpdate(), ortherwise it is a series of save() calls on all the found objects
+ *
+ * @return int The number of deleted rows
+ */
+public function updateWithoutArchive(array $values, $con = null, bool $forceIndividualSaves = false): int
+{
+    $this->archiveOnUpdate = false;
+
+    return $this->update($values, $con, $forceIndividualSaves);
+}
+
+/**
+ * Enable/disable auto-archiving on delete for the next query.
+ *
+ * @param bool True if the query must archive deleted objects, false otherwise.
+ */
+public function setArchiveOnDelete(bool $archiveOnDelete)
+{
+    $this->archiveOnDelete = $archiveOnDelete;
+}
+
+/**
+ * Delete records matching the current query without archiving them.
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface|null $con    Connection to use.
+ *
+ * @return int The number of deleted rows
+ */
+public function deleteWithoutArchive($con = null): int
+{
+    $this->archiveOnDelete = false;
+
+    return $this->delete($con);
+}
+
+/**
+ * Delete all records without archiving them.
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface|null $con    Connection to use.
+ *
+ * @return int The number of deleted rows
+ */
+public function deleteAllWithoutArchive($con = null): int
+{
+    $this->archiveOnDelete = false;
+
+    return $this->deleteAll($con);
+}
+
+
+preDeleteQuery:
+
+// archivable behavior
+
+if ($this->archiveOnDelete) {
+    $this->archive($con);
+} else {
+    $this->archiveOnDelete = true;
+}
+
+
+postUpdateQuery:
+
+// archivable behavior
+
+if ($this->archiveOnUpdate) {
+    $this->archive($con);
+} else {
+    $this->archiveOnUpdate = true;
+}

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/concrete-inheritance---child-model_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/concrete-inheritance---child-model_reference.txt
@@ -1,0 +1,60 @@
+
+
+objectMethods:
+
+// concrete_inheritance behavior
+
+/**
+ * Get or Create the parent ChildParent object of the current object
+ *
+ * @return ChildParent The parent object
+ */
+public function getParentOrCreate(?ConnectionInterface $con = null)
+{
+    if (!$this->isNew()) {
+        return ChildParentQuery::create()->findPk($this->getPrimaryKey(), $con);
+    }
+
+    if ($this->isPrimaryKeyNull()) {
+        $parent = new ChildParent();
+        $parent->setDescendantClass('Child');
+
+        return $parent;
+    }
+
+    $parent = ChildParentQuery::create()->findPk($this->getPrimaryKey(), $con);
+    if (!$parent || $parent->getDescendantClass() !== null) {
+        $parent = new ChildParent();
+        $parent->setPrimaryKey($this->getPrimaryKey());
+        $parent->setDescendantClass('Child');
+    }
+
+    return $parent;
+}
+
+/**
+ * Create or Update the parent Parent object.
+ *
+ * @return Parent The parent object
+ */
+public function getSyncParent(?ConnectionInterface $con = null)
+{
+    $parent = $this->getParentOrCreate($con);
+    $parent->setTitle($this->getTitle());
+
+    return $parent;
+}
+
+
+postDelete:
+
+// concrete_inheritance behavior
+$this->getParentOrCreate($con)->delete($con);
+
+
+preSave:
+
+// concrete_inheritance behavior
+$parent = $this->getSyncParent($con);
+$parent->save($con);
+$this->setPrimaryKey($parent->getPrimaryKey());

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/concrete-inheritance---parent-model_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/concrete-inheritance---parent-model_reference.txt
@@ -1,0 +1,31 @@
+
+
+objectMethods:
+
+// concrete_inheritance_parent behavior
+
+/**
+ * Whether this object is the parent of a child object
+ *
+ * @return bool
+ */
+public function hasChildObject(): bool
+{
+    return $this->getDescendantClass() !== null;
+}
+
+/**
+ * Get the child object of this object
+ *
+ * @return mixed
+ */
+public function getChildObject()
+{
+    if (!$this->hasChildObject()) {
+        return null;
+    }
+    $childObjectClass = $this->getDescendantClass();
+    $childObject = PropelQuery::from($childObjectClass)->findPk($this->getPrimaryKey());
+
+    return $childObject->hasChildObject() ? $childObject->getChildObject() : $childObject;
+}

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/delegate---delegator-model_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/delegate---delegator-model_reference.txt
@@ -1,0 +1,69 @@
+
+
+objectFilter:
+
+    /**
+     * Exports the object as an array.
+     *
+     * You can specify the key type of the array by passing one of the class
+     * type constants.
+     *
+     * @param string $keyType (optional) One of the class type constants TableMap::TYPE_PHPNAME, TableMap::TYPE_CAMELNAME,
+     *                    TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME, TableMap::TYPE_NUM.
+     *                    Defaults to TableMap::TYPE_PHPNAME.
+     * @param bool $includeLazyLoadColumns (optional) Whether to include lazy loaded columns. Defaults to TRUE.
+     * @param array<string, array<string|bool>> $alreadyDumpedObjects List of objects to skip to avoid recursion
+     * @param bool $includeForeignObjects (optional) Whether to include hydrated related objects. Default to FALSE.
+     *
+     * @return array<mixed> An associative array containing the field names (as keys) and field values
+     */
+    public function toArray(
+        string $keyType = TableMap::TYPE_PHPNAME,
+        bool $includeLazyLoadColumns = true,
+        array $alreadyDumpedObjects = [],
+        bool $includeForeignObjects = false
+    ): array {
+        if (isset($alreadyDumpedObjects['Delegator'][$this->hashCode()])) {
+            return ['*RECURSION*'];
+        }
+        $alreadyDumpedObjects['Delegator'][$this->hashCode()] = true;
+        $keys = DelegatorTableMap::getFieldNames($keyType);
+        $keys_resolver = \Map\ResolverTableMap::getFieldNames($keyType);
+        $result = [
+            $keys[0] => $this->getId(),
+            $keys_resolver[1] => $this->getDelegatedColumn(),
+
+        ];
+
+        foreach ($this->virtualColumns as $key => $virtualColumn) {
+            $result[$key] = $virtualColumn;
+        }
+
+        if ($includeForeignObjects) {
+            if ($this->singleResolver !== null) {
+                $key = match ($keyType) {
+                     TableMap::TYPE_CAMELNAME => 'resolver',
+                     TableMap::TYPE_FIELDNAME => 'resolver',
+                     default => 'Resolver',
+                };
+                $result[$key] = $this->singleResolver->toArray($keyType, $includeLazyLoadColumns, $alreadyDumpedObjects, true);
+            }
+        }
+
+        return $result;
+    }
+
+
+objectCall:
+
+// delegate behavior
+
+if (method_exists(\Resolver::class, $name)) {
+    $delegate = $this->getResolver();
+    if (!$delegate) {
+        $delegate = new ChildResolver();
+        $this->setResolver($delegate);
+    }
+
+    return $delegate->$name(...$params);
+}

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/delegate---delegator-query_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/delegate---delegator-query_reference.txt
@@ -1,0 +1,94 @@
+
+
+queryAttributes:
+
+// delegate behavior
+
+protected $delegatedFields = [
+    'DelegatedColumn' => 'Resolver',
+];
+
+
+
+queryAttributes:
+
+// delegate behavior
+
+protected $delegatedFields = [
+    'DelegatedColumn' => 'Resolver',
+];
+
+
+
+queryMethods:
+
+// delegate behavior
+/**
+* Filter the query by delegated_column column
+*
+* Example usage:
+* <code>
+    * $query->filterByDelegatedColumn(1234); // WHERE delegated_column = 1234
+    * $query->filterByDelegatedColumn(array(12, 34)); // WHERE delegated_column IN (12, 34)
+    * $query->filterByDelegatedColumn(array('min' => 12)); // WHERE delegated_column >= 12
+    * </code>
+*
+* @param mixed $value The value to use as filter.
+*              Use scalar values for equality.
+*              Use array values for in_array() equivalent.
+*              Use associative array('min' => $minValue, 'max' => $maxValue) for intervals.
+* @param string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+*
+* @return $this|ChildDelegatorQuery*/
+public function filterByDelegatedColumn($value = null, $comparison = null)
+{
+    return $this->useResolverQuery()->filterByDelegatedColumn($value, $comparison)->endUse();
+}
+
+/**
+* Adds an ORDER BY clause to the query
+* Usability layer on top of Criteria::addAscendingOrderByColumn() and Criteria::addDescendingOrderByColumn()
+* Infers $column and $order from $columnName and some optional arguments
+* Examples:
+*   $c->orderBy('Book.CreatedAt')
+*    => $c->addAscendingOrderByColumn(BookTableMap::CREATED_AT)
+*   $c->orderBy('Book.CategoryId', 'desc')
+*    => $c->addDescendingOrderByColumn(BookTableMap::CATEGORY_ID)
+*
+* @param string $order The sorting order. Criteria::ASC by default, also accepts Criteria::DESC
+*
+* @return $this|ModelCriteria
+*/
+public function orderByDelegatedColumn(string $order = Criteria::ASC)
+{
+    return $this->useResolverQuery()->orderByDelegatedColumn($order)->endUse();
+}
+
+/**
+ * Adds a condition on a column based on a column phpName and a value
+ * Uses introspection to translate the column phpName into a fully qualified name
+ * Warning: recognizes only the phpNames of the main Model (not joined tables)
+ * <code>
+ * $c->filterBy('Title', 'foo');
+ * </code>
+ *
+ * @see Criteria::add()
+ *
+ * @param string $column A string representing the column phpName, e.g. 'AuthorId'
+ * @param mixed $value A value for the condition
+ * @param string $comparison What to use for the column comparison, defaults to Criteria::EQUAL and Criteria::IN for queries
+ *
+ * @return $this
+ */
+public function filterBy(string $column, $value, ?string $comparison = null)
+{
+    if (isset($this->delegatedFields[$column])) {
+        $methodUse = "use{$this->delegatedFields[$column]}Query";
+
+        $this->{$methodUse}()->filterBy($column, $value, $comparison)->endUse();
+    } else {
+        $this->add($this->getRealColumnName($column), $value, $comparison);
+    }
+
+    return $this;
+}

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/i18n---object_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/i18n---object_reference.txt
@@ -1,0 +1,427 @@
+
+
+objectMethods:
+
+// i18n behavior
+
+/**
+ * Sets the locale for translations
+ *
+ * @param string $locale Locale to use for the translation, e.g. 'fr_FR'
+ *
+ * @return $this The current object (for fluent API support)
+ */
+public function setLanguage($locale = 'en_US')
+{
+    $this->currentLocale = $locale;
+
+    return $this;
+}
+
+/**
+ * Gets the locale for translations
+ *
+ * @return string $locale Locale to use for the translation, e.g. 'fr_FR'
+ */
+public function getLanguage()
+{
+    return $this->currentLocale;
+}
+
+/**
+ * Gets the locale for translations.
+ * Alias for getLocale(), for BC purpose.
+ *
+ * @return string $locale Locale to use for the translation, e.g. 'fr_FR'
+ */
+public function getCulture()
+{
+    return $this->getLanguage();
+}
+
+/**
+ * Sets the locale for translations.
+ * Alias for setLocale(), for BC purpose.
+ *
+ * @param string $locale Locale to use for the translation, e.g. 'fr_FR'
+ *
+ * @return $this|ChildTable The current object (for fluent API support)
+ */
+public function setCulture($locale = 'en_US')
+{
+    return $this->setLanguage($locale);
+}
+
+/**
+ * Returns the current translation for a given locale
+ *
+ * @param string $locale Locale to use for the translation, e.g. 'fr_FR'
+ * @param \Propel\Runtime\Connection\ConnectionInterface|null $con an optional connection object
+ *
+ * @return ChildTableI18n */
+public function getTranslation(string $locale = 'en_US', ?ConnectionInterface $con = null)
+{
+    if (!isset($this->currentTranslations[$locale])) {
+        if (null !== $this->collTableI18ns) {
+            foreach ($this->collTableI18ns as $translation) {
+                if ($translation->getLanguage() == $locale) {
+                    $this->currentTranslations[$locale] = $translation;
+
+                    return $translation;
+                }
+            }
+        }
+        if ($this->isNew()) {
+            $translation = new ChildTableI18n();
+            $translation->setLanguage($locale);
+        } else {
+            $translation = ChildTableI18nQuery::create()
+                ->filterByPrimaryKey(array($this->getPrimaryKey(), $locale))
+                ->findOneOrCreate($con);
+            $this->currentTranslations[$locale] = $translation;
+        }
+        $this->addTableI18n($translation);
+    }
+
+    return $this->currentTranslations[$locale];
+}
+
+/**
+ * Remove the translation for a given locale
+ *
+ * @param string $locale Locale to use for the translation, e.g. 'fr_FR'
+ * @param \Propel\Runtime\Connection\ConnectionInterface|null $con an optional connection object
+ *
+ * @return $this The current object (for fluent API support)
+ */
+public function removeTranslation(string $locale = 'en_US', ?ConnectionInterface $con = null)
+{
+    if (!$this->isNew()) {
+        ChildTableI18nQuery::create()
+            ->filterByPrimaryKey(array($this->getPrimaryKey(), $locale))
+            ->delete($con);
+    }
+    unset($this->currentTranslations[$locale]);
+    foreach ($this->collTableI18ns as $key => $translation) {
+        if ($translation->getLanguage() == $locale) {
+            unset($this->collTableI18ns[$key]);
+            break;
+        }
+    }
+
+    return $this;
+}
+
+/**
+ * Returns the current translation
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface|null $con an optional connection object
+ *
+ * @return ChildTableI18n 
+ */
+public function getCurrentTranslation(?ConnectionInterface $con = null)
+{
+    return $this->getTranslation($this->getLanguage(), $con);
+}
+
+/**
+* Get the [bar] column value.
+*
+* @return string|null
+*/
+public function getBar()
+{
+    return $this->getCurrentTranslation()->getBar();
+}
+
+/**
+* Set the value of [bar] column.
+*
+* @param string|null $v New value
+*
+* @return $this
+*/
+public function setBar($v)
+{    $this->getCurrentTranslation()->setBar($v);
+
+    return $this;
+}
+
+
+objectFilter:
+
+    /**
+     * Initializes the collTableI18ns collection.
+     *
+     * By default this just sets the collTableI18ns collection to an empty array (like clearcollTableI18ns());
+     * however, you may wish to override this method in your stub class to provide setting appropriate
+     * to your application -- for example, setting the initial array to the values stored in database.
+     *
+     * @param bool $overrideExisting If set to true, the method call initializes
+     *                                        the collection even if it is not empty
+     *
+     * @return void
+     */
+    public function initTableI18ns(bool $overrideExisting = true): void
+    {
+        if ($this->collTableI18ns !== null && !$overrideExisting) {
+            return;
+        }
+
+        $this->collTableI18ns = new TableI18nCollection();
+        $this->collTableI18ns->setModel('\TableI18n');
+    }
+
+    /**
+     * Reset is the collTableI18ns collection loaded partially.
+     *
+     * @param bool $isPartial
+     *
+     * @return void
+     */
+    public function resetPartialTableI18ns(bool $isPartial = true): void
+    {
+        $this->collTableI18nsPartial = $isPartial;
+    }
+
+    /**
+     * Clears out the collTableI18ns collection
+     *
+     * This does not modify the database; however, it will remove any associated objects, causing
+     * them to be refetched by subsequent calls to accessor method.
+     *
+     * @return static
+     */
+    public function clearTableI18ns(): static
+    {
+        $this->collTableI18ns = null;
+
+        return $this;
+    }
+
+    /**
+     * Gets table objects which contain a foreign key that references this object.
+     *
+     * If the $criteria is not null, it is used to always fetch the results from the database.
+     * Otherwise the results are fetched from the database the first time, then cached.
+     * Next time the same method is called without $criteria, the cached collection is returned.
+     * If this Table is new, it will return
+     * an empty collection or the current collection; the criteria is ignored on a new object.
+     *
+     * @param \Propel\Runtime\ActiveQuery\Criteria|null $criteria
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
+     *
+     * @return \Base\Collection\TableI18nCollection
+     */
+    public function getTableI18ns(?Criteria $criteria = null, ?ConnectionInterface $con = null): TableI18nCollection
+    {
+        $partial = $this->collTableI18nsPartial && !$this->isNew();
+        if ($this->collTableI18ns && !$criteria && !$partial) {
+            return $this->collTableI18ns;
+        }
+
+        if ($this->isNew()) {
+            // return empty collection
+            if ($this->collTableI18ns === null) {
+                $this->initTableI18ns();
+
+                return $this->collTableI18ns;
+            }
+
+            $collTableI18ns = new TableI18nCollection();
+            $collTableI18ns->setModel('\TableI18n');
+
+            return $collTableI18ns;
+        }
+
+        $collTableI18ns = ChildTableI18nQuery::create(null, $criteria)
+            ->filterByTable($this)
+            ->findObjects($con);
+
+        if ($criteria) {
+            if ($this->collTableI18nsPartial !== false && count($collTableI18ns)) {
+                $this->initTableI18ns(false);
+
+                foreach ($collTableI18ns as $obj) {
+                    if (!$this->collTableI18ns->contains($obj)) {
+                        $this->collTableI18ns->append($obj);
+                    }
+                }
+
+                $this->collTableI18nsPartial = true;
+            }
+
+            return $collTableI18ns;
+        }
+
+        if ($this->collTableI18nsPartial && $this->collTableI18ns) {
+            foreach ($this->collTableI18ns as $obj) {
+                if ($obj->isNew()) {
+                    $collTableI18ns[] = $obj;
+                }
+            }
+        }
+
+        $this->collTableI18ns = $collTableI18ns;
+        $this->collTableI18nsPartial = false;
+
+        return $this->collTableI18ns;
+    }
+
+    /**
+     * Sets a collection of table objects related by a one-to-many relationship
+     * to the current object.
+     *
+     * It will also schedule objects for deletion based on a diff between old objects (aka persisted)
+     * and new objects from the given Propel collection.
+     *
+     * @param \Propel\Runtime\Collection\Collection<\TableI18n> $tableI18ns
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
+     *
+     * @return static
+     */
+    public function setTableI18ns(Collection $tableI18ns, ?ConnectionInterface $con = null): static
+    {
+        $tableI18nsToDelete = $this->getTableI18ns(null, $con)->diff($tableI18ns);
+
+        //since at least one column in the foreign key is at the same time a PK
+        //we can not just set a PK to NULL in the lines below. We have to store
+        //a backup of all values, so we are able to manipulate these items based on the onDelete value later.
+        $this->tableI18nsScheduledForDeletion = clone $tableI18nsToDelete;
+
+        foreach ($tableI18nsToDelete as $tableI18nRemoved) {
+            $tableI18nRemoved->setTable(null);
+        }
+
+        $this->collTableI18ns = null;
+        foreach ($tableI18ns as $tableI18n) {
+            $this->addTableI18n($tableI18n);
+        }
+
+        $this->collTableI18nsPartial = false;
+        $this->collTableI18ns = $tableI18ns instanceof TableI18nCollection
+            ? $tableI18ns : new TableI18nCollection($tableI18ns->getData());
+
+        return $this;
+    }
+
+    /**
+     * Returns the number of related table objects.
+     *
+     * @param \Propel\Runtime\ActiveQuery\Criteria|null $criteria
+     * @param bool $distinct
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
+     *
+     * @return int Count of related table objects.
+     */
+    public function countTableI18ns(?Criteria $criteria = null, bool $distinct = false, ?ConnectionInterface $con = null): int
+    {
+        $partial = $this->collTableI18nsPartial && !$this->isNew();
+        if ($this->collTableI18ns === null || $criteria !== null || $partial) {
+            if ($this->isNew() && $this->collTableI18ns === null) {
+                return 0;
+            }
+
+            if ($partial && !$criteria) {
+                return count($this->getTableI18ns());
+            }
+
+            $query = ChildTableI18nQuery::create(null, $criteria);
+            if ($distinct) {
+                $query->distinct();
+            }
+
+            return $query
+                ->filterByTable($this)
+                ->count($con);
+        }
+
+        return count($this->collTableI18ns);
+    }
+
+    /**
+     * Method called to associate a ChildTableI18n object to this object
+     * through the ChildTableI18n foreign key attribute.
+     *
+     * @param \TableI18n $childTableI18n
+     *
+     * @return $this
+     */
+    public function addTableI18n(ChildTableI18n $childTableI18n)
+    {
+        if ($childTableI18n && $locale = $childTableI18n->getLanguage()) {
+            $this->setLanguage($locale);
+            $this->currentTranslations[$locale] = $childTableI18n;
+        }
+        if ($this->collTableI18ns === null) {
+            $this->initTableI18ns();
+            $this->collTableI18nsPartial = true;
+        }
+
+        if (!$this->collTableI18ns->contains($childTableI18n)) {
+            $this->doAddTableI18n($childTableI18n);
+
+            if ($this->tableI18nsScheduledForDeletion && $this->tableI18nsScheduledForDeletion->contains($childTableI18n)) {
+                $this->tableI18nsScheduledForDeletion->remove($this->tableI18nsScheduledForDeletion->search($childTableI18n));
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param \TableI18n $tableI18n The ChildTableI18n object to add.
+     *
+     * @return void
+     */
+    protected function doAddTableI18n(ChildTableI18n $tableI18n): void
+    {
+        $this->collTableI18ns->append($tableI18n);
+        assert($this instanceof ChildTable);
+        $tableI18n->setTable($this);
+    }
+
+    /**
+     * @param \TableI18n $tableI18n The ChildTableI18n object to remove.
+     *
+     * @return static
+     */
+    public function removeTableI18n(ChildTableI18n $tableI18n): static
+    {
+        if ($this->getTableI18ns()->contains($tableI18n)) {
+            $pos = $this->collTableI18ns->search($tableI18n);
+            $this->collTableI18ns->remove($pos);
+            if ($this->tableI18nsScheduledForDeletion === null) {
+                $this->tableI18nsScheduledForDeletion = clone $this->collTableI18ns;
+                $this->tableI18nsScheduledForDeletion->clear();
+            }
+            $this->tableI18nsScheduledForDeletion->append(clone $tableI18n);
+            $tableI18n->setTable(null);
+        }
+
+        return $this;
+    }
+
+
+objectAttributes:
+
+// i18n behavior
+
+/**
+ * Current locale
+ * @var string
+ */
+protected $currentLocale = 'en_US';
+
+/**
+ * Current translation objects
+ * @var array[ChildTableI18n]
+ */
+protected $currentTranslations;
+
+
+objectClearReferences:
+
+// i18n behavior
+$this->currentLocale = 'en_US';
+$this->currentTranslations = null;

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/i18n---query_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/i18n---query_reference.txt
@@ -1,0 +1,57 @@
+
+
+queryMethods:
+
+// i18n behavior
+
+/**
+ * Adds a JOIN clause to the query using the i18n relation
+ *
+ * @param string $locale Locale to use for the join condition, e.g. 'fr_FR'
+ * @param string $relationAlias optional alias for the relation
+ * @param string $joinType Accepted values are null, 'left join', 'right join', 'inner join'. Defaults to left join.
+ *
+ * @return ChildTableQuery */
+public function joinI18n($locale = 'en_US', $relationAlias = null, $joinType = Criteria::LEFT_JOIN)
+{
+    $relationName = $relationAlias ? $relationAlias : 'TableI18n';
+
+    return $this
+        ->joinTableI18n($relationAlias, $joinType)
+        ->addJoinCondition($relationName, $relationName . '.Language = ?', $locale);
+}
+
+/**
+ * Adds a JOIN clause to the query and hydrates the related I18n object.
+ * Shortcut for $c->joinI18n($locale)->with()
+ *
+ * @param string $locale Locale to use for the join condition, e.g. 'fr_FR'
+ * @param string $joinType Accepted values are null, 'left join', 'right join', 'inner join'. Defaults to left join.
+ *
+ * @return $this
+ */
+public function joinWithI18n($locale = 'en_US', $joinType = Criteria::LEFT_JOIN)
+{
+    $this
+        ->joinI18n($locale, null, $joinType)
+        ->with('TableI18n');
+    $this->with['TableI18n']->setIsWithOneToMany(false);
+
+    return $this;
+}
+
+/**
+ * Use the I18n relation query object
+ *
+ * @param string $locale Locale to use for the join condition, e.g. 'fr_FR'
+ * @param string $relationAlias optional alias for the relation
+ * @param string $joinType Accepted values are null, 'left join', 'right join', 'inner join'. Defaults to left join.
+ *
+ * @return ChildTableI18nQuery A secondary query class using the current class as primary query
+ */
+public function useI18nQuery($locale = 'en_US', $relationAlias = null, $joinType = Criteria::LEFT_JOIN)
+{
+    return $this
+        ->joinI18n($locale, $relationAlias, $joinType)
+        ->useQuery($relationAlias ?: 'TableI18n', '\TableI18nQuery');
+}

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/nested_set---object_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/nested_set---object_reference.txt
@@ -1,0 +1,941 @@
+
+
+objectMethods:
+
+// nested_set behavior
+
+/**
+ * Execute queries that were saved to be run inside the save transaction
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ *
+ * @return void
+ */
+protected function processNestedSetQueries(ConnectionInterface $con): void
+{
+    foreach ($this->nestedSetQueries as ['callable' => $callable, 'arguments' => $arguments]) {
+        $arguments[] = $con;
+        $callable(...$arguments);
+    }
+    $this->nestedSetQueries = [];
+}
+
+/**
+ * Proxy getter method for the left value of the nested set model.
+ * It provides a generic way to get the value, whatever the actual column name is.
+ *
+ * @return int The nested set left value
+ */
+public function getLeftValue(): int
+{
+    return $this->tree_left ?: 0;
+}
+
+/**
+ * Proxy getter method for the right value of the nested set model.
+ * It provides a generic way to get the value, whatever the actual column name is.
+ *
+ * @return int The nested set right value
+ */
+public function getRightValue(): int
+{
+    return $this->tree_right ?: 0;
+}
+
+/**
+ * Proxy getter method for the level value of the nested set model.
+ * It provides a generic way to get the value, whatever the actual column name is.
+ *
+ * @return int The nested set level value
+ */
+public function getLevel(): int
+{
+    return $this->tree_level ?: 0;
+}
+
+/**
+ * Proxy setter method for the left value of the nested set model.
+ * It provides a generic way to set the value, whatever the actual column name is.
+ *
+ * @param int $v The nested set left value
+ * @return $this|ChildTable The current object (for fluent API support)
+ */
+public function setLeftValue($v)
+{
+    return $this->setTreeLeft($v);
+}
+
+/**
+ * Proxy setter method for the right value of the nested set model.
+ * It provides a generic way to set the value, whatever the actual column name is.
+ *
+ * @param int $v The nested set right value
+ *
+ * @return $this
+ */
+public function setRightValue(int $v)
+{
+    $this->setTreeRight($v);
+
+    return $this;
+}
+
+/**
+ * Proxy setter method for the level value of the nested set model.
+ * It provides a generic way to set the value, whatever the actual column name is.
+ *
+ * @param int $v The nested set level value
+ *
+ * @return $this
+ */
+public function setLevel(int $v)
+{
+    $this->setTreeLevel($v);
+
+    return $this;
+}
+
+/**
+ * Creates the supplied node as the root node.
+ *
+ * @return $this
+ *
+ * @throws     PropelException
+ */
+public function makeRoot()
+{
+    if ($this->getLeftValue() || $this->getRightValue()) {
+        throw new PropelException('Cannot turn an existing node into a root node.');
+    }
+
+    $this->setLeftValue(1);
+    $this->setRightValue(2);
+    $this->setLevel(0);
+
+    return $this;
+}
+
+/**
+ * Tests if object is a node, i.e. if it is inserted in the tree
+ *
+ * @return bool
+ */
+public function isInTree(): bool
+{
+    return $this->getLeftValue() > 0 && $this->getRightValue() > $this->getLeftValue();
+}
+
+/**
+ * Tests if node is a root
+ *
+ * @return bool
+ */
+public function isRoot(): bool
+{
+    return $this->isInTree() && $this->getLeftValue() == 1;
+}
+
+/**
+ * Tests if node is a leaf
+ *
+ * @return bool
+ */
+public function isLeaf(): bool
+{
+    return $this->isInTree() &&  ($this->getRightValue() - $this->getLeftValue()) == 1;
+}
+
+/**
+ * Tests if node is a descendant of another node
+ *
+ * @param ChildTable $parent Propel node object
+ *
+ * @return bool
+ */
+public function isDescendantOf(ChildTable $parent): bool
+{
+    return $this->isInTree() && $this->getLeftValue() > $parent->getLeftValue() && $this->getRightValue() < $parent->getRightValue();
+}
+
+/**
+ * Tests if node is a ancestor of another node
+ *
+ * @param ChildTable $child Propel node object
+ *
+ * @return bool
+ */
+public function isAncestorOf(ChildTable $child): bool
+{
+    return $child->isDescendantOf($this);
+}
+
+/**
+ * Tests if object has an ancestor
+ *
+ * @return bool
+ */
+public function hasParent(): bool
+{
+    return $this->getLevel() > 0;
+}
+
+/**
+ * Sets the cache for parent node of the current object.
+ * Warning: this does not move the current object in the tree.
+ * Use moveTofirstChildOf() or moveToLastChildOf() for that purpose
+ *
+ * @param ChildTable $parent
+ *
+ * @return $this
+ */
+public function setParent(?ChildTable $parent = null)
+{
+    $this->aNestedSetParent = $parent;
+
+    return $this;
+}
+
+/**
+ * Gets parent node for the current object if it exists
+ * The result is cached so further calls to the same method don't issue any queries
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ *
+ * @return ChildTable|null Propel object if exists else null
+ */
+public function getParent(?ConnectionInterface $con = null)
+{
+    if (null === $this->aNestedSetParent && $this->hasParent()) {
+        $this->aNestedSetParent = ChildTableQuery::create()
+            ->ancestorsOf($this)
+            ->orderByLevel(true)
+            ->findOne($con);
+    }
+
+    return $this->aNestedSetParent;
+}
+
+/**
+ * Determines if the node has previous sibling
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ *
+ * @return bool
+ */
+public function hasPrevSibling(?ConnectionInterface $con = null): bool
+{
+    if (!ChildTableQuery::isValid($this)) {
+        return false;
+    }
+
+    return ChildTableQuery::create()
+        ->filterByTreeRight($this->getLeftValue() - 1)
+        ->exists($con);
+}
+
+/**
+ * Gets previous sibling for the given node if it exists
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ *
+ * @return ChildTable|null         Propel object if exists else null
+ */
+public function getPrevSibling(?ConnectionInterface $con = null)
+{
+    return ChildTableQuery::create()
+        ->filterByTreeRight($this->getLeftValue() - 1)
+        ->findOne($con);
+}
+
+/**
+ * Determines if the node has next sibling
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ * @return bool
+ */
+public function hasNextSibling(?ConnectionInterface $con = null): bool
+{
+    if (!ChildTableQuery::isValid($this)) {
+        return false;
+    }
+
+    return ChildTableQuery::create()
+        ->filterByTreeLeft($this->getRightValue() + 1)
+        ->exists($con);
+}
+
+/**
+ * Gets next sibling for the given node if it exists
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ * @return ChildTable|null         Propel object if exists else null
+ */
+public function getNextSibling(?ConnectionInterface $con = null)
+{
+    return ChildTableQuery::create()
+        ->filterByTreeLeft($this->getRightValue() + 1)
+        ->findOne($con);
+}
+
+/**
+ * Clears out the $collNestedSetChildren collection
+ *
+ * This does not modify the database; however, it will remove any associated objects, causing
+ * them to be refetched by subsequent calls to accessor method.
+ *
+ * @return void
+ */
+public function clearNestedSetChildren(): void
+{
+    $this->collNestedSetChildren = null;
+}
+
+/**
+ * Initializes the $collNestedSetChildren collection.
+ *
+ * @return void
+ */
+public function initNestedSetChildren(): void
+{
+    $collectionClassName = \Map\TableTableMap::getTableMap()->getCollectionClassName();
+
+    $this->collNestedSetChildren = new $collectionClassName;
+    $this->collNestedSetChildren->setModel('\Table');
+}
+
+/**
+ * Adds an element to the internal $collNestedSetChildren collection.
+ * Beware that this doesn't insert a node in the tree.
+ * This method is only used to facilitate children hydration.
+ *
+ * @param ChildTable $table
+ *
+ * @return void
+ */
+public function addNestedSetChild(ChildTable $table): void
+{
+    if (null === $this->collNestedSetChildren) {
+        $this->initNestedSetChildren();
+    }
+    if (!in_array($table, $this->collNestedSetChildren->getArrayCopy(), true)) { // only add it if the **same** object is not already associated
+        $this->collNestedSetChildren[] = $table;
+        $table->setParent($this);
+    }
+}
+
+/**
+ * Tests if node has children
+ *
+ * @return bool
+ */
+public function hasChildren(): bool
+{
+    return ($this->getRightValue() - $this->getLeftValue()) > 1;
+}
+
+/**
+ * Gets the children of the given node
+ *
+ * @param \Propel\Runtime\ActiveQuery\Criteria $criteria Criteria to filter results.
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ *
+ * @return ObjectCollection|ChildTable[] List of ChildTable objects
+ */
+public function getChildren(?Criteria $criteria = null, ?ConnectionInterface $con = null)
+{
+    if (null === $this->collNestedSetChildren || null !== $criteria) {
+        if ($this->isLeaf() || ($this->isNew() && null === $this->collNestedSetChildren)) {
+            // return empty collection
+            $this->initNestedSetChildren();
+        } else {
+            $collNestedSetChildren = ChildTableQuery::create(null, $criteria)
+                ->childrenOf($this)
+                ->orderByBranch()
+                ->find($con);
+            if (null !== $criteria) {
+                return $collNestedSetChildren;
+            }
+            $this->collNestedSetChildren = $collNestedSetChildren;
+        }
+    }
+
+    return $this->collNestedSetChildren;
+}
+
+/**
+ * Gets number of children for the given node
+ *
+ * @param \Propel\Runtime\ActiveQuery\Criteria $criteria Criteria to filter results.
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ *
+ * @return int Number of children
+ */
+public function countChildren(?Criteria $criteria = null, ?ConnectionInterface $con = null)
+{
+    if (null === $this->collNestedSetChildren || null !== $criteria) {
+        if ($this->isLeaf() || ($this->isNew() && null === $this->collNestedSetChildren)) {
+            return 0;
+        } else {
+            return ChildTableQuery::create(null, $criteria)
+                ->childrenOf($this)
+                ->count($con);
+        }
+    } else {
+        return count($this->collNestedSetChildren);
+    }
+}
+
+/**
+ * Gets the first child of the given node
+ *
+ * @param \Propel\Runtime\ActiveQuery\Criteria $criteria Criteria to filter results.
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ *
+ * @return ChildTable|null First child or null if this is a leaf
+ */
+public function getFirstChild(?Criteria $criteria = null, ?ConnectionInterface $con = null)
+{
+    if ($this->isLeaf()) {
+        return null;
+    } else {
+        return ChildTableQuery::create(null, $criteria)
+            ->childrenOf($this)
+            ->orderByBranch()
+            ->findOne($con);
+    }
+}
+
+/**
+ * Gets the last child of the given node
+ *
+ * @param \Propel\Runtime\ActiveQuery\Criteria $criteria Criteria to filter results.
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ * @return ChildTable|null Last child or null if this is a leaf
+ */
+public function getLastChild(?Criteria $criteria = null, ?ConnectionInterface $con = null)
+{
+    if ($this->isLeaf()) {
+        return null;
+    } else {
+        return ChildTableQuery::create(null, $criteria)
+            ->childrenOf($this)
+            ->orderByBranch(true)
+            ->findOne($con);
+    }
+}
+
+/**
+ * Gets the siblings of the given node
+ *
+ * @param bool $includeNode Whether to include the current node or not
+ * @param \Propel\Runtime\ActiveQuery\Criteria $criteria Criteria to filter results.
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ *
+ * @return ObjectCollection|ChildTable[] List of ChildTable objects
+ */
+public function getSiblings($includeNode = false, ?Criteria $criteria = null, ?ConnectionInterface $con = null)
+{
+    if ($this->isRoot()) {
+        return [];
+    } else {
+        $query = ChildTableQuery::create(null, $criteria)
+            ->childrenOf($this->getParent($con))
+            ->orderByBranch();
+        if (!$includeNode) {
+            $query->prune($this);
+        }
+
+        return $query->find($con);
+    }
+}
+
+/**
+ * Gets descendants for the given node
+ *
+ * @param \Propel\Runtime\ActiveQuery\Criteria $criteria Criteria to filter results.
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ * @return ObjectCollection|ChildTable[] List of ChildTable objects
+ */
+public function getDescendants(?Criteria $criteria = null, ?ConnectionInterface $con = null)
+{
+    if ($this->isLeaf()) {
+        return [];
+    } else {
+        return ChildTableQuery::create(null, $criteria)
+            ->descendantsOf($this)
+            ->orderByBranch()
+            ->find($con);
+    }
+}
+
+/**
+ * Gets number of descendants for the given node
+ *
+ * @param \Propel\Runtime\ActiveQuery\Criteria $criteria Criteria to filter results.
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ *
+ * @return int Number of descendants
+ */
+public function countDescendants(?Criteria $criteria = null, ?ConnectionInterface $con = null)
+{
+    if ($this->isLeaf()) {
+        // save one query
+        return 0;
+    } else {
+        return ChildTableQuery::create(null, $criteria)
+            ->descendantsOf($this)
+            ->count($con);
+    }
+}
+
+/**
+ * Gets descendants for the given node, plus the current node
+ *
+ * @param \Propel\Runtime\ActiveQuery\Criteria $criteria Criteria to filter results.
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ * @return ObjectCollection|ChildTable[] List of ChildTable objects
+ */
+public function getBranch(?Criteria $criteria = null, ?ConnectionInterface $con = null)
+{
+    return ChildTableQuery::create(null, $criteria)
+        ->branchOf($this)
+        ->orderByBranch()
+        ->find($con);
+}
+
+/**
+ * Gets ancestors for the given node, starting with the root node
+ * Use it for breadcrumb paths for instance
+ *
+ * @param \Propel\Runtime\ActiveQuery\Criteria $criteria Criteria to filter results.
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ * @return ObjectCollection|ChildTable[] List of ChildTable objects
+ */
+public function getAncestors(?Criteria $criteria = null, ?ConnectionInterface $con = null)
+{
+    if ($this->isRoot()) {
+        // save one query
+        return [];
+    } else {
+        return ChildTableQuery::create(null, $criteria)
+            ->ancestorsOf($this)
+            ->orderByBranch()
+            ->find($con);
+    }
+}
+
+/**
+ * Inserts the given $child node as first child of current
+ * The modifications in the current object and the tree
+ * are not persisted until the child object is saved.
+ *
+ * @param ChildTable $child    Propel object for child node
+ *
+ * @return $this The current Propel object
+ */
+public function addChild(ChildTable $child)
+{
+    if ($this->isNew()) {
+        throw new PropelException('A ChildTable object must not be new to accept children.');
+    }
+    $child->insertAsFirstChildOf($this);
+
+    return $this;
+}
+
+/**
+ * Inserts the current node as first child of given $parent node
+ * The modifications in the current object and the tree
+ * are not persisted until the current object is saved.
+ *
+ * @param ChildTable $parent    Propel object for parent node
+ *
+ * @return $this The current Propel object
+ */
+public function insertAsFirstChildOf(ChildTable $parent)
+{
+    if ($this->isInTree()) {
+        throw new PropelException('A ChildTable object must not already be in the tree to be inserted. Use the moveToFirstChildOf() instead.');
+    }
+    $left = $parent->getLeftValue() + 1;
+    // Update node properties
+    $this->setLeftValue($left);
+    $this->setRightValue($left + 1);
+    $this->setLevel($parent->getLevel() + 1);
+    // update the children collection of the parent
+    $parent->addNestedSetChild($this);
+
+    // Keep the tree modification query for the save() transaction
+    $this->nestedSetQueries[] = [
+        'callable'  => array('\TableQuery', 'makeRoomForLeaf'),
+        'arguments' => array($left, $this->isNew() ? null : $this)
+    ];
+
+    return $this;
+}
+
+/**
+ * Inserts the current node as last child of given $parent node
+ * The modifications in the current object and the tree
+ * are not persisted until the current object is saved.
+ *
+ * @param ChildTable $parent Propel object for parent node
+ * @return $this|ChildTable The current Propel object
+ */
+public function insertAsLastChildOf(ChildTable $parent)
+{
+    if ($this->isInTree()) {
+        throw new PropelException(
+            'A ChildTable object must not already be in the tree to be inserted. Use the moveToLastChildOf() instead.'
+        );
+    }
+
+    $left = $parent->getRightValue();
+    // Update node properties
+    $this->setLeftValue($left);
+    $this->setRightValue($left + 1);
+    $this->setLevel($parent->getLevel() + 1);
+
+    // update the children collection of the parent
+    $parent->addNestedSetChild($this);
+
+    // Keep the tree modification query for the save() transaction
+    $this->nestedSetQueries []= [
+        'callable'  => ['\TableQuery', 'makeRoomForLeaf'],
+        'arguments' => [$left, $this->isNew() ? null : $this],
+    ];
+
+    return $this;
+}
+
+/**
+ * Inserts the current node as prev sibling given $sibling node
+ * The modifications in the current object and the tree
+ * are not persisted until the current object is saved.
+ *
+ * @param ChildTable $sibling    Propel object for parent node
+ *
+ * @return $this The current Propel object
+ */
+public function insertAsPrevSiblingOf(ChildTable $sibling)
+{
+    if ($this->isInTree()) {
+        throw new PropelException('A ChildTable object must not already be in the tree to be inserted. Use the moveToPrevSiblingOf() instead.');
+    }
+    $left = $sibling->getLeftValue();
+    // Update node properties
+    $this->setLeftValue($left);
+    $this->setRightValue($left + 1);
+    $this->setLevel($sibling->getLevel());
+    // Keep the tree modification query for the save() transaction
+    $this->nestedSetQueries [] = [
+        'callable'  => array('\TableQuery', 'makeRoomForLeaf'),
+        'arguments' => array($left, $this->isNew() ? null : $this)
+    ];
+
+    return $this;
+}
+
+/**
+ * Inserts the current node as next sibling given $sibling node
+ * The modifications in the current object and the tree
+ * are not persisted until the current object is saved.
+ *
+ * @param ChildTable $sibling    Propel object for parent node
+ *
+ * @return $this The current Propel object
+ */
+public function insertAsNextSiblingOf(ChildTable $sibling)
+{
+    if ($this->isInTree()) {
+        throw new PropelException('A ChildTable object must not already be in the tree to be inserted. Use the moveToNextSiblingOf() instead.');
+    }
+    $left = $sibling->getRightValue() + 1;
+    // Update node properties
+    $this->setLeftValue($left);
+    $this->setRightValue($left + 1);
+    $this->setLevel($sibling->getLevel());
+    // Keep the tree modification query for the save() transaction
+    $this->nestedSetQueries [] = [
+        'callable'  => ['\TableQuery', 'makeRoomForLeaf'],
+        'arguments' => [$left, $this->isNew() ? null : $this],
+    ];
+
+    return $this;
+}
+
+/**
+ * Moves current node and its subtree to be the first child of $parent
+ * The modifications in the current object and the tree are immediate
+ *
+ * @param ChildTable $parent    Propel object for parent node
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ *
+ * @return $this The current Propel object
+ */
+public function moveToFirstChildOf(ChildTable $parent, ?ConnectionInterface $con = null)
+{
+    if (!$this->isInTree()) {
+        throw new PropelException('A ChildTable object must be already in the tree to be moved. Use the insertAsFirstChildOf() instead.');
+    }
+    if ($parent->isDescendantOf($this)) {
+        throw new PropelException('Cannot move a node as child of one of its subtree nodes.');
+    }
+
+    $this->moveSubtreeTo($parent->getLeftValue() + 1, $parent->getLevel() - $this->getLevel() + 1, $con);
+
+    return $this;
+}
+
+/**
+ * Moves current node and its subtree to be the last child of $parent
+ * The modifications in the current object and the tree are immediate
+ *
+ * @param ChildTable $parent    Propel object for parent node
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ *
+ * @return $this The current Propel object
+ */
+public function moveToLastChildOf(ChildTable $parent, ?ConnectionInterface $con = null)
+{
+    if (!$this->isInTree()) {
+        throw new PropelException('A ChildTable object must be already in the tree to be moved. Use the insertAsLastChildOf() instead.');
+    }
+    if ($parent->isDescendantOf($this)) {
+        throw new PropelException('Cannot move a node as child of one of its subtree nodes.');
+    }
+
+    $this->moveSubtreeTo($parent->getRightValue(), $parent->getLevel() - $this->getLevel() + 1, $con);
+
+    return $this;
+}
+
+/**
+ * Moves current node and its subtree to be the previous sibling of $sibling
+ * The modifications in the current object and the tree are immediate
+ *
+ * @param ChildTable $sibling    Propel object for sibling node
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ *
+ * @return $this The current Propel object
+ */
+public function moveToPrevSiblingOf(ChildTable $sibling, ?ConnectionInterface $con = null)
+{
+    if (!$this->isInTree()) {
+        throw new PropelException('A ChildTable object must be already in the tree to be moved. Use the insertAsPrevSiblingOf() instead.');
+    }
+    if ($sibling->isRoot()) {
+        throw new PropelException('Cannot move to previous sibling of a root node.');
+    }
+    if ($sibling->isDescendantOf($this)) {
+        throw new PropelException('Cannot move a node as sibling of one of its subtree nodes.');
+    }
+
+    $this->moveSubtreeTo($sibling->getLeftValue(), $sibling->getLevel() - $this->getLevel(), $con);
+
+    return $this;
+}
+
+/**
+ * Moves current node and its subtree to be the next sibling of $sibling
+ * The modifications in the current object and the tree are immediate
+ *
+ * @param ChildTable $sibling    Propel object for sibling node
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ *
+ * @return $this The current Propel object
+ */
+public function moveToNextSiblingOf(ChildTable $sibling, ?ConnectionInterface $con = null)
+{
+    if (!$this->isInTree()) {
+        throw new PropelException('A ChildTable object must be already in the tree to be moved. Use the insertAsNextSiblingOf() instead.');
+    }
+    if ($sibling->isRoot()) {
+        throw new PropelException('Cannot move to next sibling of a root node.');
+    }
+    if ($sibling->isDescendantOf($this)) {
+        throw new PropelException('Cannot move a node as sibling of one of its subtree nodes.');
+    }
+
+    $this->moveSubtreeTo($sibling->getRightValue() + 1, $sibling->getLevel() - $this->getLevel(), $con);
+
+    return $this;
+}
+
+/**
+ * Move current node and its children to location $destLeft and updates rest of tree
+ *
+ * @param int $destLeft Destination left value
+ * @param int $levelDelta Delta to add to the levels
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ */
+protected function moveSubtreeTo($destLeft, $levelDelta, ?ConnectionInterface $con = null)
+{
+    $left  = $this->getLeftValue();
+    $right = $this->getRightValue();
+
+    $treeSize = $right - $left +1;
+
+    if (null === $con) {
+        $con = Propel::getServiceContainer()->getWriteConnection(TableTableMap::DATABASE_NAME);
+    }
+
+    $con->transaction(function () use ($con, $treeSize, $destLeft, $left, $right, $levelDelta) {
+        $preventDefault = false;
+
+        // make room next to the target for the subtree
+        ChildTableQuery::shiftRLValues($treeSize, $destLeft, null, $con);
+
+        if (!$preventDefault) {
+
+            if ($left >= $destLeft) { // src was shifted too?
+                $left += $treeSize;
+                $right += $treeSize;
+            }
+
+            if ($levelDelta) {
+                // update the levels of the subtree
+                ChildTableQuery::shiftLevel($levelDelta, $left, $right, $con);
+            }
+
+            // move the subtree to the target
+            ChildTableQuery::shiftRLValues($destLeft - $left, $left, $right, $con);
+        }
+
+        // remove the empty room at the previous location of the subtree
+        ChildTableQuery::shiftRLValues(-$treeSize, $right + 1, null, $con);
+
+        // update all loaded nodes
+        ChildTableQuery::updateLoadedNodes(null, $con);
+    });
+}
+
+/**
+ * Deletes all descendants for the given node
+ * Instance pooling is wiped out by this command,
+ * so existing ChildTable instances are probably invalid (except for the current one)
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ *
+ * @return int number of deleted nodes
+ */
+public function deleteDescendants(?ConnectionInterface $con = null)
+{
+    if ($this->isLeaf()) {
+        // save one query
+        return;
+    }
+    if (null === $con) {
+        $con = Propel::getServiceContainer()->getReadConnection(TableTableMap::DATABASE_NAME);
+    }
+    $left = $this->getLeftValue();
+    $right = $this->getRightValue();
+
+    return $con->transaction(function () use ($con, $left, $right) {
+        // delete descendant nodes (will empty the instance pool)
+        $ret = ChildTableQuery::create()
+            ->descendantsOf($this)
+            ->delete($con);
+
+        // fill up the room that was used by descendants
+        ChildTableQuery::shiftRLValues($left - $right + 1, $right, null, $con);
+
+        // fix the right value for the current node, which is now a leaf
+        $this->setRightValue($left + 1);
+
+        return $ret;
+    });
+}
+
+/**
+ * Returns a pre-order iterator for this node and its children.
+ *
+ * @return NestedSetRecursiveIterator
+ */
+public function getIterator()
+{
+    return new NestedSetRecursiveIterator($this);
+}
+
+
+objectAttributes:
+
+// nested_set behavior
+
+/**
+ * Queries to be executed in the save transaction
+ *
+ * @var array
+ */
+protected $nestedSetQueries = [];
+
+/**
+ * Internal cache for children nodes
+ *
+ * @var  null|ObjectCollection
+ */
+protected $collNestedSetChildren = null;
+
+/**
+ * Internal cache for parent node
+ *
+ * @var  null|ChildTable
+ */
+protected $aNestedSetParent = null;
+
+/**
+ * Left column for the set
+ */
+const LEFT_COL = 'table.tree_left';
+
+/**
+ * Right column for the set
+ */
+const RIGHT_COL = 'table.tree_right';
+
+/**
+ * Level column for the set
+ */
+const LEVEL_COL = 'table.tree_level';
+
+
+preDelete:
+
+// nested_set behavior
+if ($this->isRoot()) {
+    throw new PropelException('Deletion of a root node is disabled for nested sets. Use `ChildTableQuery::deleteTree()` instead to delete an entire tree');
+}
+
+if ($this->isInTree()) {
+    $this->deleteDescendants($con);
+}
+
+
+postDelete:
+
+// nested_set behavior
+if ($this->isInTree()) {
+    // fill up the room that was used by the node
+    ChildTableQuery::shiftRLValues(-2, $this->getRightValue() + 1, null, $con);
+}
+
+
+preSave:
+
+// nested_set behavior
+if ($this->isNew() && $this->isRoot()) {
+    // check if no other root exist in, the tree
+    $rootExists = ChildTableQuery::create()
+        ->addUsingOperator(ChildTable::LEFT_COL, 1, Criteria::EQUAL)
+        ->exists($con);
+    if ($rootExists) {
+            throw new PropelException('A root node already exists in this tree. To allow multiple root nodes, add the `use_scope` parameter in the nested_set behavior tag.');
+    }
+}
+$this->processNestedSetQueries($con);
+
+objectClearReferences:
+
+// nested_set behavior
+$this->collNestedSetChildren = null;
+$this->aNestedSetParent = null;

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/nested_set---query_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/nested_set---query_reference.txt
@@ -1,0 +1,423 @@
+
+
+queryMethods:
+
+// nested_set behavior
+
+/**
+ * Filter the query to restrict the result to descendants of an object
+ *
+ * @param ChildTable $table The object to use for descendant search
+ *
+ * @return $this
+ */
+public function descendantsOf(ChildTable $table)
+{
+    $leftColumn = $this->resolveLocalColumnByName('tree_left');
+    $this
+        ->addUsingOperator($leftColumn, $table->getLeftValue(), Criteria::GREATER_THAN)
+        ->addUsingOperator($leftColumn, $table->getRightValue(), Criteria::LESS_THAN);
+
+    return $this;
+}
+
+/**
+ * Filter the query to restrict the result to the branch of an object.
+ * Same as descendantsOf(), except that it includes the object passed as parameter in the result
+ *
+ * @param ChildTable $table The object to use for branch search
+ *
+ * @return $this
+ */
+public function branchOf(ChildTable $table)
+{
+    $leftColumn = $this->resolveLocalColumnByName('tree_left');
+    $this
+        ->addUsingOperator($leftColumn, $table->getLeftValue(), Criteria::GREATER_EQUAL)
+        ->addUsingOperator($leftColumn, $table->getRightValue(), Criteria::LESS_EQUAL);
+
+    return $this;
+}
+
+/**
+ * Filter the query to restrict the result to children of an object
+ *
+ * @param ChildTable $table The object to use for child search
+ *
+ * @return $this
+ */
+public function childrenOf(ChildTable $table)
+{
+    $this
+        ->descendantsOf($table)
+        ->addUsingOperator($this->resolveLocalColumnByName('tree_level'), $table->getLevel() + 1, Criteria::EQUAL);
+
+    return $this;
+}
+
+/**
+ * Filter the query to restrict the result to siblings of an object.
+ * The result does not include the object passed as parameter.
+ *
+ * @param ChildTable $table The object to use for sibling search
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ *
+ * @return $this
+ */
+public function siblingsOf(ChildTable $table, ?ConnectionInterface $con = null)
+{
+    if ($table->isRoot()) {
+        $this->
+            add(ChildTable::LEVEL_COL, '1<>1', Criteria::CUSTOM);
+    } else {
+        $this
+            ->childrenOf($table->getParent($con))
+            ->prune($table);
+    }
+
+    return $this;
+}
+
+/**
+ * Filter the query to restrict the result to ancestors of an object
+ *
+ * @param ChildTable $table The object to use for ancestors search
+ *
+ * @return $this
+ */
+public function ancestorsOf(ChildTable $table)
+{
+    $this
+        ->addUsingOperator($this->resolveLocalColumnByName('tree_left'), $table->getLeftValue(), Criteria::LESS_THAN)
+        ->addUsingOperator($this->resolveLocalColumnByName('tree_right'), $table->getRightValue(), Criteria::GREATER_THAN);
+
+    return $this;
+}
+
+/**
+ * Filter the query to restrict the result to roots of an object.
+ * Same as ancestorsOf(), except that it includes the object passed as parameter in the result
+ *
+ * @param ChildTable $table The object to use for roots search
+ *
+ * @return $this
+ */
+public function rootsOf(ChildTable $table)
+{
+    $this
+        ->addUsingOperator($this->resolveLocalColumnByName('tree_left'), $table->getLeftValue(), Criteria::LESS_EQUAL)
+        ->addUsingOperator($this->resolveLocalColumnByName('tree_right'), $table->getRightValue(), Criteria::GREATER_EQUAL);
+
+    return $this;
+}
+
+/**
+ * Order the result by branch, i.e. natural tree order
+ *
+ * @param bool $reverse if true, reverses the order
+ *
+ * @return $this
+ */
+public function orderByBranch($reverse = false)
+{
+    if ($reverse) {
+        $this
+            ->addDescendingOrderByColumn(ChildTable::LEFT_COL);
+    } else {
+        $this
+            ->addAscendingOrderByColumn(ChildTable::LEFT_COL);
+    }
+
+    return $this;
+}
+
+/**
+ * Order the result by level, the closer to the root first
+ *
+ * @param bool $reverse if true, reverses the order
+ *
+ * @return $this
+ */
+public function orderByLevel($reverse = false)
+{
+    if ($reverse) {
+        $this
+            ->addDescendingOrderByColumn(ChildTable::LEVEL_COL)
+            ->addDescendingOrderByColumn(ChildTable::LEFT_COL);
+    } else {
+        $this
+            ->addAscendingOrderByColumn(ChildTable::LEVEL_COL)
+            ->addAscendingOrderByColumn(ChildTable::LEFT_COL);
+    }
+
+    return $this;
+}
+
+/**
+ * Returns the root node for the tree
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ *
+ * @return ChildTable The tree root object
+ */
+public function findRoot(?ConnectionInterface $con = null)
+{
+    return $this
+        ->addUsingOperator($this->resolveLocalColumnByName('tree_left'), 1, Criteria::EQUAL)
+        ->findOne($con);
+}
+
+/**
+ * Returns the tree of objects
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ *
+ * @return ChildTable[]|ObjectCollection|mixed the list of results, formatted by the current formatter
+ */
+public function findTree(?ConnectionInterface $con = null)
+{
+    return $this
+        ->orderByBranch()
+        ->find($con);
+}
+
+/**
+ * Returns the root node for a given scope
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ *
+ * @return ChildTable            Propel object for root node
+ */
+static public function retrieveRoot(?ConnectionInterface $con = null)
+{
+    $query = new Criteria(TableTableMap::DATABASE_NAME);
+    $query->addAnd(ChildTable::LEFT_COL, 1, Criteria::EQUAL);
+
+    return ChildTableQuery::create(null, $query)->findOne($con);
+}
+
+/**
+ * Returns the whole tree node for a given scope
+ *
+ * @param \Propel\Runtime\ActiveQuery\Criteria $query    Optional Criteria to filter the query
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ *
+ * @return ChildTable[]|ObjectCollection|mixed the list of results, formatted by the current formatter
+ */
+static public function retrieveTree(?Criteria $query = null, ?ConnectionInterface $con = null)
+{
+    if (null === $query) {
+        $query = new Criteria(TableTableMap::DATABASE_NAME);
+    }
+    $query->addAscendingOrderByColumn(ChildTable::LEFT_COL);
+
+    return ChildTableQuery::create(null, $query)->find($con);
+}
+
+/**
+ * Tests if node is valid
+ *
+ * @param ChildTable $node    Propel object for src node
+ *
+ * @return bool
+ */
+static public function isValid(?ChildTable $node = null)
+{
+    if (is_object($node) && $node->getRightValue() > $node->getLeftValue()) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+/**
+ * Delete an entire tree
+ * 
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ *
+ * @return int The number of deleted nodes
+ */
+static public function deleteTree(?ConnectionInterface $con = null)
+{
+
+    return TableTableMap::doDeleteAll($con);
+}
+
+/**
+ * Adds $delta to all L and R values that are >= $first and <= $last.
+ * '$delta' can also be negative.
+ *
+ * @param int $delta               Value to be shifted by, can be negative
+ * @param int $first               First node to be shifted
+ * @param int $last                Last node to be shifted (optional)
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ *
+ * @return void
+ */
+static public function shiftRLValues($delta, $first, $last = null, ?ConnectionInterface $con = null)
+{
+    if ($con === null) {
+        $con = Propel::getServiceContainer()->getWriteConnection(TableTableMap::DATABASE_NAME);
+    }
+
+    // Shift left column values
+    $updateQuery = new Criteria(TableTableMap::DATABASE_NAME);
+    $criterion = $updateQuery->getNewCriterion(ChildTable::LEFT_COL, $first, Criteria::GREATER_EQUAL);
+    if (null !== $last) {
+        $criterion->addAnd($updateQuery->getNewCriterion(ChildTable::LEFT_COL, $last, Criteria::LESS_EQUAL));
+    }
+    $updateQuery->addAnd($criterion);
+
+    $updateQuery->setUpdateExpression(ChildTable::LEFT_COL, ChildTable::LEFT_COL . ' + ?', $delta, \PDO::PARAM_INT);
+
+    $updateQuery->doUpdate(null, $con);
+
+    // Shift right column values
+    $updateQuery = new Criteria(TableTableMap::DATABASE_NAME);
+    $criterion = $updateQuery->getNewCriterion(ChildTable::RIGHT_COL, $first, Criteria::GREATER_EQUAL);
+    if (null !== $last) {
+        $criterion->addAnd($updateQuery->getNewCriterion(ChildTable::RIGHT_COL, $last, Criteria::LESS_EQUAL));
+    }
+    $updateQuery->addAnd($criterion);
+
+    $updateQuery->setUpdateExpression(ChildTable::RIGHT_COL, ChildTable::RIGHT_COL . ' + ?', $delta, \PDO::PARAM_STR);
+
+    $updateQuery->doUpdate(null, $con);
+}
+
+/**
+ * Adds $delta to level for nodes having left value >= $first and right value <= $last.
+ * '$delta' can also be negative.
+ *
+ * @param int $delta        Value to be shifted by, can be negative
+ * @param int $first        First node to be shifted
+ * @param int $last            Last node to be shifted
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ *
+ * @return void
+ */
+static public function shiftLevel($delta, $first, $last, ?ConnectionInterface $con = null)
+{
+    if ($con === null) {
+        $con = Propel::getServiceContainer()->getWriteConnection(TableTableMap::DATABASE_NAME);
+    }
+
+    $updateQuery = new Criteria(TableTableMap::DATABASE_NAME);
+    $updateQuery->addAnd(ChildTable::LEFT_COL, $first, Criteria::GREATER_EQUAL);
+    $updateQuery->addAnd(ChildTable::RIGHT_COL, $last, Criteria::LESS_EQUAL);
+
+    $updateQuery->setUpdateExpression(ChildTable::LEVEL_COL, ChildTable::LEVEL_COL . ' + ?', $delta, \PDO::PARAM_INT);
+
+    $updateQuery->doUpdate(null, $con);
+}
+
+/**
+ * Reload all already loaded nodes to sync them with updated db
+ *
+ * @param ChildTable $prune Object to prune from the update
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ *
+ * @return void
+ */
+static public function updateLoadedNodes($prune = null, ?ConnectionInterface $con = null)
+{
+    if (Propel::isInstancePoolingEnabled()) {
+        $keys = [];
+        /** @var $obj ChildTable */
+        foreach (TableTableMap::$instances as $obj) {
+            if (!$prune || !$prune->equals($obj)) {
+                $keys[] = $obj->getPrimaryKey();
+            }
+        }
+
+        if (!empty($keys)) {
+            // We don't need to alter the object instance pool; we're just modifying these ones
+            // already in the pool.
+            $query = new Criteria(TableTableMap::DATABASE_NAME);
+            $query->addAnd(TableTableMap::COL_ID, $keys, Criteria::IN);
+            $dataFetcher = ChildTableQuery::create(null, $query)->fetch($con);
+            while ($row = $dataFetcher->fetch()) {
+                $key = TableTableMap::getPrimaryKeyHashFromRow($row, 0);
+                /** @var $object ChildTable */
+                if (null !== ($object = TableTableMap::getInstanceFromPool($key))) {
+                    $object->setLeftValue($row[2]);
+                    $object->setRightValue($row[3]);
+                    $object->setLevel($row[4]);
+                    $object->clearNestedSetChildren();
+                }
+            }
+            $dataFetcher->close();
+        }
+    }
+}
+
+/**
+ * Update the tree to allow insertion of a leaf at the specified position
+ *
+ * @param int $left    left column value
+ * @param mixed $prune    Object to prune from the shift
+ * @param \Propel\Runtime\Connection\ConnectionInterface|null $con Connection to use.
+ *
+ * @return void
+ */
+static public function makeRoomForLeaf($left, $prune = null, ?ConnectionInterface $con = null)
+{
+    // Update database nodes
+    ChildTableQuery::shiftRLValues(2, $left, null, $con);
+
+    // Update all loaded nodes
+    ChildTableQuery::updateLoadedNodes($prune, $con);
+}
+
+/**
+ * Update the tree to allow insertion of a leaf at the specified position
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface|null $con Connection to use.
+ *
+ * @return void
+ */
+static public function fixLevels(?ConnectionInterface $con = null): void
+{
+    $query = new Criteria();
+    $query->addAscendingOrderByColumn(ChildTable::LEFT_COL);
+    $dataFetcher = ChildTableQuery::create(null, $query)->fetch($con);
+    
+    // set the class once to avoid overhead in the loop
+    $cls = TableTableMap::getOMClass(false);
+    $level = null;
+    // iterate over the statement
+    while ($row = $dataFetcher->fetch()) {
+
+        // hydrate object
+        $key = TableTableMap::getPrimaryKeyHashFromRow($row, 0);
+        /** @var $obj ChildTable */
+        if (null === ($obj = TableTableMap::getInstanceFromPool($key))) {
+            $obj = new $cls();
+            $obj->hydrate($row);
+            TableTableMap::addInstanceToPool($obj, $key);
+            
+        }
+
+        // compute level
+        // Algorithm shamelessly stolen from sfPropelActAsNestedSetBehaviorPlugin
+        // Probably authored by Tristan Rivoallan
+        if ($level === null) {
+            $level = 0;
+            $i = 0;
+            $prev = [$obj->getRightValue()];
+        } else {
+            while ($obj->getRightValue() > $prev[$i]) {
+                $i--;
+            }
+            $level = ++$i;
+            $prev[$i] = $obj->getRightValue();
+        }
+
+        // update level in node if necessary
+        if ($obj->getLevel() !== $level) {
+            $obj->setLevel($level);
+            $obj->save($con);
+        }
+    }
+    $dataFetcher->close();
+}

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/output_group---object_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/output_group---object_reference.txt
@@ -1,0 +1,51 @@
+
+
+objectMethods:
+
+// output_group behavior
+
+/**
+ * Export subset of object fields as specified by output group.
+ *
+ * @param string|array<string,string> $outputGroup  Name of the output group used for all tables or 
+ *                                                  an array mapping model classes to output group name.
+ *                                                  If a model class does not have a definition for the
+ *                                                  given output group, the whole data is returned.
+ * @param string $keyType (optional) One of the class type constants TableMap::TYPE_PHPNAME,
+ *                                        TableMap::TYPE_CAMELNAME, TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME,
+ *                                        TableMap::TYPE_NUM. Defaults to TableMap::TYPE_PHPNAME.
+ * @param array $alreadyDumpedObjects   Internally used on recursion, typically not set by user (List of 
+ *                                      objects to skip to avoid recursion).
+ * @return array
+ */
+public function toOutputGroup(
+    $outputGroup,
+    string $keyType = TableMap::TYPE_PHPNAME,
+    array $alreadyDumpedObjects = []
+): array
+{
+    if (isset($alreadyDumpedObjects['Table'][$this->hashCode()])) {
+        return ['*RECURSION*'];
+    }
+    $alreadyDumpedObjects['Table'][$this->hashCode()] = true;
+    $keys = TableTableMap::getFieldNames($keyType);
+    $outputGroupName = is_string($outputGroup) ? $outputGroup : $outputGroup[get_class($this)] ?? $outputGroup['default'] ?? '';
+    [
+        'column_index' => $columnIndexes, 
+        'relation' => $relationsLookup
+    ] = TableTableMap::getOutputGroupData($outputGroupName);
+    $result = [];
+
+    foreach($columnIndexes as $columnIndex){
+        $columnName = $keys[$columnIndex];
+        $columnValue = $this->getByPosition($columnIndex);
+        $result[$columnName] = $columnValue;
+    }
+
+    $virtualColumns = $this->virtualColumns;
+    foreach ($virtualColumns as $key => $virtualColumn) {
+        $result[$key] = $virtualColumn;
+    }
+
+    return $result;
+}

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/output_group---tablemap_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/output_group---tablemap_reference.txt
@@ -1,0 +1,64 @@
+
+
+staticAttributes:
+
+// output_group behavior
+/**
+ * Output group definitions.
+ *
+ * @var array<string, array{'column_index': array<int>, 'relation': array<int>}>
+ */
+protected static $outputGroups = [
+    'group1' => [
+        'column_index' => [2, 3],
+        'relation' => [
+        ],
+    ],
+    'group2' => [
+        'column_index' => [1, 3],
+        'relation' => [
+        ],
+    ],
+];
+
+
+staticMethods:
+
+// output_group behavior
+/**
+ * Get column indexes for the given output group name.
+ *
+ * @param string|array<string> $outputGroupName Name of the output group as specified in schema.xml. Can be array of output group names.
+ *
+ * @return array<string, array{'column_index': array<int>, 'relation': array<int>|null}>
+ */
+public static function getOutputGroupData($outputGroupName): array
+{
+    if (is_string($outputGroupName) ){
+        return self::$outputGroups[$outputGroupName] ?? [
+            'column_index' => self::$fieldKeys[self::TYPE_NUM],
+            'relation' => null,
+        ];
+    }
+
+    $columnIndex = [];
+    $relation = [];
+    foreach ($outputGroupName as $groupName) {
+        if (!isset(self::$outputGroups[$groupName])) {
+            continue;
+        }
+        $groupData = self::$outputGroups[$groupName];
+        array_push($columnIndex, ...$groupData['column_index']);
+        $relation = array_merge($relation, $groupData['relation']);
+    }
+    $columnIndex = array_unique($columnIndex, SORT_NUMERIC);
+    sort($columnIndex);
+
+    return ($columnIndex || $relation) ? [
+        'column_index' => $columnIndex,
+        'relation' => $relation,
+    ]: [
+        'column_index' => self::$fieldKeys[self::TYPE_NUM],
+        'relation' => null,
+    ];
+}

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/query_cache---query_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/query_cache---query_reference.txt
@@ -1,0 +1,142 @@
+
+
+queryAttributes:
+
+// query_cache behavior
+protected $queryKey = '';
+protected static $cacheBackend;
+            
+
+queryAttributes:
+
+// query_cache behavior
+protected $queryKey = '';
+protected static $cacheBackend;
+            
+
+queryMethods:
+
+// query_cache behavior
+
+public function setQueryKey($key)
+{
+    $this->queryKey = $key;
+
+    return $this;
+}
+
+public function getQueryKey()
+{
+    return $this->queryKey;
+}
+
+public function cacheContains($key)
+{
+
+    return isset(self::$cacheBackend[$key]);
+}
+
+public function cacheFetch($key)
+{
+
+    return isset(self::$cacheBackend[$key]) ? self::$cacheBackend[$key] : null;
+}
+
+public function cacheStore($key, $value, $lifetime = 3600)
+{
+    self::$cacheBackend[$key] = $value;
+}
+
+public function doSelect(?ConnectionInterface $con = null): \Propel\Runtime\DataFetcher\DataFetcherInterface
+{
+    // check that the columns of the main class are already added (if this is the primary ModelCriteria)
+    if (!$this->hasSelectClause() && !$this->getPrimaryCriteria()) {
+        $this->addSelfSelectColumns();
+    }
+    $this->configureSelectColumns();
+
+    $dbMap = Propel::getServiceContainer()->getDatabaseMap(TableTableMap::DATABASE_NAME);
+    $db = Propel::getServiceContainer()->getAdapter(TableTableMap::DATABASE_NAME);
+
+    $key = $this->getQueryKey();
+    if ($key && $this->cacheContains($key)) {
+        $params = $this->getParams();
+        $sql = $this->cacheFetch($key);
+    } else {
+        $params = [];
+        $sql = $this->createSelectSql($params);
+    }
+
+    try {
+        $stmt = $con->prepare($sql);
+        $db->bindValues($stmt, $params, $dbMap);
+        $stmt->execute();
+        } catch (Exception $e) {
+            Propel::log($e->getMessage(), Propel::LOG_ERR);
+            throw new PropelException(sprintf('Unable to execute SELECT statement [%s]', $sql), 0, $e);
+        }
+
+    if ($key && !$this->cacheContains($key)) {
+            $this->cacheStore($key, $sql);
+    }
+
+    return $con->getDataFetcher($stmt);
+}
+
+public function doCount(?ConnectionInterface $con = null): \Propel\Runtime\DataFetcher\DataFetcherInterface
+{
+    $dbMap = Propel::getServiceContainer()->getDatabaseMap($this->getDbName());
+    $db = Propel::getServiceContainer()->getAdapter($this->getDbName());
+
+    $key = $this->getQueryKey();
+    if ($key && $this->cacheContains($key)) {
+        $params = $this->getParams();
+        $sql = $this->cacheFetch($key);
+    } else {
+        // check that the columns of the main class are already added (if this is the primary ModelCriteria)
+        if (!$this->hasSelectClause() && !$this->getPrimaryCriteria()) {
+            $this->addSelfSelectColumns();
+        }
+
+        $this->configureSelectColumns();
+
+        $needsComplexCount = $this->getGroupByColumns()
+            || $this->getOffset()
+            || $this->getLimit() >= 0
+            || $this->getHaving()
+            || in_array(Criteria::DISTINCT, $this->getSelectModifiers())
+            || count($this->selectQueries) > 0
+        ;
+
+        $params = [];
+        if ($needsComplexCount) {
+            if ($this->needsSelectAliases()) {
+                if ($this->getHaving()) {
+                    throw new PropelException('Propel cannot create a COUNT query when using HAVING and  duplicate column names in the SELECT part');
+                }
+                $db->turnSelectColumnsToAliases($this);
+            }
+            $selectSql = $this->createSelectSql($params);
+            $sql = 'SELECT COUNT(*) FROM (' . $selectSql . ') propelmatch4cnt';
+        } else {
+            // Replace SELECT columns with COUNT(*)
+            $this->clearSelectColumns()->addSelectColumn('COUNT(*)');
+            $sql = $this->createSelectSql($params);
+        }
+    }
+
+    try {
+        $stmt = $con->prepare($sql);
+        $db->bindValues($stmt, $params, $dbMap);
+        $stmt->execute();
+    } catch (Exception $e) {
+        Propel::log($e->getMessage(), Propel::LOG_ERR);
+        throw new PropelException(sprintf('Unable to execute COUNT statement [%s]', $sql), 0, $e);
+    }
+
+    if ($key && !$this->cacheContains($key)) {
+            $this->cacheStore($key, $sql);
+    }
+
+    return $con->getDataFetcher($stmt);
+}

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/sluggable---model_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/sluggable---model_reference.txt
@@ -1,0 +1,172 @@
+
+
+objectMethods:
+
+// sluggable behavior
+
+/**
+ * Wrap the setter for slug value
+ *
+ * @param string
+ * @return $this
+ */
+public function setSlug($v)
+{
+    $this->setUrl($v);
+
+    return $this;
+}
+
+/**
+ * Wrap the getter for slug value
+ *
+ * @return string
+ */
+public function getSlug()
+{
+    return $this->getUrl();
+}
+
+/**
+ * Create a unique slug based on the object
+ *
+ * @return string The object slug
+ */
+protected function createSlug(): string
+{
+    $slug = $this->createRawSlug();
+    $slug = $this->limitSlugSize($slug);
+    $slug = $this->makeSlugUnique($slug);
+
+    return $slug;
+}
+
+/**
+ * Create the slug from the appropriate columns
+ *
+ * @return string
+ */
+protected function createRawSlug(): string
+{
+    return '/foo/' . $this->cleanupSlugPart((string)$this->getTitle()) . '/bar';
+}
+
+/**
+ * Cleanup a string to make a slug of it
+ * Removes special characters, replaces blanks with a separator, and trim it
+ *
+ * @param string $slug        the text to slugify
+ * @param string $replacement the separator used by slug
+ * @return string the slugified text
+ */
+protected static function cleanupSlugPart(string $slug, string $replacement = '-'): string
+{
+    // set locale explicitly
+    $localeOrigin = setlocale(LC_CTYPE, '0');
+    setlocale(LC_CTYPE, 'C.UTF-8');
+
+    // transliterate
+    if (function_exists('iconv')) {
+        $slug = iconv('utf-8', 'us-ascii//TRANSLIT', $slug);
+    }
+
+    // lowercase
+    $slug = function_exists('mb_strtolower') ? mb_strtolower($slug) : strtolower($slug);
+
+    // remove accents resulting from OSX's iconv
+    $slug = str_replace(array('\'', '`', '^'), '', $slug);
+
+    // replace non letter or digits with separator
+    $slug = preg_replace('/[^\w\/]+/', $replacement, $slug);
+
+    $slug = trim($slug, $replacement);
+
+    setlocale(LC_CTYPE, $localeOrigin);
+
+    return empty($slug) ? 'n-a' : $slug;
+}
+
+
+/**
+ * Make sure the slug is short enough to accommodate the column size
+ *
+ * @param string $slug The slug to check
+ * @param int $incrementReservedSpace Space to reserve
+ *
+ * @return string The truncated slug
+ */
+protected static function limitSlugSize(string $slug, int $incrementReservedSpace = 3): string
+{
+    // check length, as suffix could put it over maximum
+    if (strlen($slug) > (100 - $incrementReservedSpace)) {
+        $slug = substr($slug, 0, 100 - $incrementReservedSpace);
+    }
+
+    return $slug;
+}
+
+
+/**
+ * Get the slug, ensuring its uniqueness
+ *
+ * @param string $slug            the slug to check
+ * @param string $separator       the separator used by slug
+ * @param bool $alreadyExists   false for the first try, true for the second, and take the high count + 1
+ * @return string the unique slug
+ */
+protected function makeSlugUnique(string $slug, string $separator = '/', bool $alreadyExists = false)
+{
+    if (!$alreadyExists) {
+        $slug2 = $slug;
+    } else {
+        $slug2 = $slug . $separator;
+    }
+
+    $adapter = \Propel\Runtime\Propel::getServiceContainer()->getAdapter('');
+    $col = 'q.Url';
+    $compare = $alreadyExists ? $adapter->compareRegex($col, '?') : sprintf('%s = ?', $col);
+
+    $query = \TableQuery::create('q')
+        ->where($compare, $alreadyExists ? '^' . $slug2 . '[0-9]+$' : $slug2)
+        ->prune($this)
+    ;
+
+    if (!$alreadyExists) {
+        $count = $query->count();
+        if ($count > 0) {
+            return $this->makeSlugUnique($slug, $separator, true);
+        }
+
+        return $slug2;
+    }
+
+    $adapter = \Propel\Runtime\Propel::getServiceContainer()->getAdapter('');
+    // Already exists
+    $object = $query
+        ->addDescendingOrderByColumn($adapter->strLength('url'))
+        ->addDescendingOrderByColumn('url')
+    ->findOne();
+
+    // First duplicate slug
+    if ($object === null) {
+        return $slug2 . '1';
+    }
+
+    $slugNum = substr($object->getUrl(), strlen($slug) + 1);
+    if ($slugNum[0] == 0) {
+        $slugNum[0] = 1;
+    }
+
+    return $slug2 . ($slugNum + 1);
+}
+
+
+preSave:
+
+// sluggable behavior
+
+if ($this->isColumnModified(TableTableMap::COL_URL) && $this->getUrl()) {
+    $this->setUrl($this->makeSlugUnique($this->getUrl()));
+} elseif (!$this->getUrl()) {
+    $this->setUrl($this->createSlug());
+}

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/sluggable---query_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/sluggable---query_reference.txt
@@ -1,0 +1,32 @@
+
+
+queryMethods:
+
+// sluggable behavior
+
+/**
+ * Filter the query on the slug column
+ *
+ * @param string $slug The value to use as filter.
+ *
+ * @return $this
+ */
+public function filterBySlug(string $slug)
+{
+    $this->addUsingOperator($this->resolveLocalColumnByName('url'), $slug, Criteria::EQUAL);
+
+    return $this;
+}
+
+/**
+ * Find one object based on its slug
+ *
+ * @param string $slug The value to use as filter.
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con The optional connection object
+ *
+ * @return ChildTable the result, formatted by the current formatter
+ */
+public function findOneBySlug(string $slug, ?ConnectionInterface $con = null)
+{
+    return $this->filterBySlug($slug)->findOne($con);
+}

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/sortable---object_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/sortable---object_reference.txt
@@ -1,0 +1,370 @@
+
+
+objectMethods:
+
+// sortable behavior
+
+/**
+ * Wrap the getter for rank value
+ *
+ * @return int
+ */
+public function getRank()
+{
+    return $this->sortable_rank;
+}
+
+/**
+ * Wrap the setter for rank value
+ *
+ * @param int
+ * @return $this
+ */
+public function setRank($v)
+{
+    $this->setSortableRank($v);
+
+    return $this;
+}
+
+/**
+ * Check if the object is first in the list, i.e. if it has 1 for rank
+ *
+ * @return bool
+ */
+public function isFirst()
+{
+    return $this->getSortableRank() == 1;
+}
+
+/**
+ * Check if the object is last in the list, i.e. if its rank is the highest rank
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Optional connection
+ *
+ * @return bool
+ */
+public function isLast(?ConnectionInterface $con = null)
+{
+    return $this->getSortableRank() == ChildTableQuery::create()->getMaxRankArray($con);
+}
+
+/**
+ * Get the next item in the list, i.e. the one for which rank is immediately higher
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Optional connection
+ *
+ * @return ChildTable
+ */
+public function getNext(?ConnectionInterface $con = null)
+{
+
+    $query = ChildTableQuery::create();
+
+    $query->filterByRank($this->getSortableRank() + 1);
+
+
+    return $query->findOne($con);
+}
+
+/**
+ * Get the previous item in the list, i.e. the one for which rank is immediately lower
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con      optional connection
+ *
+ * @return ChildTable
+ */
+public function getPrevious(?ConnectionInterface $con = null)
+{
+
+    $query = ChildTableQuery::create();
+
+    $query->filterByRank($this->getSortableRank() - 1);
+
+
+    return $query->findOne($con);
+}
+
+/**
+ * Insert at specified rank
+ * The modifications are not persisted until the object is saved.
+ *
+ * @param int $rank rank value
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Optional connection
+ *
+ * @return $this The current object
+ *
+ * @throws    PropelException
+ */
+public function insertAtRank($rank, ?ConnectionInterface $con = null)
+{
+    $maxRank = ChildTableQuery::create()->getMaxRankArray($con);
+    if ($rank < 1 || $rank > $maxRank + 1) {
+        throw new PropelException('Invalid rank ' . $rank);
+    }
+    // move the object in the list, at the given rank
+    $this->setSortableRank($rank);
+    if ($rank != $maxRank + 1) {
+        // Keep the list modification query for the save() transaction
+        $this->sortableQueries [] = [
+            'callable'  => array('\TableQuery', 'sortableShiftRank'),
+            'arguments' => array(1, $rank, null, ),
+        ];
+    }
+
+    return $this;
+}
+
+/**
+ * Insert in the last rank
+ * The modifications are not persisted until the object is saved.
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con optional connection
+ *
+ * @return $this The current object
+ *
+ * @throws    PropelException
+ */
+public function insertAtBottom(?ConnectionInterface $con = null)
+{
+    $this->setSortableRank(ChildTableQuery::create()->getMaxRankArray($con) + 1);
+
+    return $this;
+}
+
+/**
+ * Insert in the first rank
+ * The modifications are not persisted until the object is saved.
+ *
+ * @return $this The current object
+ */
+public function insertAtTop()
+{
+    $this->insertAtRank(1);
+
+    return $this;
+}
+
+/**
+ * Move the object to a new rank, and shifts the rank
+ * Of the objects inbetween the old and new rank accordingly
+ *
+ * @param int $newRank rank value
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con optional connection
+ *
+ * @return $this The current object
+ *
+ * @throws    PropelException
+ */
+public function moveToRank($newRank, ?ConnectionInterface $con = null)
+{
+    if ($this->isNew()) {
+        throw new PropelException('New objects cannot be moved. Please use insertAtRank() instead');
+    }
+    if (null === $con) {
+        $con = Propel::getServiceContainer()->getWriteConnection(TableTableMap::DATABASE_NAME);
+    }
+    if ($newRank < 1 || $newRank > ChildTableQuery::create()->getMaxRankArray($con)) {
+        throw new PropelException('Invalid rank ' . $newRank);
+    }
+
+    $oldRank = $this->getSortableRank();
+    if ($oldRank == $newRank) {
+        return $this;
+    }
+
+    $con->transaction(function () use ($con, $oldRank, $newRank) {
+        // shift the objects between the old and the new rank
+        $delta = ($oldRank < $newRank) ? -1 : 1;
+        ChildTableQuery::sortableShiftRank($delta, min($oldRank, $newRank), max($oldRank, $newRank), $con);
+
+        // move the object to its new rank
+        $this->setSortableRank($newRank);
+        $this->save($con);
+    });
+
+    return $this;
+}
+
+/**
+ * Exchange the rank of the object with the one passed as argument, and saves both objects
+ *
+ * @param ChildTable $object
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con optional connection
+ *
+ * @return $this The current object
+ *
+ * @throws Exception if the database cannot execute the two updates
+ */
+public function swapWith($object, ?ConnectionInterface $con = null)
+{
+    if (null === $con) {
+        $con = Propel::getServiceContainer()->getWriteConnection(TableTableMap::DATABASE_NAME);
+    }
+    $con->transaction(function () use ($con, $object) {
+        $oldRank = $this->getSortableRank();
+        $newRank = $object->getSortableRank();
+
+        $this->setSortableRank($newRank);
+        $object->setSortableRank($oldRank);
+
+        $this->save($con);
+        $object->save($con);
+    });
+
+    return $this;
+}
+
+/**
+ * Move the object higher in the list, i.e. exchanges its rank with the one of the previous object
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con optional connection
+ *
+ * @return $this The current object
+ */
+public function moveUp(?ConnectionInterface $con = null)
+{
+    if ($this->isFirst()) {
+        return $this;
+    }
+    if (null === $con) {
+        $con = Propel::getServiceContainer()->getWriteConnection(TableTableMap::DATABASE_NAME);
+    }
+    $con->transaction(function () use ($con) {
+        $prev = $this->getPrevious($con);
+        $this->swapWith($prev, $con);
+    });
+
+    return $this;
+}
+
+/**
+ * Move the object higher in the list, i.e. exchanges its rank with the one of the next object
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con optional connection
+ *
+ * @return $this The current object
+ */
+public function moveDown(?ConnectionInterface $con = null)
+{
+    if ($this->isLast($con)) {
+        return $this;
+    }
+    if (null === $con) {
+        $con = Propel::getServiceContainer()->getWriteConnection(TableTableMap::DATABASE_NAME);
+    }
+    $con->transaction(function () use ($con) {
+        $next = $this->getNext($con);
+        $this->swapWith($next, $con);
+    });
+
+    return $this;
+}
+
+/**
+ * Move the object to the top of the list
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con optional connection
+ *
+ * @return $this The current object
+ */
+public function moveToTop(?ConnectionInterface $con = null)
+{
+    if ($this->isFirst()) {
+        return $this;
+    }
+
+    $this->moveToRank(1, $con);
+
+    return $this;
+}
+
+/**
+ * Move the object to the bottom of the list
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con optional connection
+ *
+ * @return $this The current object
+ */
+public function moveToBottom(?ConnectionInterface $con = null)
+{
+    if ($this->isLast($con)) {
+        return $this;
+    }
+
+    if ($con === null) {
+        $con = Propel::getServiceContainer()->getWriteConnection(TableTableMap::DATABASE_NAME);
+    }
+
+    $con->transaction(function () use ($con) {
+        $bottom = ChildTableQuery::create()->getMaxRankArray($con);
+
+        $this->moveToRank($bottom, $con);
+    });
+
+    return $this;
+}
+
+/**
+ * Removes the current object from the list.
+ * The modifications are not persisted until the object is saved.
+ *
+ * @return $this The current object
+ */
+public function removeFromList()
+{
+    // Keep the list modification query for the save() transaction
+    $this->sortableQueries[] = [
+        'callable'  => ['\TableQuery', 'sortableShiftRank'],
+        'arguments' => [-1, $this->getSortableRank() + 1, null]
+    ];
+    // remove the object from the list
+    $this->setSortableRank(null);
+    
+
+    return $this;
+}
+
+/**
+ * Execute queries that were saved to be run inside the save transaction
+ */
+protected function processSortableQueries($con)
+{
+    foreach ($this->sortableQueries as ['callable' => $callable, 'arguments' => $arguments]) {
+        $arguments[] = $con;
+        $callable(...$arguments);
+    }
+    $this->sortableQueries = [];
+}
+
+
+objectAttributes:
+
+// sortable behavior
+
+/**
+ * Queries to be executed in the save transaction
+ * @var array
+ */
+protected $sortableQueries = [];
+
+
+preDelete:
+
+// sortable behavior
+
+ChildTableQuery::sortableShiftRank(-1, $this->getSortableRank() + 1, null, $con);
+TableTableMap::clearInstancePool();
+
+
+preSave:
+
+// sortable behavior
+$this->processSortableQueries($con);
+
+preInsert:
+
+// sortable behavior
+if (!$this->isColumnModified(TableTableMap::RANK_COL)) {
+    $this->setSortableRank(ChildTableQuery::create()->getMaxRankArray($con) + 1);
+}

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/sortable---query_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/sortable---query_reference.txt
@@ -1,0 +1,224 @@
+
+
+queryMethods:
+
+// sortable behavior
+
+/**
+ * Filter the query based on a rank in the list
+ *
+ * @param int $rank rank
+ *
+ * @return static
+ */
+public function filterByRank($rank)
+{
+    return $this
+        ->addUsingOperator(TableTableMap::RANK_COL, $rank, Criteria::EQUAL);
+}
+
+/**
+ * Order the query based on the rank in the list.
+ * Using the default $order, returns the item with the lowest rank first
+ *
+ * @param string $order either Criteria::ASC (default) or Criteria::DESC
+ *
+ * @return $this
+ */
+public function orderByRank(string $order = Criteria::ASC)
+{
+    $order = strtoupper($order);
+    switch ($order) {
+        case Criteria::ASC:
+            $this->addAscendingOrderByColumn($this->getAliasedColName(TableTableMap::RANK_COL));
+
+            return $this;
+        case Criteria::DESC:
+            $this->addDescendingOrderByColumn($this->getAliasedColName(TableTableMap::RANK_COL));
+
+            return $this;
+        default:
+            throw new PropelException('ChildTableQuery::orderBy() only accepts "asc" or "desc" as argument');
+    }
+}
+
+/**
+ * Get an item from the list based on its rank
+ *
+ * @param int $rank rank
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con optional connection
+ *
+ * @return ChildTable
+ */
+public function findOneByRank($rank, ?ConnectionInterface $con = null)
+{
+
+    return $this
+        ->filterByRank($rank)
+        ->findOne($con);
+}
+
+/**
+ * Returns the list of objects
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ *
+ * @return mixed the list of results, formatted by the current formatter
+ */
+public function findList($con = null)
+{
+
+    return $this
+        ->orderByRank()
+        ->find($con);
+}
+
+/**
+ * Get the highest rank
+ * 
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Optional connection
+ *
+ * @return int|null Highest position
+ */
+public function getMaxRank(?ConnectionInterface $con = null): ?int
+{
+    if (null === $con) {
+        $con = Propel::getServiceContainer()->getReadConnection(TableTableMap::DATABASE_NAME);
+    }
+    // shift the objects with a position lower than the one of object
+    $this->addSelectColumn('MAX(' . TableTableMap::RANK_COL . ')');
+    $stmt = $this->doSelect($con);
+
+    return $stmt->fetchColumn();
+}
+
+/**
+ * Get the highest rank by a scope with a array format.
+ * 
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Optional connection
+ *
+ * @return int|null Highest position
+ */
+public function getMaxRankArray(?ConnectionInterface $con = null): ?int
+{
+    if ($con === null) {
+        $con = Propel::getConnection(TableTableMap::DATABASE_NAME);
+    }
+    // shift the objects with a position lower than the one of object
+    $this->addSelectColumn('MAX(' . TableTableMap::RANK_COL . ')');
+    $stmt = $this->doSelect($con);
+
+    return $stmt->fetchColumn();
+}
+
+/**
+ * Get an item from the list based on its rank
+ *
+ * @param int $rank rank
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con optional connection
+ *
+ * @return ChildTable
+ */
+static public function retrieveByRank($rank, ?ConnectionInterface $con = null)
+{
+    if (null === $con) {
+        $con = Propel::getServiceContainer()->getReadConnection(TableTableMap::DATABASE_NAME);
+    }
+
+    $c = new Criteria;
+    $c->addAnd(TableTableMap::RANK_COL, $rank);
+
+    return static::create(null, $c)->findOne($con);
+}
+
+/**
+ * Reorder a set of sortable objects based on a list of id/position
+ * Beware that there is no check made on the positions passed
+ * So incoherent positions will result in an incoherent list
+ *
+ * @param mixed $order id => rank pairs
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con   optional connection
+ *
+ * @return bool true if the reordering took place, false if a database problem prevented it
+ */
+public function reorder($order, ?ConnectionInterface $con = null)
+{
+    if (null === $con) {
+        $con = Propel::getServiceContainer()->getReadConnection(TableTableMap::DATABASE_NAME);
+    }
+
+    $con->transaction(function () use ($con, $order) {
+        $ids = array_keys($order);
+        $objects = $this->findPks($ids, $con);
+        /** @var Table $object */
+        foreach ($objects as $object) {
+            $pk = $object->getPrimaryKey();
+            if ($object->getSortableRank() != $order[$pk]) {
+                $object->setSortableRank($order[$pk]);
+                $object->save($con);
+            }
+        }
+    });
+
+    return true;
+}
+
+/**
+ * Return an array of sortable objects ordered by position
+ *
+ * @param \Propel\Runtime\ActiveQuery\Criteria $criteria  optional criteria object
+ * @param string $order     sorting order, to be chosen between Criteria::ASC (default) and Criteria::DESC
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con       optional connection
+ *
+ * @return array|\Propel\Runtime\Collection\Collection list of sortable objects
+ */
+static public function doSelectOrderByRank(?Criteria $criteria = null, $order = Criteria::ASC, ?ConnectionInterface $con = null)
+{
+    if (null === $con) {
+        $con = Propel::getServiceContainer()->getReadConnection(TableTableMap::DATABASE_NAME);
+    }
+
+    if (null === $criteria) {
+        $criteria = new Criteria();
+    } elseif ($criteria instanceof Criteria) {
+        $criteria = clone $criteria;
+    }
+
+    $criteria->clearOrderByColumns();
+
+    if (Criteria::ASC == $order) {
+        $criteria->addAscendingOrderByColumn(TableTableMap::RANK_COL);
+    } else {
+        $criteria->addDescendingOrderByColumn(TableTableMap::RANK_COL);
+    }
+
+    return ChildTableQuery::create(null, $criteria)->find($con);
+}
+
+/**
+ * Adds $delta to all Rank values that are >= $first and <= $last.
+ * '$delta' can also be negative.
+ *
+ * @param int $delta Value to be shifted by, can be negative
+ * @param int $first First node to be shifted
+ * @param int $last  Last node to be shifted
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
+ */
+static public function sortableShiftRank($delta, $first, $last = null, ?ConnectionInterface $con = null)
+{
+    if (null === $con) {
+        $con = Propel::getServiceContainer()->getWriteConnection(TableTableMap::DATABASE_NAME);
+    }
+
+    $whereCriteria = new Criteria(TableTableMap::DATABASE_NAME);
+    $criterion = $whereCriteria->getNewCriterion(TableTableMap::RANK_COL, $first, Criteria::GREATER_EQUAL);
+    if (null !== $last) {
+        $criterion->addAnd($whereCriteria->getNewCriterion(TableTableMap::RANK_COL, $last, Criteria::LESS_EQUAL));
+    }
+    $whereCriteria->addFilter($criterion);
+
+    $whereCriteria->setUpdateExpression(TableTableMap::RANK_COL, TableTableMap::RANK_COL . ' + ?', $delta, \PDO::PARAM_INT);
+
+    $whereCriteria->doUpdate(null, $con);
+    TableTableMap::clearInstancePool();
+}

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/sortable---tablemap_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/sortable---tablemap_reference.txt
@@ -1,0 +1,10 @@
+
+
+staticAttributes:
+
+// sortable behavior
+/**
+ * rank column
+ */
+const RANK_COL = "table.sortable_rank";
+

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/timestampable---object_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/timestampable---object_reference.txt
@@ -1,0 +1,36 @@
+
+
+objectMethods:
+
+// timestampable behavior
+
+/**
+ * Mark the current object so that the update date doesn't get updated during next save
+ *
+ * @return $this
+ */
+public function keepUpdateDateUnchanged()
+{
+    $this->modifiedColumns[TableTableMap::COL_UPDATED_AT] = true;
+
+    return $this;
+}
+
+
+preInsert:
+
+// timestampable behavior
+$mtime = microtime(true);
+if (!$this->isColumnModified(TableTableMap::COL_CREATED_AT)) {
+    $this->setCreatedAt(PropelDateTime::createHighPrecision(PropelDateTime::formatMicrotime($mtime), '\DateTime'));
+}
+if (!$this->isColumnModified(TableTableMap::COL_UPDATED_AT)) {
+    $this->setUpdatedAt(PropelDateTime::createHighPrecision(PropelDateTime::formatMicrotime($mtime), '\DateTime'));
+}
+
+preUpdate:
+
+// timestampable behavior
+if ($this->isModified() && !$this->isColumnModified(TableTableMap::COL_UPDATED_AT)) {
+    $this->setUpdatedAt(PropelDateTime::createHighPrecision(null, '\DateTime'));
+}

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/timestampable---query_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/timestampable---query_reference.txt
@@ -1,0 +1,79 @@
+
+
+queryMethods:
+
+// timestampable behavior
+
+/**
+ * Filter by the latest updated
+ *
+ * @param int $nbDays Maximum age of the latest update in days
+ *
+ * @return $this
+ */
+public function recentlyUpdated($nbDays = 7)
+{
+    $this->addUsingOperator($this->resolveLocalColumnByName('updated_at'), time() - $nbDays * 24 * 60 * 60, Criteria::GREATER_EQUAL);
+
+    return $this;
+}
+
+/**
+ * Order by update date desc
+ *
+ * @return $this
+ */
+public function lastUpdatedFirst()
+{
+    $this->addDescendingOrderByColumn(TableTableMap::COL_UPDATED_AT);
+
+    return $this;
+}
+
+/**
+ * Order by update date asc
+ *
+ * @return $this
+ */
+public function firstUpdatedFirst()
+{
+    $this->addAscendingOrderByColumn(TableTableMap::COL_UPDATED_AT);
+
+    return $this;
+}
+
+/**
+ * Order by create date desc
+ *
+ * @return $this
+ */
+public function lastCreatedFirst()
+{
+    $this->addDescendingOrderByColumn(TableTableMap::COL_CREATED_AT);
+
+    return $this;
+}
+
+/**
+ * Filter by the latest created
+ *
+ * @param int $nbDays Maximum age of in days
+ *
+ * @return static
+ */
+public function recentlyCreated($nbDays = 7)
+{
+    return $this->addUsingOperator($this->resolveLocalColumnByName('created_at'), time() - $nbDays * 24 * 60 * 60, Criteria::GREATER_EQUAL);
+}
+
+/**
+ * Order by create date asc
+ *
+ * @return $this
+ */
+public function firstCreatedFirst()
+{
+    $this->addAscendingOrderByColumn(TableTableMap::COL_CREATED_AT);
+
+    return $this;
+}

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/validateable---object_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/validateable---object_reference.txt
@@ -1,0 +1,90 @@
+
+
+objectMethods:
+
+// validate behavior
+
+/**
+ * Configure validators constraints. The Validator object uses this method
+ * to perform object validation.
+ *
+ * @param ClassMetadata $metadata
+ */
+static public function loadValidatorMetadata(ClassMetadata $metadata)
+{
+    $metadata->addPropertyConstraint('name', new Unique());
+    $metadata->addPropertyConstraint('website', new Url());
+}
+
+/**
+ * Validates the object and all objects related to this table.
+ *
+ * @see        getValidationFailures()
+ * @param ValidatorInterface|null $validator A Validator class instance
+ * @return bool Whether all objects pass validation.
+ */
+public function validate(?ValidatorInterface $validator = null)
+{
+    if (null === $validator) {
+        $validator = new RecursiveValidator(
+            new ExecutionContextFactory(new IdentityTranslator()),
+            new LazyLoadingMetadataFactory(new StaticMethodLoader()),
+            new ConstraintValidatorFactory()
+        );
+    }
+
+    $failureMap = new ConstraintViolationList();
+
+    if (!$this->alreadyInValidation) {
+        $this->alreadyInValidation = true;
+        $retval = null;
+
+
+        $retval = $validator->validate($this);
+        if (count($retval) > 0) {
+            $failureMap->addAll($retval);
+        }
+
+
+        $this->alreadyInValidation = false;
+    }
+
+    $this->validationFailures = $failureMap;
+
+    return (bool) (!(count($this->validationFailures) > 0));
+
+}
+
+/**
+ * Gets any ConstraintViolation objects that resulted from last call to validate().
+ *
+ *
+ * @return ConstraintViolationList
+ * @see        validate()
+ */
+public function getValidationFailures()
+{
+    return $this->validationFailures;
+}
+
+
+objectAttributes:
+
+// validate behavior
+
+/**
+ * Flag to prevent endless validation loop, if this object is referenced
+ * by another object which falls in this transaction.
+ *
+ * @var bool
+ */
+protected $alreadyInValidation = false;
+
+/**
+ * ConstraintViolationList object
+ *
+ * @see     http://api.symfony.com/2.0/Symfony/Component/Validator/ConstraintViolationList.html
+ *
+ * @var     ConstraintViolationList
+ */
+protected $validationFailures;

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/versionable---object_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/versionable---object_reference.txt
@@ -1,0 +1,327 @@
+
+
+objectMethods:
+
+// versionable behavior
+
+/**
+ * Wrap the setter for version value
+ *
+ * @param string
+ * @return $this
+ */
+public function setVersion($v)
+{
+    $this->setCustomversion($v);
+
+    return $this;
+}
+
+/**
+ * Wrap the getter for version value
+ *
+ * @return string
+ */
+public function getVersion()
+{
+    return $this->getCustomversion();
+}
+
+/**
+ * Enforce a new Version of this object upon next save.
+ *
+ * @return $this
+ */
+public function enforceVersioning()
+{
+    $this->enforceVersion = true;
+
+    return $this;
+}
+        
+/**
+ * Checks whether the current state must be recorded as a version
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con The ConnectionInterface connection to use.
+ * @return bool
+ */
+public function isVersioningNecessary(?ConnectionInterface $con = null): bool
+{
+    if ($this->alreadyInSave) {
+        return false;
+    }
+
+    if ($this->enforceVersion) {
+        return true;
+    }
+
+    if (ChildTableQuery::isVersioningEnabled() && ($this->isNew() || $this->isModified()) || $this->isDeleted()) {
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * Creates a version of the current object and saves it.
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con The ConnectionInterface connection to use.
+ *
+ * @return ChildTableVersion A version object
+ */
+public function addVersion(?ConnectionInterface $con = null)
+{
+    $this->enforceVersion = false;
+
+    $version = new ChildTableVersion();
+    $version->setId($this->getId());
+    $version->setBar($this->getBar());
+    $version->setCustomversion($this->getCustomversion());
+    $version->setTable($this);
+    $version->save($con);
+
+    return $version;
+}
+
+/**
+ * Sets the properties of the current object to the value they had at a specific version
+ *
+ * @param int $versionNumber The version number to read
+ * @param \Propel\Runtime\Connection\ConnectionInterface|null $con The ConnectionInterface connection to use.
+ *
+ * @return $this
+ */
+public function toVersion($versionNumber, ?ConnectionInterface $con = null)
+{
+    $version = $this->getOneVersion($versionNumber, $con);
+    if (!$version) {
+        throw new PropelException(sprintf('No ChildTable object found with version %d', $version));
+    }
+    $this->populateFromVersion($version, $con);
+
+    return $this;
+}
+
+/**
+ * Sets the properties of the current object to the value they had at a specific version
+ *
+ * @param ChildTableVersion $version The version object to use
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con the connection to use
+ * @param array $loadedObjects objects that been loaded in a chain of populateFromVersion calls on referrer or fk objects.
+ *
+ * @return $this
+ */
+public function populateFromVersion($version, $con = null, &$loadedObjects = [])
+{
+    $loadedObjects['ChildTable'][$version->getId()][$version->getCustomversion()] = $this;
+    $this->setId($version->getId());
+    $this->setBar($version->getBar());
+    $this->setCustomversion($version->getCustomversion());
+
+    return $this;
+}
+
+/**
+ * Gets the latest persisted version number for the current object
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con The ConnectionInterface connection to use.
+ *
+ * @return int
+ */
+public function getLastVersionNumber(?ConnectionInterface $con = null): int
+{
+    $v = ChildTableVersionQuery::create()
+        ->filterByTable($this)
+        ->orderByCustomversion('desc')
+        ->findOne($con);
+    if (!$v) {
+        return 0;
+    }
+
+    return $v->getCustomversion();
+}
+
+/**
+ * Checks whether the current object is the latest one
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con The ConnectionInterface connection to use.
+ *
+ * @return bool
+ */
+public function isLastVersion(?ConnectionInterface $con = null)
+{
+    return $this->getLastVersionNumber($con) == $this->getVersion();
+}
+
+/**
+ * Retrieves a version object for this entity and a version number
+ *
+ * @param int $versionNumber The version number to read
+ * @param \Propel\Runtime\Connection\ConnectionInterface|null $con The ConnectionInterface connection to use.
+ *
+ * @return ChildTableVersion A version object
+ */
+public function getOneVersion(int $versionNumber, ?ConnectionInterface $con = null)
+{
+    return ChildTableVersionQuery::create()
+        ->filterByTable($this)
+        ->filterByCustomversion($versionNumber)
+        ->findOne($con);
+}
+
+/**
+ * Gets all the versions of this object, in incremental order
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con The ConnectionInterface connection to use.
+ *
+ * @return ObjectCollection|ChildTableVersion[] A list of ChildTableVersion objects
+ */
+public function getAllVersions(?ConnectionInterface $con = null)
+{
+    $criteria = new Criteria();
+    $criteria->addAscendingOrderByColumn(TableVersionTableMap::COL_CUSTOMVERSION);
+
+    return $this->getTableVersions($criteria, $con);
+}
+
+/**
+ * Compares the current object with another of its version.
+ * <code>
+ * print_r($book->compareVersion(1));
+ * => array(
+ *   '1' => array('Title' => 'Book title at version 1'),
+ *   '2' => array('Title' => 'Book title at version 2')
+ * );
+ * </code>
+ *
+ * @param int $versionNumber
+ * @param string $keys Main key used for the result diff (versions|columns)
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con The ConnectionInterface connection to use.
+ * @param array $ignoredColumns  The columns to exclude from the diff.
+ *
+ * @return array A list of differences
+ */
+public function compareVersion(int $versionNumber, string $keys = 'columns', ?ConnectionInterface $con = null, array $ignoredColumns = []): array
+{
+    $fromVersion = $this->toArray();
+    $toVersion = $this->getOneVersion($versionNumber, $con)->toArray();
+
+    return $this->computeDiff($fromVersion, $toVersion, $keys, $ignoredColumns);
+}
+
+/**
+ * Compares two versions of the current object.
+ * <code>
+ * print_r($book->compareVersions(1, 2));
+ * => array(
+ *   '1' => array('Title' => 'Book title at version 1'),
+ *   '2' => array('Title' => 'Book title at version 2')
+ * );
+ * </code>
+ *
+ * @param int $fromVersionNumber
+ * @param int $toVersionNumber
+ * @param string $keys Main key used for the result diff (versions|columns)
+ * @param \Propel\Runtime\Connection\ConnectionInterface|null $con The ConnectionInterface connection to use.
+ * @param array $ignoredColumns  The columns to exclude from the diff.
+ *
+ * @return array A list of differences
+ */
+public function compareVersions(int $fromVersionNumber, int $toVersionNumber, string $keys = 'columns', ?ConnectionInterface $con = null, array $ignoredColumns = []): array
+{
+    $fromVersion = $this->getOneVersion($fromVersionNumber, $con)->toArray();
+    $toVersion = $this->getOneVersion($toVersionNumber, $con)->toArray();
+
+    return $this->computeDiff($fromVersion, $toVersion, $keys, $ignoredColumns);
+}
+
+/**
+ * Computes the diff between two versions.
+ * <code>
+ * print_r($book->computeDiff(1, 2));
+ * => array(
+ *   '1' => array('Title' => 'Book title at version 1'),
+ *   '2' => array('Title' => 'Book title at version 2')
+ * );
+ * </code>
+ *
+ * @param array $fromVersion     An array representing the original version.
+ * @param array $toVersion       An array representing the destination version.
+ * @param string $keys            Main key used for the result diff (versions|columns).
+ * @param array $ignoredColumns  The columns to exclude from the diff.
+ *
+ * @return array A list of differences
+ */
+protected function computeDiff($fromVersion, $toVersion, $keys = 'columns', $ignoredColumns = [])
+{
+    $fromVersionNumber = $fromVersion['Customversion'];
+    $toVersionNumber = $toVersion['Customversion'];
+    $ignoredColumns = array_merge(array(
+        'Customversion',
+    ), $ignoredColumns);
+    $diff = [];
+    foreach ($fromVersion as $key => $value) {
+        if (in_array($key, $ignoredColumns)) {
+            continue;
+        }
+        if ($toVersion[$key] != $value) {
+            switch ($keys) {
+                case 'versions':
+                    $diff[$fromVersionNumber][$key] = $value;
+                    $diff[$toVersionNumber][$key] = $toVersion[$key];
+                    break;
+                default:
+                    $diff[$key] = [
+                        $fromVersionNumber => $value,
+                        $toVersionNumber => $toVersion[$key],
+                    ];
+                    break;
+            }
+        }
+    }
+
+    return $diff;
+}
+/**
+ * Retrieve the last $number versions.
+ *
+ * @param int $number The number of record to return.
+ * @param \Propel\Runtime\ActiveQuery\Criteria $criteria The Criteria object containing modified values.
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con The ConnectionInterface connection to use.
+ *
+ * @return PropelCollection|\TableVersion[] List of \TableVersion objects
+ */
+public function getLastVersions($number = 10, $criteria = null, ?ConnectionInterface $con = null)
+{
+    $criteria = ChildTableVersionQuery::create(null, $criteria);
+    $criteria->addDescendingOrderByColumn(TableVersionTableMap::COL_VERSION);
+    $criteria->limit($number);
+
+    return $this->getTableVersions($criteria, $con);
+}
+
+objectAttributes:
+
+// versionable behavior
+
+
+/**
+ * @var bool
+ */
+protected $enforceVersion = false;
+        
+
+preSave:
+
+// versionable behavior
+if ($this->isVersioningNecessary()) {
+    $this->setCustomversion($this->isNew() ? 1 : $this->getLastVersionNumber($con) + 1);
+    $createVersion = true; // for postSave hook
+}
+
+postSave:
+
+// versionable behavior
+if (isset($createVersion)) {
+    $this->addVersion($con);
+}

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/versionable---query_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/versionable---query_reference.txt
@@ -1,0 +1,78 @@
+
+
+queryAttributes:
+
+// versionable behavior
+
+/**
+ * Whether the versioning is enabled
+ */
+static $isVersioningEnabled = true;
+
+
+queryAttributes:
+
+// versionable behavior
+
+/**
+ * Whether the versioning is enabled
+ */
+static $isVersioningEnabled = true;
+
+
+queryMethods:
+
+// versionable behavior
+
+/**
+ * Wrap the filter on the version column
+ *
+ * @param int|null $version
+ * @param string|null  $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+ * @return $this
+ */
+public function filterByVersion($version = null, ?string $comparison = null)
+{
+    $this->filterByCustomversion($version, $comparison);
+
+    return $this;
+}
+
+/**
+ * Wrap the order on the version column
+ *
+ * @param string $order The sorting order. Criteria::ASC by default, also accepts Criteria::DESC
+ * @return $this
+ */
+public function orderByVersion(string $order = Criteria::ASC)
+{
+    $this->orderBy('Customversion', $order);
+
+    return $this;
+}
+
+/**
+ * Checks whether versioning is enabled
+ *
+ * @return bool
+ */
+static public function isVersioningEnabled(): bool
+{
+    return self::$isVersioningEnabled;
+}
+
+/**
+ * Enables versioning
+ */
+static public function enableVersioning(): void
+{
+    self::$isVersioningEnabled = true;
+}
+
+/**
+ * Disables versioning
+ */
+static public function disableVersioning(): void
+{
+    self::$isVersioningEnabled = false;
+}


### PR DESCRIPTION
## Issue
Behavior code has no code reference in tests, making it hard to understand how much a behavior does, or track updates to its generated code.


## Changes
Adds code references similar to other builder output.


## Implementation Details
The test file contains a schema snippet for each behavior, which is used to set up the code builder affected by the behavior (usually ObjectBuilder and/or QueryBuilder). Then the behavior hooks are triggered and the result is written to file.

If the behavior changes existing code, that part of the code is generated and used as input. 

## Test strategy
Perpltm's code comparator.

## Notes
I did not read the behavior code in the files. If a behavior produces obvious nonsense, it now seems like tested behavior. But it is just the current (and runtime/functionally-tested) state.