### PR TITLE
More behavior code test and deprecation fix 

### DIFF
--- a/src/Propel/Generator/Behavior/Sortable/SortableBehavior.php
+++ b/src/Propel/Generator/Behavior/Sortable/SortableBehavior.php
@@ -6,12 +6,13 @@ namespace Propel\Generator\Behavior\Sortable;
 
 use InvalidArgumentException;
 use Propel\Generator\Model\Behavior;
+use function array_filter;
+use function array_map;
 use function count;
 use function explode;
 use function implode;
+use function is_string;
 use function sprintf;
-use function str_replace;
-use function trim;
 
 /**
  * Gives a model class the ability to be ordered
@@ -65,19 +66,19 @@ class SortableBehavior extends Behavior
         }
 
         if ($this->useScope()) {
-            if (!$this->hasMultipleScopes() && !$table->hasColumn($this->getParameter('scope_column'))) {
-                $table->addColumn([
-                    'name' => $this->getParameter('scope_column'),
-                    'type' => 'INTEGER',
-                ]);
-            }
-
             $scopes = $this->getScopes();
-            if (count($scopes) === 0) {
+            if (!$scopes) {
                 throw new InvalidArgumentException(sprintf(
                     'The sortable behavior in `%s` needs a `scope_column` parameter.',
                     $this->getTable()->getName(),
                 ));
+            }
+
+            if (count($scopes) === 1 && !$table->hasColumn($scopes[0])) { // what about others?
+                $table->addColumn([
+                    'name' => $scopes[0],
+                    'type' => 'INTEGER',
+                ]);
             }
         }
     }
@@ -220,13 +221,16 @@ class SortableBehavior extends Behavior
     /**
      * Returns all scope columns as array.
      *
-     * @return list<string>
+     * @return array<string>
      */
     public function getScopes(): array
     {
-        return $this->getParameter('scope_column')
-            ? explode(',', str_replace(' ', '', trim($this->getParameter('scope_column'))))
-            : [];
+        $scopeColumnCsv = $this->getParameter('scope_column');
+        if (!$scopeColumnCsv || !is_string($scopeColumnCsv)) {
+            return [];
+        }
+
+        return array_filter(array_map('trim', explode(',', $scopeColumnCsv)));
     }
 
     /**

--- a/src/Propel/Generator/Util/QuickBuilder.php
+++ b/src/Propel/Generator/Util/QuickBuilder.php
@@ -317,7 +317,7 @@ class QuickBuilder
 
         $pdo = new PdoConnection($dsn, $user, $pass, [], $adapter->getPdoSubclass());
         $con = new ConnectionWrapper($pdo);
-        $con->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
+        $con->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         /** @phpstan-var \Propel\Runtime\Adapter\Pdo\SqliteAdapter $adapter */
         $adapter->initConnection($con, []);
         $this->buildSQL($con);

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/BehaviorCodeTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/BehaviorCodeTest.php
@@ -40,6 +40,10 @@ class BehaviorCodeTest extends CompareGeneratedCodeTestCase
                 "$refDir/aggregate_column---source_model_reference.txt",
             ],
             [
+                [static::AGGREGATE_COLUMN_SCHEMA, 'source_table', BuilderType::QueryBase,],
+                "$refDir/aggregate_column---source_query_reference.txt",
+            ],
+            [
                 [static::AGGREGATE_MULTIPLE_COLUMNS_SCHEMA, 'aggregated_table', BuilderType::ObjectBase,],
                 "$refDir/aggregate_multiple_columns---target_model_reference.txt",
             ],
