### PR TITLE
versionable+archiveable behavior fix and cleanup

### DIFF
--- a/src/Propel/Generator/Behavior/AggregateColumn/AggregateColumnBehavior.php
+++ b/src/Propel/Generator/Behavior/AggregateColumn/AggregateColumnBehavior.php
@@ -20,18 +20,18 @@ use function sprintf;
  */
 class AggregateColumnBehavior extends Behavior
 {
-    /**
-     * Default parameters value
-     *
-     * @var array<string, mixed>
-     */
-    protected $parameters = [
-        'name' => null,
-        'expression' => null,
-        'condition' => null,
-        'foreign_table' => null,
-        'foreign_schema' => null,
-    ];
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->parameters = [
+            'name' => null,
+            'expression' => null,
+            'condition' => null,
+            'foreign_table' => null,
+            'foreign_schema' => null,
+        ];
+    }
 
     /**
      * Multiple aggregates on the same table is OK.

--- a/src/Propel/Generator/Behavior/AggregateColumn/AggregateColumnRelationBehavior.php
+++ b/src/Propel/Generator/Behavior/AggregateColumn/AggregateColumnRelationBehavior.php
@@ -18,16 +18,16 @@ use function str_replace;
  */
 class AggregateColumnRelationBehavior extends Behavior
 {
-    /**
-     * Default parameters value
-     *
-     * @var array<string, mixed>
-     */
-    protected $parameters = [
-        'foreign_table' => '',
-        'update_method' => '',
-        'aggregate_name' => '',
-    ];
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->parameters = [
+            'foreign_table' => '',
+            'update_method' => '',
+            'aggregate_name' => '',
+        ];
+    }
 
     /**
      * @return bool

--- a/src/Propel/Generator/Behavior/AggregateMultipleColumns/AggregateMultipleColumnsBehavior.php
+++ b/src/Propel/Generator/Behavior/AggregateMultipleColumns/AggregateMultipleColumnsBehavior.php
@@ -55,28 +55,25 @@ class AggregateMultipleColumnsBehavior extends Behavior
     public const PARAMETER_KEY_COLUMN_EXPRESSION = 'expression';
 
     /**
-     * Keeps track of inserted aggregation functions to avoid naming collisions.
+     * Maps table name to inserted aggregation function names. Used to detect naming collisions.
      *
-     * @var array
+     * @var array<string, list<string>>
      */
-    private static $insertedAggregationNames = [];
+    private static array $insertedAggregationNames = [];
 
-    /**
-     * Default parameters value.
-     *
-     * @var array<string, mixed>
-     */
-    protected $parameters = [
-        self::PARAMETER_KEY_FOREIGN_TABLE => null,
-        self::PARAMETER_KEY_FOREIGN_SCHEMA => null,
-        self::PARAMETER_KEY_CONDITION => null,
-        self::PARAMETER_KEY_COLUMNS => null,
-    ];
+    private string|null $aggregationName = null;
 
-    /**
-     * @var string|null
-     */
-    private $aggregationName;
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->parameters = [
+            self::PARAMETER_KEY_FOREIGN_TABLE => null,
+            self::PARAMETER_KEY_FOREIGN_SCHEMA => null,
+            self::PARAMETER_KEY_CONDITION => null,
+            self::PARAMETER_KEY_COLUMNS => null,
+        ];
+    }
 
     /**
      * Reset the function name memorizer. Needed when running tests.
@@ -298,12 +295,14 @@ class AggregateMultipleColumnsBehavior extends Behavior
     protected function addObjectUpdate(): string
     {
         $table = $this->getTable();
-        $columnPhpNames = array_map(function (array $columnParameters) use ($table) {
-            $columName = $columnParameters[self::PARAMETER_KEY_COLUMN_NAME];
+        $columnPhpNames = array_map(
+            function (array $columnParameters) use ($table) {
+                $columnName = $columnParameters[self::PARAMETER_KEY_COLUMN_NAME];
 
-            return $table->getColumn($columName)->getPhpName();
-        },
-        $this->getParameter(static::PARAMETER_KEY_COLUMNS));
+                return $table->getColumn($columnName)->getPhpName();
+            },
+            $this->getParameter(static::PARAMETER_KEY_COLUMNS),
+        );
 
         return $this->renderLocalTemplate('objectUpdate', [
             'aggregationName' => $this->getAggregationName(),

--- a/src/Propel/Generator/Behavior/Archivable/ArchivableBehavior.php
+++ b/src/Propel/Generator/Behavior/Archivable/ArchivableBehavior.php
@@ -36,15 +36,14 @@ class ArchivableBehavior extends SyncedTableBehavior
      */
     public const PARAMETER_KEY_SYNCED_PHPNAME = 'archive_phpname';
 
-    /**
-     * @var \Propel\Generator\Behavior\Archivable\ArchivableBehaviorObjectBuilderModifier|null
-     */
-    protected $objectBuilderModifier;
+    protected ArchivableBehaviorObjectBuilderModifier|null $objectBuilderModifier = null;
 
