### PR TITLE
disable symfony advisory blocks in min version tests

### DIFF
--- a/tests/composer/composer-symfony6-min.json
+++ b/tests/composer/composer-symfony6-min.json
@@ -69,9 +69,7 @@
             "phpstan/extension-installer": true
         },
         "audit": {
-            "ignore": {
-                "PKSA-w2tw-kmfg-rt9s": "Ignore Security Advisories in symfony/valdiator (https://symfony.com/blog/cve-2025-64500-incorrect-parsing-of-path-info-can-lead-to-limited-authorization-bypass)"
-            }
+            "block-insecure": false
         }
     }
 }

--- a/tests/composer/composer-symfony7-min.json
+++ b/tests/composer/composer-symfony7-min.json
@@ -69,9 +69,7 @@
             "phpstan/extension-installer": true
         },
         "audit": {
-            "ignore": {
-                "PKSA-w2tw-kmfg-rt9s": "Ignore Security Advisories in symfony/valdiator (https://symfony.com/blog/cve-2025-64500-incorrect-parsing-of-path-info-can-lead-to-limited-authorization-bypass)"
-            }
+            "block-insecure": false
         }
     }
 }

--- a/tests/composer/composer-symfony8-min.json
+++ b/tests/composer/composer-symfony8-min.json
@@ -67,9 +67,7 @@
             "phpstan/extension-installer": true
         },
         "audit": {
-            "ignore": {
-                "PKSA-w2tw-kmfg-rt9s": "Ignore Security Advisories in symfony/valdiator (https://symfony.com/blog/cve-2025-64500-incorrect-parsing-of-path-info-can-lead-to-limited-authorization-bypass)"
-            }
+            "block-insecure": false
         }
     }
 }


### PR DESCRIPTION
## Issue
In CI symfony min version tests, composer won't load Symfony Yaml parser due to recently discovered bugs, leading to failing CI during setup (see [run](https://github.com/perplorm/perpl/actions/runs/26158135162/job/76942732736?pr=142)).

## Changes
Blocking of insecure packages is now disabled in min tests.

## Implementation Details
Instead of disabling the block, whitelisting the individual blocks would also be possible. However, while blocking insecure packages is a great feature in user projects, it does not do anything for us in CI symfony min version tests. 

## Test strategy
Ci works again.