@@ -94,6 +98,10 @@ class BehaviorCodeTest extends CompareGeneratedCodeTestCase
             [
                 [static::OUTPUT_GROUP_SCHEMA, 'table', BuilderType::TableMap,],
                 "$refDir/output_group---tablemap_reference.txt",
+            ],
+            [
+                [static::OUTPUT_GROUP_SCHEMA, 'table', BuilderType::Collection,],
+                "$refDir/output_group---collection_reference.txt",
             ],
             [
                 [static::QUERY_CACHE_SCHEMA, 'table', BuilderType::QueryBase,],
@@ -379,7 +387,24 @@ XML;
             <column name="col1" outputGroup="group2"/>
             <column name="col2" outputGroup="group1"/>
             <column name="col3" outputGroup="group1,group2"/>
+            
+            <foreign-key foreignTable="fkTable">
+                <reference local="col2" foreign="id"/>
+            </foreign-key>
         </table>
+
+        <table name="fkTable">
+            <column name="id"/>
+        </table>
+
+        <table name="refFkTable">
+            <column name="id"/>
+            
+            <foreign-key foreignTable="table">
+                <reference local="id" foreign="col1"/>
+            </foreign-key>
+        </table>
+
     </database>
 XML;
 
@@ -417,9 +442,14 @@ XML;
     <database>
         <table name="table">
             <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER"/>
-            <column name="title" type="VARCHAR" size="100" primaryString="true"/>
+            <column name="category_id" required="true" type="INTEGER"/>
+            <column name="sub_category_id" type="INTEGER"/>
 
-            <behavior name="sortable"/>
+            <behavior name="sortable">
+                <parameter name="use_scope" value="true"/>
+                <parameter name="scope_column" value="category_id"/>
+                <parameter name="scope_column" value="sub_category_id"/>
+            </behavior>
         </table>
     </database>
 XML;
@@ -454,7 +484,11 @@ XML;
             <column name="bar" type="INTEGER"/>
 
             <behavior name="versionable">
+                <parameter name="version_table" value="le_version_table"/>
                 <parameter name="version_column" value="CustomVersion"/>
+                <parameter name="log_created_at" value="true"/>
+                <parameter name="log_created_by" value="true"/>
+                <parameter name="log_comment" value="true"/>
             </behavior>
         </table>
     </database>

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/aggregate_column---source_query_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/aggregate_column---source_query_reference.txt
@@ -1,0 +1,86 @@
+
+
+queryAttributes:
+
+// aggregate_column_relation_aggregate_column behavior
+
+/**
+ * @var \Base\Collection\AggregatedTableCollection|null
+ */
+protected ?AggregatedTableCollection $aggregatedTableRelatedEntriess = null;
+
+
+queryAttributes:
+
+// aggregate_column_relation_aggregate_column behavior
+
+/**
+ * @var \Base\Collection\AggregatedTableCollection|null
+ */
+protected ?AggregatedTableCollection $aggregatedTableRelatedEntriess = null;
+
+
+queryMethods:
+
+// aggregate_column_relation_aggregate_column behavior
+
+/**
+ * Finds the related AggregatedTable objects and keep them for later
+ *
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con A connection object
+ *
+ * @return void
+ */
+protected function findRelatedAggregatedTableRelatedEntriess($con)
+{
+    $criteria = clone $this;
+    if ($this->useAliasInSQL) {
+        $alias = $this->getModelAlias();
+        $criteria->removeAlias($alias);
+    } else {
+        $alias = '';
+    }
+
+    $this->aggregatedTableRelatedEntriess = ChildAggregatedTableQuery::create()
+        ->joinSourceTable($alias)
+        ->mergeWith($criteria)
+        ->findObjects($con);
+}
+
+/**
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con A connection object
+ *
+ * @return void
+ */
+protected function updateRelatedAggregatedTableRelatedEntriess($con)
+{
+    if ($this->aggregatedTableRelatedEntriess === null) {
+        return;
+    }
+
+    foreach ($this->aggregatedTableRelatedEntriess as $aggregatedTableRelatedEntries) {
+        $aggregatedTableRelatedEntries->updateRelatedEntries($con);
+    }
+    $this->aggregatedTableRelatedEntriess = null;
+}
+
+
+preDeleteQuery:
+
+// aggregate_column_relation_aggregate_column behavior
+$this->findRelatedAggregatedTableRelatedEntriess($con);
+
+postDeleteQuery:
+
+// aggregate_column_relation_aggregate_column behavior
+$this->updateRelatedAggregatedTableRelatedEntriess($con);
+
+preUpdateQuery:
+
+// aggregate_column_relation_aggregate_column behavior
+$this->findRelatedAggregatedTableRelatedEntriess($con);
+
+postUpdateQuery:
+
+// aggregate_column_relation_aggregate_column behavior
+$this->updateRelatedAggregatedTableRelatedEntriess($con);

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/output_group---collection_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/output_group---collection_reference.txt
@@ -1,0 +1,38 @@
+
+
+addObjectCollectionMethods:
+
+// output_group behavior
+     /**
+     * Turn collection objects into arrays with values specified by output group.
+     *
+     * @param array<string, string>|string $outputGroup Name of the output group used for all tables or
+     *                                                  an array mapping model classes to output group name.
+     *                                                  If a model class does not have a definition for the
+     *                                                  given output group, the whole data is returned.
+     * @param string|null $keyColumn (optional) Column name to use as index.
+     * @param string $keyType (optional) One of the class type constants TableMap::TYPE_PHPNAME,
+     *                                        TableMap::TYPE_CAMELNAME, TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME,
+     *                                        TableMap::TYPE_NUM. Defaults to TableMap::TYPE_PHPNAME.
+     * @param array $alreadyDumpedObjects Internally used on recursion, typically not set by user (List of
+     *                                      objects to skip to avoid recursion).
+     *
+     * @return array
+     */
+    public function toOutputGroup(
+        $outputGroup,
+        ?string $keyColumn = null,
+        string $keyType = TableMap::TYPE_PHPNAME,
+        array $alreadyDumpedObjects = []
+    ): array {
+        $ret = [];
+        $keyGetterMethod = 'get' . $keyColumn;
+
+        /** @var \Propel\Generator\Behavior\OutputGroup\ObjectWithOutputGroupInterface $obj */
+        foreach ($this->data as $key => $obj) {
+            $key = (!$keyColumn) ? $key : $obj->$keyGetterMethod();
+            $ret[$key] = $obj->toOutputGroup($outputGroup, $keyType, $alreadyDumpedObjects);
+        }
+
+        return $ret;
+    }

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/output_group---object_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/output_group---object_reference.txt
@@ -47,5 +47,29 @@ public function toOutputGroup(
         $result[$key] = $virtualColumn;
     }
 
+    if ($this->aFktable !== null && ($relationsLookup === null || isset($relationsLookup['Fktable']))) {
+        $key = match ($keyType) {
+             TableMap::TYPE_CAMELNAME => 'fktable',
+             TableMap::TYPE_FIELDNAME => 'fkTable',
+             default => 'Fktable',
+        };
+        if (!isset($alreadyDumpedObjects['table_fk_9378ed'][$this->aFktable->hashCode()])){
+            $alreadyDumpedObjects['table_fk_9378ed'][$this->aFktable->hashCode()] = 1;
+            $result[$key] = $this->aFktable->toOutputGroup($outputGroup, $keyType, $alreadyDumpedObjects);
+        }
+    }
+
+    if ($this->collReffktables !== null && ($relationsLookup === null || isset($relationsLookup['Reffktable']))) {
+        $key = match ($keyType) {
+             TableMap::TYPE_CAMELNAME => 'reffktables',
+             TableMap::TYPE_FIELDNAME => 'refFkTables',
+             default => 'Reffktables',
+        };
+        if (!isset($alreadyDumpedObjects['refFkTable_fk_8b1062'][$this->hashCode()])){
+            $alreadyDumpedObjects['refFkTable_fk_8b1062'][$this->hashCode()] = 1;
+            $result[$key] = $this->collReffktables->toOutputGroup($outputGroup, null, $keyType, $alreadyDumpedObjects);
+        }
+    }
+
     return $result;
 }

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/sortable---object_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/sortable---object_reference.txt
@@ -28,6 +28,43 @@ public function setRank($v)
 }
 
 /**
+ * Wrap the getter for scope value
+ *
+ * @param bool $returnNulls If true and all scope values are null, this will return null instead of a array full with nulls
+ *
+ * @return mixed A array or a native type
+ */
+public function getScopeValue($returnNulls = true)
+{
+
+    $result = [];
+    $onlyNulls = true;
+
+    $onlyNulls &= null === ($result[] = $this->getCategoryId());
+
+    $onlyNulls &= null === ($result[] = $this->getSubCategoryId());
+
+
+    return $onlyNulls && $returnNulls ? null : $result;
+
+}
+
+/**
+ * Wrap the setter for scope value
+ *
+ * @param mixed A array or a native type
+ *
+ * @return $this
+ */
+public function setScopeValue($v)
+{
+    $this->setCategoryId($v === null ? null : $v[0]);
+    $this->setSubCategoryId($v === null ? null : $v[1]);
+
+    return $this;
+}
+
+/**
  * Check if the object is first in the list, i.e. if it has 1 for rank
  *
  * @return bool
@@ -46,7 +83,7 @@ public function isFirst()
  */
 public function isLast(?ConnectionInterface $con = null)
 {
-    return $this->getSortableRank() == ChildTableQuery::create()->getMaxRankArray($con);
+    return $this->getSortableRank() == ChildTableQuery::create()->getMaxRankArray($this->getScopeValue(), $con);
 }
 
 /**
@@ -61,7 +98,13 @@ public function getNext(?ConnectionInterface $con = null)
 
     $query = ChildTableQuery::create();
 
-    $query->filterByRank($this->getSortableRank() + 1);
+    $scope = $this->getScopeValue();
+    
+    $scopeCategoryId = $scope[0];
+    $scopeSubCategoryId = $scope[1];
+
+
+    $query->filterByRank($this->getSortableRank() + 1, $scopeCategoryId, $scopeSubCategoryId);
 
 
     return $query->findOne($con);
@@ -79,7 +122,13 @@ public function getPrevious(?ConnectionInterface $con = null)
 
     $query = ChildTableQuery::create();
 
-    $query->filterByRank($this->getSortableRank() - 1);
+    $scope = $this->getScopeValue();
+    
+    $scopeCategoryId = $scope[0];
+    $scopeSubCategoryId = $scope[1];
+
+
+    $query->filterByRank($this->getSortableRank() - 1, $scopeCategoryId, $scopeSubCategoryId);
 
 
     return $query->findOne($con);
@@ -98,7 +147,7 @@ public function getPrevious(?ConnectionInterface $con = null)
  */
 public function insertAtRank($rank, ?ConnectionInterface $con = null)
 {
-    $maxRank = ChildTableQuery::create()->getMaxRankArray($con);
+    $maxRank = ChildTableQuery::create()->getMaxRankArray($this->getScopeValue(), $con);
     if ($rank < 1 || $rank > $maxRank + 1) {
         throw new PropelException('Invalid rank ' . $rank);
     }
@@ -108,7 +157,7 @@ public function insertAtRank($rank, ?ConnectionInterface $con = null)
         // Keep the list modification query for the save() transaction
         $this->sortableQueries [] = [
             'callable'  => array('\TableQuery', 'sortableShiftRank'),
-            'arguments' => array(1, $rank, null, ),
+            'arguments' => array(1, $rank, null, $this->getScopeValue()),
         ];
     }
 