-    /**
-     * @var \Propel\Generator\Behavior\Archivable\ArchivableBehaviorQueryBuilderModifier|null
-     */
-    protected $queryBuilderModifier;
+    protected ArchivableBehaviorQueryBuilderModifier|null $queryBuilderModifier = null;
+
+    public function __construct()
+    {
+        $this->tableModificationOrder = 90; // should be higher than behaviors adding columns to table (i.e. Versionable)
+    }
 
     /**
      * @see \Propel\Generator\Behavior\SyncedTable\SyncedTableBehavior::getDefaultParameters()

--- a/src/Propel/Generator/Behavior/AutoAddPk/AutoAddPkBehavior.php
+++ b/src/Propel/Generator/Behavior/AutoAddPk/AutoAddPkBehavior.php
@@ -12,16 +12,16 @@ use function array_merge;
  */
 class AutoAddPkBehavior extends Behavior
 {
-    /**
-     * Default parameters value
-     *
-     * @var array<string, mixed>
-     */
-    protected $parameters = [
-        'name' => 'id',
-        'autoIncrement' => 'true',
-        'type' => 'INTEGER',
-    ];
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->parameters = [
+            'name' => 'id',
+            'autoIncrement' => 'true',
+            'type' => 'INTEGER',
+        ];
+    }
 
     /**
      * Copy the behavior to the database tables

--- a/src/Propel/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehavior.php
+++ b/src/Propel/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehavior.php
@@ -35,24 +35,21 @@ class ConcreteInheritanceBehavior extends Behavior
      */
     protected const ATTRIBUTE_IS_PARENT_CHILD = 'is-parent-child';
 
-    /**
-     * @var \Propel\Generator\Builder\Om\ObjectBuilder
-     */
-    protected $builder;
+    protected ObjectBuilder|null $builder = null;
 
-    /**
-     * Default parameters value
-     *
-     * @var array<string, mixed>
-     */
-    protected $parameters = [
-        'extends' => '',
-        'descendant_column' => 'descendant_class',
-        'copy_data_to_parent' => 'true',
-        'copy_data_to_child' => 'false',
-        'schema' => '',
-        'exclude_behaviors' => '',
-    ];
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->parameters = [
+            'extends' => '',
+            'descendant_column' => 'descendant_class',
+            'copy_data_to_parent' => 'true',
+            'copy_data_to_child' => 'false',
+            'schema' => '',
+            'exclude_behaviors' => '',
+        ];
+    }
 
     /**
      * @return void

--- a/src/Propel/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceParentBehavior.php
+++ b/src/Propel/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceParentBehavior.php
@@ -14,19 +14,16 @@ use Propel\Generator\Model\Behavior;
  */
 class ConcreteInheritanceParentBehavior extends Behavior
 {
-    /**
-     * @var \Propel\Generator\Builder\Om\ObjectBuilder
-     */
-    protected $builder;
+    protected ObjectBuilder|null $builder = null;
 
-    /**
-     * Default parameters value
-     *
-     * @var array<string, mixed>
-     */
-    protected $parameters = [
-        'descendant_column' => 'descendant_class',
-    ];
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->parameters = [
+            'descendant_column' => 'descendant_class',
+        ];
+    }
 
     /**
      * @return void

--- a/src/Propel/Generator/Behavior/Delegate/DelegateBehavior.php
+++ b/src/Propel/Generator/Behavior/Delegate/DelegateBehavior.php
@@ -41,23 +41,23 @@ class DelegateBehavior extends Behavior
     public const MANY_TO_ONE = 2;
 
     /**
-     * Default parameters value
-     *
-     * @var array<string, mixed>
-     */
-    protected $parameters = [
-        'to' => '',
-    ];
-
-    /**
      * @var array<int>
      */
-    protected $delegates = [];
+    protected array $delegates = [];
 
     /**
-     * @var array|null
+     * @var array<string, int> |null
      */
-    protected $doubleDefined;
+    protected array|null $doubleDefined = null;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->parameters = [
+            'to' => '',
+        ];
+    }
 
     /**
      * Lists the delegates and checks that the behavior can use them,
@@ -247,10 +247,7 @@ if (method_exists({$ARFQCN}::class, \$name)) {
                 $delegateTable = $this->getDelegateTable($key);
                 foreach ($delegateTable->getColumns() as $columnDelegated) {
                     $columnName = $columnDelegated->getName();
-                    if (!isset($this->doubleDefined[$columnName])) {
-                        $this->doubleDefined[$columnName] = 0;
-                    }
-                    $this->doubleDefined[$columnName]++;
+                    $this->doubleDefined[$columnName] = ($this->doubleDefined[$columnName] ?? 0) + 1;
                 }
             }
         }

--- a/src/Propel/Generator/Behavior/I18n/I18nBehavior.php
+++ b/src/Propel/Generator/Behavior/I18n/I18nBehavior.php
@@ -7,11 +7,13 @@ namespace Propel\Generator\Behavior\I18n;
 use Propel\Generator\Behavior\Validate\ValidateBehavior;
 use Propel\Generator\Builder\Om\AbstractOMBuilder;
 use Propel\Generator\Exception\EngineException;
+use Propel\Generator\Exception\LogicException;
 use Propel\Generator\Model\Behavior;
 use Propel\Generator\Model\Column;
 use Propel\Generator\Model\ForeignKey;
 use Propel\Generator\Model\PropelTypes;
 use Propel\Generator\Model\Table;
+use function array_find;
 use function array_merge;
 use function count;
 use function explode;
@@ -31,41 +33,28 @@ class I18nBehavior extends Behavior
      */
     public const DEFAULT_LOCALE = 'en_US';
 
