### PR TITLE
CI waits for MySql init

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,17 @@ jobs:
                 symfony-version: ${{ matrix.symfony-version }}
                 cache-key-suffix: ${{ matrix.db-type}}
 
-            - name: Grant MySQL privileges to DB user
+            - name: Finish MySQL init
               if: matrix.db-type == 'mysql'
               run: |
+                bash -c "
+                for i in {1..10}; do
+                  mysqladmin -h 127.0.0.1 -u root status >/dev/null 2>&1 && exit 0 || sleep 6
+                  echo 'MySQL not up yet, waiting...'
+                done;
+                echo 'could not establish connection after 10 tries'
+                exit 1
+                "
                 mysql -h 127.0.0.1 -u root -e "
                   GRANT ALL PRIVILEGES ON *.* TO '${{ env.DB_USER }}'@'%';
                   FLUSH PRIVILEGES;


### PR DESCRIPTION
## Issue
CI runs occasionally fail with MySQL (see [this run](https://github.com/perplorm/perpl/actions/runs/26499172467/job/78034837032?pr=143)), This used to happen when the MySQL container is up, but MySQL itself has not finished initializing yet.


## Changes
Re-introduce check if MySQL is up yet.


## Implementation Details
I don't fully trust the multi-line syntax of `steps.run`, the [documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsrun) is rather sparse. We'll see how it goes.

## Test strategy
This is a race condition, we'll have to see if the error occurs again. My guess is it affected every 20eth run or so.