@@ -127,7 +176,7 @@ public function insertAtRank($rank, ?ConnectionInterface $con = null)
  */
 public function insertAtBottom(?ConnectionInterface $con = null)
 {
-    $this->setSortableRank(ChildTableQuery::create()->getMaxRankArray($con) + 1);
+    $this->setSortableRank(ChildTableQuery::create()->getMaxRankArray($this->getScopeValue(), $con) + 1);
 
     return $this;
 }
@@ -164,7 +213,7 @@ public function moveToRank($newRank, ?ConnectionInterface $con = null)
     if (null === $con) {
         $con = Propel::getServiceContainer()->getWriteConnection(TableTableMap::DATABASE_NAME);
     }
-    if ($newRank < 1 || $newRank > ChildTableQuery::create()->getMaxRankArray($con)) {
+    if ($newRank < 1 || $newRank > ChildTableQuery::create()->getMaxRankArray($this->getScopeValue(), $con)) {
         throw new PropelException('Invalid rank ' . $newRank);
     }
 
@@ -176,7 +225,7 @@ public function moveToRank($newRank, ?ConnectionInterface $con = null)
     $con->transaction(function () use ($con, $oldRank, $newRank) {
         // shift the objects between the old and the new rank
         $delta = ($oldRank < $newRank) ? -1 : 1;
-        ChildTableQuery::sortableShiftRank($delta, min($oldRank, $newRank), max($oldRank, $newRank), $con);
+        ChildTableQuery::sortableShiftRank($delta, min($oldRank, $newRank), max($oldRank, $newRank), $this->getScopeValue(), $con);
 
         // move the object to its new rank
         $this->setSortableRank($newRank);
@@ -202,6 +251,12 @@ public function swapWith($object, ?ConnectionInterface $con = null)
         $con = Propel::getServiceContainer()->getWriteConnection(TableTableMap::DATABASE_NAME);
     }
     $con->transaction(function () use ($con, $object) {
+        $oldScope = $this->getScopeValue();
+        $newScope = $object->getScopeValue();
+        if ($oldScope != $newScope) {
+            $this->setScopeValue($newScope);
+            $object->setScopeValue($oldScope);
+        }
         $oldRank = $this->getSortableRank();
         $newRank = $object->getSortableRank();
 
@@ -297,7 +352,7 @@ public function moveToBottom(?ConnectionInterface $con = null)
     }
 
     $con->transaction(function () use ($con) {
-        $bottom = ChildTableQuery::create()->getMaxRankArray($con);
+        $bottom = ChildTableQuery::create()->getMaxRankArray($this->getScopeValue(), $con);
 
         $this->moveToRank($bottom, $con);
     });
@@ -306,21 +361,20 @@ public function moveToBottom(?ConnectionInterface $con = null)
 }
 
 /**
- * Removes the current object from the list.
+ * Removes the current object from the list (moves it to the null scope).
  * The modifications are not persisted until the object is saved.
  *
  * @return $this The current object
  */
 public function removeFromList()
 {
-    // Keep the list modification query for the save() transaction
-    $this->sortableQueries[] = [
-        'callable'  => ['\TableQuery', 'sortableShiftRank'],
-        'arguments' => [-1, $this->getSortableRank() + 1, null]
-    ];
-    // remove the object from the list
-    $this->setSortableRank(null);
-    
+    // check if object is already removed
+    if ($this->getScopeValue() === null) {
+        throw new PropelException('Object is already removed (has null scope)');
+    }
+
+    // move the object to the end of null scope
+    $this->setScopeValue(null);
 
     return $this;
 }
@@ -348,12 +402,18 @@ objectAttributes:
  */
 protected $sortableQueries = [];
 
+/**
+ * The old scope value.
+ * @var int
+ */
+protected $oldScope;
+
 
 preDelete:
 
 // sortable behavior
 
-ChildTableQuery::sortableShiftRank(-1, $this->getSortableRank() + 1, null, $con);
+ChildTableQuery::sortableShiftRank(-1, $this->getSortableRank() + 1, null, $this->getScopeValue(), $con);
 TableTableMap::clearInstancePool();
 
 
@@ -366,5 +426,15 @@ preInsert:
 
 // sortable behavior
 if (!$this->isColumnModified(TableTableMap::RANK_COL)) {
-    $this->setSortableRank(ChildTableQuery::create()->getMaxRankArray($con) + 1);
+    $this->setSortableRank(ChildTableQuery::create()->getMaxRankArray($this->getScopeValue(), $con) + 1);
+}
+
+
+preUpdate:
+
+// sortable behavior
+// if scope has changed and rank was not modified (if yes, assuming superior action)
+// insert object to the end of new scope and cleanup old one
+if (($this->isColumnModified(TableTableMap::COL_CATEGORY_ID) OR $this->isColumnModified(TableTableMap::COL_SUB_CATEGORY_ID)) && !$this->isColumnModified(TableTableMap::RANK_COL)) { ChildTableQuery::sortableShiftRank(-1, $this->getSortableRank() + 1, null, $this->oldScope, $con);
+    $this->insertAtBottom($con);
 }

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/sortable---query_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/sortable---query_reference.txt
@@ -5,15 +5,39 @@ queryMethods:
 // sortable behavior
 
 /**
+ * Returns the objects in a certain list, from the list scope
+ *
+ * @param int $scopeCategoryId Scope value for column `CategoryId`
+ * @param int $scopeSubCategoryId Scope value for column `SubCategoryId`
+ *
+ * @return $this
+ */
+public function inList($scopeCategoryId, $scopeSubCategoryId = null)
+{
+    
+    $scope[] = $scopeCategoryId;
+    $scope[] = $scopeSubCategoryId;
+
+
+    static::sortableApplyScopeCriteria($this, $scope, 'addUsingOperator');
+
+    return $this;
+}
+
+/**
  * Filter the query based on a rank in the list
  *
  * @param int $rank rank
+ * @param int $scopeCategoryId Scope value for column `CategoryId`
+ * @param int $scopeSubCategoryId Scope value for column `SubCategoryId`
+
  *
  * @return static
  */
-public function filterByRank($rank)
+public function filterByRank($rank, $scopeCategoryId, $scopeSubCategoryId = null)
 {
     return $this
+        ->inList($scopeCategoryId, $scopeSubCategoryId)
         ->addUsingOperator(TableTableMap::RANK_COL, $rank, Criteria::EQUAL);
 }
 
@@ -46,29 +70,35 @@ public function orderByRank(string $order = Criteria::ASC)
  * Get an item from the list based on its rank
  *
  * @param int $rank rank
+ * @param int $scopeCategoryId Scope value for column `CategoryId`
+ * @param int $scopeSubCategoryId Scope value for column `SubCategoryId`
  * @param \Propel\Runtime\Connection\ConnectionInterface $con optional connection
  *
  * @return ChildTable
  */
-public function findOneByRank($rank, ?ConnectionInterface $con = null)
+public function findOneByRank($rank, $scopeCategoryId, $scopeSubCategoryId = null, ?ConnectionInterface $con = null)
 {
 
     return $this
-        ->filterByRank($rank)
+        ->filterByRank($rank, $scopeCategoryId, $scopeSubCategoryId)
         ->findOne($con);
 }
 
 /**
- * Returns the list of objects
+ * Returns a list of objects
  *
+ * @param int $scopeCategoryId Scope value for column `CategoryId`
+ * @param int $scopeSubCategoryId Scope value for column `SubCategoryId`
+
  * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
  *
  * @return mixed the list of results, formatted by the current formatter
  */
-public function findList($con = null)
+public function findList($scopeCategoryId, $scopeSubCategoryId = null, $con = null)
 {
 
     return $this
+        ->inList($scopeCategoryId, $scopeSubCategoryId)
         ->orderByRank()
         ->find($con);
 }
@@ -76,17 +106,25 @@ public function findList($con = null)
 /**
  * Get the highest rank
  * 
+ * @param int $scopeCategoryId Scope value for column `CategoryId`
+ * @param int $scopeSubCategoryId Scope value for column `SubCategoryId`
  * @param \Propel\Runtime\Connection\ConnectionInterface $con Optional connection
  *
  * @return int|null Highest position
  */
-public function getMaxRank(?ConnectionInterface $con = null): ?int
+public function getMaxRank($scopeCategoryId, $scopeSubCategoryId = null, ?ConnectionInterface $con = null): ?int
 {
     if (null === $con) {
         $con = Propel::getServiceContainer()->getReadConnection(TableTableMap::DATABASE_NAME);
     }
     // shift the objects with a position lower than the one of object
     $this->addSelectColumn('MAX(' . TableTableMap::RANK_COL . ')');
+            
+    $scope[] = $scopeCategoryId;
+    $scope[] = $scopeSubCategoryId;
+
+
+            static::sortableApplyScopeCriteria($this, $scope);
     $stmt = $this->doSelect($con);
 
     return $stmt->fetchColumn();
@@ -95,17 +133,20 @@ public function getMaxRank(?ConnectionInterface $con = null): ?int
 /**
  * Get the highest rank by a scope with a array format.
  * 
+ * @param mixed $scope      The scope value as scalar type or array($value1, ...).
+
  * @param \Propel\Runtime\Connection\ConnectionInterface $con Optional connection
  *
  * @return int|null Highest position
  */
-public function getMaxRankArray(?ConnectionInterface $con = null): ?int
+public function getMaxRankArray($scope, ?ConnectionInterface $con = null): ?int
 {
     if ($con === null) {
         $con = Propel::getConnection(TableTableMap::DATABASE_NAME);
     }
     // shift the objects with a position lower than the one of object
     $this->addSelectColumn('MAX(' . TableTableMap::RANK_COL . ')');
+    static::sortableApplyScopeCriteria($this, $scope);
     $stmt = $this->doSelect($con);
 
     return $stmt->fetchColumn();
@@ -115,11 +156,12 @@ public function getMaxRankArray(?ConnectionInterface $con = null): ?int
  * Get an item from the list based on its rank
  *
  * @param int $rank rank
+ * @param int $scope        Scope to determine which suite to consider
  * @param \Propel\Runtime\Connection\ConnectionInterface $con optional connection
  *
  * @return ChildTable
  */
-static public function retrieveByRank($rank, ?ConnectionInterface $con = null)
+static public function retrieveByRank($rank, $scope = null, ?ConnectionInterface $con = null)
 {
     if (null === $con) {
         $con = Propel::getServiceContainer()->getReadConnection(TableTableMap::DATABASE_NAME);
@@ -127,6 +169,7 @@ static public function retrieveByRank($rank, ?ConnectionInterface $con = null)
 
     $c = new Criteria;
     $c->addAnd(TableTableMap::RANK_COL, $rank);
+    static::sortableApplyScopeCriteria($c, $scope);
 
     return static::create(null, $c)->findOne($con);
 }
@@ -196,15 +239,83 @@ static public function doSelectOrderByRank(?Criteria $criteria = null, $order = 
 }
 
 /**
+ * Return an array of sortable objects in the given scope ordered by position
+ *
+ * @param int $scope  the scope of the list
+ * @param string $order  sorting order, to be chosen between Criteria::ASC (default) and Criteria::DESC
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con    optional connection
+ *
+ * @return \Propel\Runtime\Collection\ObjectCollection List of sortable objects
+ */
+static public function retrieveList($scope, $order = Criteria::ASC, ?ConnectionInterface $con = null)
+{
+    $c = new Criteria();
+    static::sortableApplyScopeCriteria($c, $scope);
+
+    return ChildTableQuery::doSelectOrderByRank($c, $order, $con);
+}
+
+/**
+ * Return the number of sortable objects in the given scope
+ *
+ * @param int $scope  the scope of the list
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con    optional connection
+ *
+ * @return int Count.
+ */
+static public function countList($scope, ?ConnectionInterface $con = null): int
+{
+    $c = new Criteria();
+    $c->addFilter(TableTableMap::SCOPE_COL, $scope);
+
+    return ChildTableQuery::create(null, $c)->count($con);
+}
+
+/**
+ * Deletes the sortable objects in the given scope
+ *
+ * @param int $scope  the scope of the list
+ * @param \Propel\Runtime\Connection\ConnectionInterface $con    optional connection
+ *
+ * @return int number of deleted objects
+ */
+static public function deleteList($scope, ?ConnectionInterface $con = null): int
+{
+    $c = new Criteria();
+    static::sortableApplyScopeCriteria($c, $scope);
+
+    return TableTableMap::doDelete($c, $con);
+}
+
+/**
+ * Applies all scope fields to the given criteria.
+ *
+ * @param \Propel\Runtime\ActiveQuery\Criteria $criteria Applies the values directly to this criteria.
+ * @param mixed $scope The scope value as scalar type or array($value1, ...).
+ * @param string $method The method we use to apply the values.
+ *
+ * @return void
+ */
+static public function sortableApplyScopeCriteria(Criteria $criteria, $scope, string $method = 'addFilter'): void
+{
+
+    $criteria->$method(TableTableMap::COL_CATEGORY_ID, $scope[0], Criteria::EQUAL);
+
+    $criteria->$method(TableTableMap::COL_SUB_CATEGORY_ID, $scope[1], Criteria::EQUAL);
+
+}
+
+/**
  * Adds $delta to all Rank values that are >= $first and <= $last.
  * '$delta' can also be negative.
  *
  * @param int $delta Value to be shifted by, can be negative
  * @param int $first First node to be shifted
  * @param int $last  Last node to be shifted
+ * @param int $scope Scope to use for the shift
  * @param \Propel\Runtime\Connection\ConnectionInterface $con Connection to use.
  */
-static public function sortableShiftRank($delta, $first, $last = null, ?ConnectionInterface $con = null)
+static public function sortableShiftRank($delta, $first, $last = null, $scope = null, ?ConnectionInterface $con = null)
 {
     if (null === $con) {
         $con = Propel::getServiceContainer()->getWriteConnection(TableTableMap::DATABASE_NAME);
@@ -216,6 +327,7 @@ static public function sortableShiftRank($delta, $first, $last = null, ?Connecti
         $criterion->addAnd($whereCriteria->getNewCriterion(TableTableMap::RANK_COL, $last, Criteria::LESS_EQUAL));
     }
     $whereCriteria->addFilter($criterion);
+    static::sortableApplyScopeCriteria($whereCriteria, $scope);
 
     $whereCriteria->setUpdateExpression(TableTableMap::RANK_COL, TableTableMap::RANK_COL . ' + ?', $delta, \PDO::PARAM_INT);
 

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/sortable---tablemap_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/sortable---tablemap_reference.txt
@@ -8,3 +8,16 @@ staticAttributes:
  */
 const RANK_COL = "table.sortable_rank";
 
+
+    /**
+* If defined, the `SCOPE_COL` contains a json_encoded array with all columns.
+* @var bool
+*/
+const MULTI_SCOPE_COL = true;
+
+    
+/**
+* Scope column for the set
+*/
+const SCOPE_COL = '["table.CATEGORY_ID","table.SUB_CATEGORY_ID"]';
+

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/versionable---object_reference.txt
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorCodeTest/expected_behavior_code/versionable---object_reference.txt
@@ -77,6 +77,9 @@ public function addVersion(?ConnectionInterface $con = null)
     $version->setId($this->getId());
     $version->setBar($this->getBar());
     $version->setCustomversion($this->getCustomversion());
+    $version->setVersionCreatedAt($this->getVersionCreatedAt());
+    $version->setVersionCreatedBy($this->getVersionCreatedBy());
+    $version->setVersionComment($this->getVersionComment());
     $version->setTable($this);
     $version->save($con);
 
@@ -117,6 +120,9 @@ public function populateFromVersion($version, $con = null, &$loadedObjects = [])
     $this->setId($version->getId());
     $this->setBar($version->getBar());
     $this->setCustomversion($version->getCustomversion());
+    $this->setVersionCreatedAt($version->getVersionCreatedAt());
+    $this->setVersionCreatedBy($version->getVersionCreatedBy());
+    $this->setVersionComment($version->getVersionComment());
 
     return $this;
 }
@@ -258,6 +264,9 @@ protected function computeDiff($fromVersion, $toVersion, $keys = 'columns', $ign
     $toVersionNumber = $toVersion['Customversion'];
     $ignoredColumns = array_merge(array(
         'Customversion',
+        'VersionCreatedAt',
+        'VersionCreatedBy',
+        'VersionComment',
     ), $ignoredColumns);
     $diff = [];
     foreach ($fromVersion as $key => $value) {
@@ -316,6 +325,9 @@ preSave:
 // versionable behavior
 if ($this->isVersioningNecessary()) {
     $this->setCustomversion($this->isNew() ? 1 : $this->getLastVersionNumber($con) + 1);
+    if (!$this->isColumnModified(TableTableMap::COL_VERSION_CREATED_AT)) {
+        $this->setVersionCreatedAt(time());
+    }
     $createVersion = true; // for postSave hook
 }
 

--- a/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorTest.php
@@ -8,6 +8,7 @@
 
 namespace Propel\Tests\Generator\Behavior\Sortable;
 
+use InvalidArgumentException;
 use Propel\Tests\Bookstore\Behavior\Map\SortableTable11TableMap;
 use Propel\Tests\Bookstore\Behavior\Map\SortableTable12TableMap;
 
@@ -33,5 +34,24 @@ class SortableBehaviorTest extends TestCase
         $table12 = SortableTable12TableMap::getTableMap();
         $this->assertEquals(count($table12->getColumns()), 4, 'Sortable does not add a column when it already exists');
         $this->assertTrue(method_exists('Propel\Tests\Bookstore\Behavior\SortableTable12', 'getPosition'), 'Sortable allows customization of rank_column name');
+    }
+
+    public function testNoScopeColumnError(): void
+    {
+        $schema = <<<XML
+    <database>
+        <table name="table">
+            <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER"/>
+
+            <behavior name="sortable">
+                <parameter name="use_scope" value="true"/>
+            </behavior>
+        </table>
+    </database>
+XML;
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("The sortable behavior in `table` needs a `scope_column` parameter.");
+        $this->buildDatabaseFromSchema($schema);
     }
 }


### PR DESCRIPTION
## Issue
- Codecov showed that  #140 missed some behavior code. 
- also, stan suddenly failed due to deprecation of `PDO::ERRMODE_WARNING` (see [run](https://github.com/perplorm/perpl/actions/runs/25078685015/job/73478093160)).



## Changes
- Added missing builders and updated schema snippets to code reference builder.
- Changed `PDO::ERRMODE_WARNING` to `PDO::ERRMODE_EXCEPTION` (deprecation is explained [here](https://wiki.php.net/rfc/deprecations_php_8_5#dokuwiki__top)).


## Implementation Details
Sortable behavior broke on missing attribute, because check came too late. I have switched it around.




## Notes
The `versionable` behavior broke when I added a FK. The code is not well documented, I am not completely sure what it does, but some lines look suspicious - I would not take a bet on it working as expected. So I removed the FK from the reference file again.