-    /**
-     * Default parameters value
-     *
-     * @var array<string, mixed>
-     */
-    protected $parameters = [
-        'i18n_table' => '%TABLE%_i18n',
-        'i18n_phpname' => '%PHPNAME%I18n',
-        'i18n_columns' => '',
-        'i18n_pk_column' => null,
-        'locale_column' => 'locale',
-        'locale_length' => 5,
-        'default_locale' => null,
-        'locale_alias' => '',
-    ];
+    protected I18nBehaviorObjectBuilderModifier|null $objectBuilderModifier = null;
 
-    /**
-     * @var int
-     */
-    protected $tableModificationOrder = 70;
+    protected I18nBehaviorQueryBuilderModifier|null $queryBuilderModifier = null;
 
-    /**
-     * @var \Propel\Generator\Behavior\I18n\I18nBehaviorObjectBuilderModifier|null
-     */
-    protected $objectBuilderModifier;
+    protected Table|null $i18nTable = null;
 
-    /**
-     * @var \Propel\Generator\Behavior\I18n\I18nBehaviorQueryBuilderModifier|null
-     */
-    protected $queryBuilderModifier;
+    public function __construct()
+    {
+        parent::__construct();
 
-    /**
-     * @var \Propel\Generator\Model\Table
-     */
-    protected $i18nTable;
+        $this->tableModificationOrder = 70;
+        $this->parameters = [
+            'i18n_table' => '%TABLE%_i18n',
+            'i18n_phpname' => '%PHPNAME%I18n',
+            'i18n_columns' => '',
+            'i18n_pk_column' => null,
+            'locale_column' => 'locale',
+            'locale_length' => 5,
+            'default_locale' => null,
+            'locale_alias' => '',
+        ];
+    }
 
     /**
      * @return void
@@ -97,10 +86,16 @@ class I18nBehavior extends Behavior
     }
 
     /**
+     * @throws \Propel\Generator\Exception\LogicException
+     *
      * @return \Propel\Generator\Model\Table
      */
     public function getI18nTable(): Table
     {
+        if (!$this->i18nTable) {
+            throw new LogicException('Cannot access i18n table before modifyTable() was called.');
+        }
+
         return $this->i18nTable;
     }
 
@@ -109,13 +104,7 @@ class I18nBehavior extends Behavior
      */
     public function getI18nForeignKey(): ?ForeignKey
     {
-        foreach ($this->i18nTable->getForeignKeys() as $fk) {
-            if ($fk->getForeignTableName() == $this->table->getName()) {
-                return $fk;
-            }
-        }
-
-        return null;
+        return array_find($this->getI18nTable()->getForeignKeys(), fn (ForeignKey $fk) => $fk->getForeignTableName() === $this->table->getName());
     }
 
     /**
@@ -258,7 +247,7 @@ class I18nBehavior extends Behavior
     protected function relateI18nTableToMainTable(): void
     {
         $table = $this->getTable();
-        $i18nTable = $this->i18nTable;
+        $i18nTable = $this->getI18nTable();
         $pks = $this->getTable()->getPrimaryKey();
 
         if (count($pks) > 1) {
@@ -299,8 +288,8 @@ class I18nBehavior extends Behavior
     {
         $localeColumnName = $this->getLocaleColumnName();
 
-        if (!$this->i18nTable->hasColumn($localeColumnName)) {
-            $this->i18nTable->addColumn([
+        if (!$this->getI18nTable()->hasColumn($localeColumnName)) {
+            $this->getI18nTable()->addColumn([
                 'name' => $localeColumnName,
                 'type' => PropelTypes::VARCHAR,
                 'size' => $this->getParameter('locale_length') ? (int)$this->getParameter('locale_length') : 5,
@@ -320,7 +309,7 @@ class I18nBehavior extends Behavior
     protected function moveI18nColumns(): void
     {
         $table = $this->getTable();
-        $i18nTable = $this->i18nTable;
+        $i18nTable = $this->getI18nTable();
 
         $i18nValidateParams = [];
         foreach ($this->getI18nColumnNamesFromConfig() as $columnName) {

--- a/src/Propel/Generator/Behavior/NestedSet/NestedSetBehavior.php
+++ b/src/Propel/Generator/Behavior/NestedSet/NestedSetBehavior.php
@@ -13,20 +13,6 @@ use Propel\Generator\Model\Column;
 class NestedSetBehavior extends Behavior
 {
     /**
-     * Default parameters value
-     *
-     * @var array<string, mixed>
-     */
-    protected $parameters = [
-        'left_column' => 'tree_left',
-        'right_column' => 'tree_right',
-        'level_column' => 'tree_level',
-        'use_scope' => 'false',
-        'scope_column' => 'tree_scope',
-        'method_proxies' => 'false',
-    ];
-
-    /**
      * @var \Propel\Generator\Behavior\NestedSet\NestedSetBehaviorObjectBuilderModifier|null
      */
     protected $objectBuilderModifier;
@@ -35,6 +21,20 @@ class NestedSetBehavior extends Behavior
      * @var \Propel\Generator\Behavior\NestedSet\NestedSetBehaviorQueryBuilderModifier|null
      */
     protected $queryBuilderModifier;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->parameters = [
+            'left_column' => 'tree_left',
+            'right_column' => 'tree_right',
+            'level_column' => 'tree_level',
+            'use_scope' => 'false',
+            'scope_column' => 'tree_scope',
+            'method_proxies' => 'false',
+        ];
+    }
 
     /**
      * Add the left, right and scope to the current table

--- a/src/Propel/Generator/Behavior/OutputGroup/OutputGroupBehavior.php
+++ b/src/Propel/Generator/Behavior/OutputGroup/OutputGroupBehavior.php
@@ -20,15 +20,6 @@ class OutputGroupBehavior extends Behavior
     public const PARAMETER_OBJECT_COLLECTION_CLASS = 'object_collection_class';
 
     /**
-     * Default parameters value
-     *
-     * @var array<string, mixed>
-     */
-    protected $parameters = [
-        self::PARAMETER_OBJECT_COLLECTION_CLASS => null,
-    ];
-
-    /**
      * @var string
      */
     public const SCHEMA_ATTRIBUTE_OUTPUT_GROUP = 'outputGroup';
@@ -48,20 +39,20 @@ class OutputGroupBehavior extends Behavior
      */
     public const SCHEMA_ATTRIBUTE_REF_IGNORE_GROUP = 'refIgnoreGroup';
 
-    /**
-     * @var \Propel\Generator\Behavior\OutputGroup\OgObjectModifier|null
-     */
-    protected $objectModifier;
+    protected OgObjectModifier|null $objectModifier = null;
 
-    /**
-     * @var \Propel\Generator\Behavior\OutputGroup\OgTableMapModifier|null
-     */
-    protected $tableModifier;
+    protected OgTableMapModifier|null $tableModifier = null;
 
-    /**
-     * @var \Propel\Generator\Behavior\OutputGroup\OgQueryModifier|null
-     */
-    protected $queryModifier;
+    protected OgQueryModifier|null $queryModifier = null;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->parameters = [
+            self::PARAMETER_OBJECT_COLLECTION_CLASS => null,
+        ];
+    }
 
     /**
      * @see \Propel\Generator\Model\Behavior::getObjectBuilderModifier()

--- a/src/Propel/Generator/Behavior/QueryCache/QueryCacheBehavior.php
+++ b/src/Propel/Generator/Behavior/QueryCache/QueryCacheBehavior.php
@@ -13,19 +13,19 @@ use Propel\Generator\Model\Behavior;
 class QueryCacheBehavior extends Behavior
 {
     /**
-     * Default parameters value
-     *
-     * @var array<string, mixed>
-     */
-    protected $parameters = [
-        'backend' => 'apc',
-        'lifetime' => '3600',
-    ];
-
-    /**
      * @var string
      */
     private $tableClassName;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->parameters = [
+            'backend' => 'apc',
+            'lifetime' => '3600',
+        ];
+    }
 
     /**
      * @param \Propel\Generator\Builder\Om\AbstractOMBuilder $builder

--- a/src/Propel/Generator/Behavior/Sluggable/SluggableBehavior.php
+++ b/src/Propel/Generator/Behavior/Sluggable/SluggableBehavior.php
@@ -15,24 +15,23 @@ use function str_replace;
  */
 class SluggableBehavior extends Behavior
 {
-    /**
-     * @var \Propel\Generator\Builder\Om\AbstractOMBuilder
-     */
-    private $builder;
+    private AbstractOMBuilder|null $builder = null;
 
-    /**
-     * @var array<string, mixed>
-     */
-    protected $parameters = [
-        'slug_column' => 'slug',
-        'slug_pattern' => '',
-        'replace_pattern' => '/\W+/',
-        'replacement' => '-',
-        'separator' => '-',
-        'permanent' => 'false',
-        'scope_column' => '',
-        'unique_constraint' => 'true',
-    ];
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->parameters = [
+            'slug_column' => 'slug',
+            'slug_pattern' => '',
+            'replace_pattern' => '/\W+/',
+            'replacement' => '-',
+            'separator' => '-',
+            'permanent' => 'false',
+            'scope_column' => '',
+            'unique_constraint' => 'true',
+        ];
+    }
 
     /**
      * Adds the slug_column to the current table.

--- a/src/Propel/Generator/Behavior/Sortable/SortableBehavior.php
+++ b/src/Propel/Generator/Behavior/Sortable/SortableBehavior.php
@@ -20,31 +20,22 @@ use function sprintf;
  */
 class SortableBehavior extends Behavior
 {
-    /**
-     * Default parameters value
-     *
-     * @var array<string, mixed>
-     */
-    protected $parameters = [
-        'rank_column' => 'sortable_rank',
-        'use_scope' => 'false',
-        'scope_column' => '',
-    ];
+    protected SortableBehaviorObjectBuilderModifier|null $objectBuilderModifier = null;
 
-    /**
-     * @var \Propel\Generator\Behavior\Sortable\SortableBehaviorObjectBuilderModifier|null
-     */
-    protected $objectBuilderModifier;
+    protected SortableBehaviorQueryBuilderModifier|null $queryBuilderModifier = null;
 
-    /**
-     * @var \Propel\Generator\Behavior\Sortable\SortableBehaviorQueryBuilderModifier|null
-     */
-    protected $queryBuilderModifier;
+    protected SortableBehaviorTableMapBuilderModifier|null $tableMapBuilderModifier = null;
 
-    /**
-     * @var \Propel\Generator\Behavior\Sortable\SortableBehaviorTableMapBuilderModifier|null
-     */
-    protected $tableMapBuilderModifier;
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->parameters = [
+            'rank_column' => 'sortable_rank',
+            'use_scope' => 'false',
+            'scope_column' => '',
+        ];
+    }
 
     /**
      * Add the rank_column to the current table

--- a/src/Propel/Generator/Behavior/SyncedTable/SyncedTableBehavior.php
+++ b/src/Propel/Generator/Behavior/SyncedTable/SyncedTableBehavior.php
@@ -21,10 +21,7 @@ use function strtolower;
  */
 class SyncedTableBehavior extends SyncedTableBehaviorDeclaration
 {
-    /**
-     * @var \Propel\Generator\Model\Table|null
-     */
-    protected $syncedTable;
+    protected Table|null $syncedTable = null;
 
     /**
      * @return \Propel\Generator\Model\Table|null

--- a/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
+++ b/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
@@ -16,15 +16,17 @@ use function strtoupper;
  */
 class TimestampableBehavior extends Behavior
 {
-    /**
-     * @var array<string, mixed>
-     */
-    protected $parameters = [
-        'create_column' => 'created_at',
-        'update_column' => 'updated_at',
-        'disable_created_at' => 'false',
-        'disable_updated_at' => 'false',
-    ];
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->parameters = [
+            'create_column' => 'created_at',
+            'update_column' => 'updated_at',
+            'disable_created_at' => 'false',
+            'disable_updated_at' => 'false',
+        ];
+    }
 
     /**
      * @return bool

--- a/src/Propel/Generator/Behavior/Versionable/VersionableBehavior.php
+++ b/src/Propel/Generator/Behavior/Versionable/VersionableBehavior.php
@@ -43,32 +43,22 @@ class VersionableBehavior extends SyncedTableBehavior
      */
     public const PARAMETER_KEY_SYNC_INDEXES = 'indices';
 
-    /**
-     * @var \Propel\Generator\Model\Table
-     */
-    protected $versionTable;
+    protected VersionableBehaviorObjectBuilderModifier|null $objectBuilderModifier = null;
 
-    /**
-     * @var \Propel\Generator\Behavior\Versionable\VersionableBehaviorObjectBuilderModifier|null
-     */
-    protected $objectBuilderModifier;
-
-    /**
-     * @var \Propel\Generator\Behavior\Versionable\VersionableBehaviorQueryBuilderModifier|null
-     */
-    protected $queryBuilderModifier;
-
-    /**
-     * @var int
-     */
-    protected $tableModificationOrder = 80;
+    protected VersionableBehaviorQueryBuilderModifier|null $queryBuilderModifier = null;
 
     /**
      * Track added version tables.
      *
-     * @var array
+     * @var array<\Propel\Generator\Model\Table>
      */
-    protected $versionTables = [];
+    protected array $versionTables = [];
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->tableModificationOrder = 80;
+    }
 
     /**
      * @see \Propel\Generator\Behavior\SyncedTable\SyncedTableBehavior::getDefaultParameters()

--- a/src/Propel/Generator/Model/Behavior.php
+++ b/src/Propel/Generator/Model/Behavior.php
@@ -24,86 +24,63 @@ class Behavior extends MappingModel
     use PathTrait;
 
     /**
+     * @var string
+     */
+    final public const PARAM_NAME_TABLE_MODIFICATION_ORDER = 'order-lateness';
+
+    /**
      * The table object on which the behavior is applied.
-     *
-     * @var \Propel\Generator\Model\Table
      */
-    protected $table;
+    protected Table|null $table = null;
+
+    protected Database|null $database = null;
+
+    protected string|null $id = null;
+
+    protected string|null $name = null;
 
     /**
-     * The database object.
-     *
-     * @var \Propel\Generator\Model\Database
-     */
-    protected $database;
-
-    /**
-     * The behavior id.
-     *
-     * @var string
-     */
-    protected $id;
-
-    /**
-     * The behavior name.
-     *
-     * @var string
-     */
-    protected $name;
-
-    /**
-     * A collection of parameters.
-     *
      * @var array<string, mixed>
      */
     protected $parameters = [];
 
     /**
-     * Whether the table has been
-     * modified by the behavior.
-     *
-     * @var bool
+     * Whether the table has been modified by the behavior.
      */
-    protected $isTableModified = false;
+    protected bool $isTableModified = false;
 
     /**
-     * The absolute path to the directory
-     * that contains the behavior's templates
-     * files.
+     * The absolute path to the directory that contains the behavior's files.
      *
-     * @var string
+     * @var string|null
      */
-    protected $dirname;
+    protected string|null $dirname = null;
 
     /**
-     * A collection of additional builders.
+     * Custom builders to create additional table classes in {@see \Propel\Generator\Manager\ModelManager::build()}
      *
-     * @var array
+     * @var array<class-string<\Propel\Generator\Builder\Om\AbstractOMBuilder>>
      */
-    protected $additionalBuilders = [];
+    protected array $additionalBuilders = [];
 
     /**
-     * The order in which the behavior must
-     * be applied.
-     *
-     * @var int
+     * The order in which the behavior must be applied.
      */
-    protected $tableModificationOrder = 50;
+    protected int $tableModificationOrder = 50;
+
+    public function __construct()
+    {
+    }
 
     /**
-     * Sets the name of the Behavior
-     *
-     * @param string $name the name of the behavior
+     * @param string $name
      *
      * @return void
      */
     public function setName(string $name): void
     {
         $this->name = $name;
-
-        if ($this->id === null) {
-            $this->id = $name;
-        }
+        $this->id ??= $name;
     }
 
     /**
@@ -130,18 +107,20 @@ class Behavior extends MappingModel
     }
 
     /**
-     * Returns the id of the Behavior
+     * @throws \Propel\Generator\Exception\LogicException
      *
      * @return string
      */
     public function getId(): string
     {
+        if ($this->id === null) {
+            throw new LogicException('Id not set.');
+        }
+
         return $this->id;
     }
 
     /**
-     * Returns the name of the Behavior
-     *
      * @return string|null
      */
     public function getName(): ?string
@@ -205,10 +184,16 @@ class Behavior extends MappingModel
      * Returns the table this behavior is applied to if behavior is applied to
      * a database element.
      *
+     * @throws \Propel\Generator\Exception\LogicException
+     *
      * @return \Propel\Generator\Model\Database
      */
     public function getDatabase(): Database
     {
+        if ($this->database === null) {
+            throw new LogicException('Database not set.');
+        }
+
         return $this->database;
     }
 
@@ -300,6 +285,8 @@ class Behavior extends MappingModel
      *
      * Default is 50.
      *
+     * @see Database::getNextTableBehavior()
+     *
      * @return int
      */
     public function getTableModificationOrder(): int
@@ -368,9 +355,19 @@ class Behavior extends MappingModel
      *
      * @return bool
      */
-    public function isTableModified(): bool
+    public function hasBeenApplied(): bool
     {
         return $this->isTableModified;
+    }
+
+    /**
+     * @deprecated Use aptly named {@see static::hasBeenApplied()}
+     *
+     * @return bool
+     */
+    public function isTableModified(): bool
+    {
+        return $this->hasBeenApplied();
     }
 
     /**
@@ -482,6 +479,7 @@ class Behavior extends MappingModel
         }
 
         $this->id = $this->getAttribute('id', $this->name);
+        $this->tableModificationOrder = (int)$this->getAttribute(static::PARAM_NAME_TABLE_MODIFICATION_ORDER, $this->tableModificationOrder);
     }
 
     /**
@@ -563,7 +561,7 @@ class Behavior extends MappingModel
     /**
      * Returns the list of additional builder objects.
      *
-     * @return array
+     * @return array<class-string<\Propel\Generator\Builder\Om\AbstractOMBuilder>>
      */
     public function getAdditionalBuilders(): array
     {

--- a/src/Propel/Generator/Model/Behavior.php
+++ b/src/Propel/Generator/Model/Behavior.php
@@ -26,7 +26,7 @@ class Behavior extends MappingModel
     /**
      * @var string
      */
-    final public const PARAM_NAME_TABLE_MODIFICATION_ORDER = 'order-lateness';
+    final public const PARAM_NAME_TABLE_MODIFICATION_ORDER = 'order-delay';
 
     /**
      * The table object on which the behavior is applied.

--- a/src/Propel/Generator/Model/BehaviorableTrait.php
+++ b/src/Propel/Generator/Model/BehaviorableTrait.php
@@ -15,7 +15,7 @@ use function sprintf;
 trait BehaviorableTrait
 {
     /**
-     * @var array<\Propel\Generator\Model\Behavior>
+     * @var array<string, \Propel\Generator\Model\Behavior>
      */
     protected $behaviors = [];
 

--- a/src/Propel/Generator/Model/Database.php
+++ b/src/Propel/Generator/Model/Database.php
@@ -10,12 +10,9 @@ use Propel\Generator\Exception\InvalidArgumentException;
 use Propel\Generator\Exception\SchemaException;
 use Propel\Generator\Platform\PlatformInterface;
 use function array_search;
-use function count;
 use function explode;
 use function implode;
 use function in_array;
-use function key;
-use function ksort;
 use function ltrim;
 use function sprintf;
 use function strpos;
@@ -842,19 +839,15 @@ class Database extends ScopedMappingModel
      */
     public function getNextTableBehavior(): ?Behavior
     {
-        // order the behaviors according to Behavior::$tableModificationOrder
-        $behaviors = [];
+        /** @var \Propel\Generator\Model\Behavior|null $nextBehavior */
         $nextBehavior = null;
         foreach ($this->tables as $table) {
             foreach ($table->getBehaviors() as $behavior) {
-                if (!$behavior->isTableModified()) {
-                    $behaviors[$behavior->getTableModificationOrder()][] = $behavior;
+                if ($behavior->hasBeenApplied() || ($nextBehavior && $nextBehavior->getTableModificationOrder() <= $behavior->getTableModificationOrder())) {
+                    continue;
                 }
+                $nextBehavior = $behavior;
             }
-        }
-        ksort($behaviors);
-        if (count($behaviors)) {
-            $nextBehavior = $behaviors[key($behaviors)][0];
         }
 
         return $nextBehavior;

--- a/src/Propel/Generator/Model/Table.php
+++ b/src/Propel/Generator/Model/Table.php
@@ -271,7 +271,7 @@ class Table extends ScopedMappingModel implements IdMethod
     public function applyBehaviors(): void
     {
         foreach ($this->behaviors as $behavior) {
-            if (!$behavior->isTableModified()) {
+            if (!$behavior->hasBeenApplied()) {
                 $behavior->getTableModifier()->modifyTable();
                 $behavior->setTableModified(true);
             }
@@ -1160,28 +1160,19 @@ class Table extends ScopedMappingModel implements IdMethod
      */
     public function hasAdditionalBuilders(): bool
     {
-        foreach ($this->behaviors as $behavior) {
-            if ($behavior->hasAdditionalBuilders()) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($this->behaviors, fn (Behavior $behavior) => $behavior->hasAdditionalBuilders());
     }
 
     /**
      * Returns the list of additional builders provided by the table behaviors.
      *
-     * @return array
+     * @return array<class-string<\Propel\Generator\Builder\Om\AbstractOMBuilder>>
      */
     public function getAdditionalBuilders(): array
     {
-        $additionalBuilders = [];
-        foreach ($this->behaviors as $behavior) {
-            $additionalBuilders = array_merge($additionalBuilders, $behavior->getAdditionalBuilders());
-        }
+        $additionalBuilders = array_map(fn (Behavior $behavior) => $behavior->getAdditionalBuilders(), array_values($this->behaviors));
 
-        return $additionalBuilders;
+        return array_merge(...$additionalBuilders);
     }
 
     /**

--- a/tests/Propel/Tests/Generator/Behavior/Archivable/ArchivableBehaviorObjectBuilderModifierTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Archivable/ArchivableBehaviorObjectBuilderModifierTest.php
@@ -23,9 +23,11 @@ use ArchivableTest10ArchiveQuery;
 use ArchivableTest10Query;
 use ArchivableTest30;
 use ArchivableTest40;
+use Map\VersionableArchivableArchiveTableMap;
 use MyOldArchivableTest30Query;
 use Propel\Generator\Util\QuickBuilder;
 use Propel\Runtime\Exception\PropelException;
+use Propel\Runtime\Map\TableMap;
 use Propel\Tests\TestCase;
 
 /**
@@ -91,6 +93,15 @@ class ArchivableBehaviorObjectBuilderModifierTest extends TestCase
         <behavior name="archivable">
             <parameter name="archive_class" value="\Propel\Tests\Generator\Behavior\Archivable\FooArchive"/>
         </behavior>
+    </table>
+
+    <table name="versionable_archivable">
+        <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER"/>
+        <column name="title" type="VARCHAR" size="100" primaryString="true"/>
+        <column name="age" type="INTEGER"/>
+
+        <behavior name="archivable" />
+        <behavior name="versionable" />
     </table>
 
 </database>
@@ -485,5 +496,13 @@ EOF;
         $ret = $a->archive();
         // time without seconds
         $this->assertEquals(date('Y-m-d H:i'), $ret->getArchivedAt('Y-m-d H:i'));
+    }
+
+    public function testArchivableContainsVersionableColumn(): void
+    {
+        /** @var TableMap $tableMap */
+        $tableMap = VersionableArchivableArchiveTableMap::getTableMap();
+
+        $this->assertTrue($tableMap->hasColumn('version'));
     }
 }

--- a/tests/Propel/Tests/Generator/Model/BehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Model/BehaviorTest.php
@@ -243,4 +243,24 @@ EOF;
         $behavior = $table->getBehavior('timestampable');
         $this->assertEquals($table->getColumn('created_on'), $behavior->getColumnForParameter('create_column'), 'getColumnForParameter() returns the configured column for behavior based on a parameter name');
     }
+
+    /**
+     * @return void
+     */
+    public function testLatenessParameter()
+    {
+        $lateness = 2000;
+        $schema = <<<XML
+<database>
+  <table name="table1">
+    <column name="id" type="INTEGER" primaryKey="true"/>
+    <column name="title" type="VARCHAR" size="100" primaryString="true"/>
+    <behavior name="timestampable" order-lateness="$lateness"/>
+  </table>
+</database>
+XML;
+        $table = $this->buildDatabaseFromSchema($schema)->getTable('table1');
+        $behavior = $table->getBehavior('timestampable');
+        $this->assertEquals($lateness, $behavior->getTableModificationOrder());
+    }
 }

--- a/tests/Propel/Tests/Generator/Model/BehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Model/BehaviorTest.php
@@ -249,18 +249,18 @@ EOF;
      */
     public function testLatenessParameter()
     {
-        $lateness = 2000;
+        $delay = 2000;
         $schema = <<<XML
 <database>
   <table name="table1">
     <column name="id" type="INTEGER" primaryKey="true"/>
     <column name="title" type="VARCHAR" size="100" primaryString="true"/>
-    <behavior name="timestampable" order-lateness="$lateness"/>
+    <behavior name="timestampable" order-delay="$delay"/>
   </table>
 </database>
 XML;
         $table = $this->buildDatabaseFromSchema($schema)->getTable('table1');
         $behavior = $table->getBehavior('timestampable');
-        $this->assertEquals($lateness, $behavior->getTableModificationOrder());
+        $this->assertEquals($delay, $behavior->getTableModificationOrder());
     }
 }

--- a/tests/Propel/Tests/Generator/Model/DatabaseTest.php
+++ b/tests/Propel/Tests/Generator/Model/DatabaseTest.php
@@ -177,20 +177,20 @@ class DatabaseTest extends ModelTestCase
         $table1 = $this->getTableMock('books', [
         'behaviors' => [
             $this->getBehaviorMock('foo', [
-                'is_table_modified' => false,
+                'has_been_applied' => false,
                 'modification_order' => 2,
             ]),
             $this->getBehaviorMock('bar', [
-                'is_table_modified' => false,
+                'has_been_applied' => false,
                 'modification_order' => 1,
             ]),
-            $this->getBehaviorMock('baz', ['is_table_modified' => true]),
+            $this->getBehaviorMock('baz', ['has_been_applied' => true]),
         ]]);
 
         $table2 = $this->getTableMock('authors', [
         'behaviors' => [
             $this->getBehaviorMock('mix', [
-                'is_table_modified' => false,
+                'has_been_applied' => false,
                 'modification_order' => 1,
             ]),
         ]]);
@@ -212,7 +212,7 @@ class DatabaseTest extends ModelTestCase
     {
         $table1 = $this->getTableMock('books', [
         'behaviors' => [
-            $this->getBehaviorMock('foo', ['is_table_modified' => true]),
+            $this->getBehaviorMock('foo', ['has_been_applied' => true]),
         ]]);
 
         $database = new Database();

--- a/tests/Propel/Tests/Generator/Model/ModelTestCase.php
+++ b/tests/Propel/Tests/Generator/Model/ModelTestCase.php
@@ -34,7 +34,7 @@ abstract class ModelTestCase extends TestCase
     {
         $defaults = [
             'additional_builders' => [],
-            'is_table_modified' => false,
+            'has_been_applied' => false,
             'modification_order' => 0,
         ];
 
@@ -71,8 +71,8 @@ abstract class ModelTestCase extends TestCase
 
         $behavior
             ->expects($this->any())
-            ->method('isTableModified')
-            ->will($this->returnValue($options['is_table_modified']));
+            ->method('hasBeenApplied')
+            ->will($this->returnValue($options['has_been_applied']));
 
         $behavior
             ->expects($this->any())

--- a/tests/Propel/Tests/Generator/Model/TableTest.php
+++ b/tests/Propel/Tests/Generator/Model/TableTest.php
@@ -94,7 +94,7 @@ class TableTest extends ModelTestCase
         $behavior = $this->getBehaviorMock('foo');
         $behavior
             ->expects($this->once())
-            ->method('isTableModified')
+            ->method('hasBeenApplied')
             ->will($this->returnValue(false));
 
         $behavior
@@ -122,9 +122,9 @@ class TableTest extends ModelTestCase
     public function testGetAdditionalBuilders()
     {
         $additionalBehaviors = [
-            $this->getBehaviorMock('foo'),
-            $this->getBehaviorMock('bar'),
-            $this->getBehaviorMock('baz'),
+            'builderClass1',
+            'builderClass2',
+            'builderClass3',
         ];
 
         $behavior = $this->getBehaviorMock('mix', [

--- a/tests/Propel/Tests/Helpers/Bookstore/Behavior/AddClassBehavior.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/Behavior/AddClassBehavior.php
@@ -12,5 +12,5 @@ use Propel\Generator\Model\Behavior;
 
 class AddClassBehavior extends Behavior
 {
-    protected $additionalBuilders = ['Propel\Tests\Helpers\Bookstore\Behavior\AddClassBehaviorBuilder'];
+    protected array $additionalBuilders = ['Propel\Tests\Helpers\Bookstore\Behavior\AddClassBehaviorBuilder'];
 }


### PR DESCRIPTION
## Issue
As reported in #141 and https://github.com/propelorm/Propel2/issues/2055, the `archiveable` behavior is applied before `versionable`, leading to missing columns on the archive table.

## Changes
- updated `tableModificationOrder` in `archivable` so it is applied after `versionable` by default
- added schema.xml parameter `order-lateness`, which allows to manually alter behavior application order
- use typed properties in behaviors (and similar cleanup)


## Implementation Details
I have added constructor functions where values of `parameters` and `tableModificationOrder` are set via assignment, instead of setting the values by overriding the properties in behavior child classes.  This should make it more obvious that those properties are part of the logic implemented in Behavior.  


## Test strategy
Via code reference file (no change => nothing broken).
Also agnostic tests for `lateness` parameter and application order of `versionable`/`archivable`.

## Notes
Naming the behavior attribute `order-lateness` is a bit wonky, but so is the parameter  `tableModificationOrder` (with its default value of 50 and higher means later). I actually prefer a somewhat weird name here, to emphasize that this is not an intuitive value and that you need to look it up if you want to use it correctly.