### PR TITLE
fix stan complaint in Lenght Validator

### DIFF
--- a/src/Propel/Runtime/Validator/Constraints/Length.php
+++ b/src/Propel/Runtime/Validator/Constraints/Length.php
@@ -35,31 +35,17 @@ class Length extends SymfonyLength
     ) {
         // Handle array syntax - extract parameters for Symfony 8 compatibility
         if (is_array($options)) {
-            $exactlyValue = $options['exactly'] ?? null;
-            $minValue = $options['min'] ?? null;
-            $maxValue = $options['max'] ?? null;
             $genericMessage = $options['message'] ?? null;
 
-            // Map generic message to specific messages, preferring explicit specific messages
-            $messages = $this->mapGenericMessage(
-                $genericMessage,
-                $exactlyValue,
-                $minValue,
-                $maxValue,
-                $options['minMessage'] ?? null,
-                $options['maxMessage'] ?? null,
-                $options['exactMessage'] ?? null,
-            );
-
             parent::__construct(
-                exactly: $exactlyValue,
-                min: $minValue,
-                max: $maxValue,
+                exactly: $options['exactly'] ?? null,
+                min: $options['min'] ?? null,
+                max: $options['max'] ?? null,
                 charset: $options['charset'] ?? null,
                 normalizer: $options['normalizer'] ?? null,
-                minMessage: $messages['minMessage'],
-                maxMessage: $messages['maxMessage'],
-                exactMessage: $messages['exactMessage'],
+                minMessage: $options['minMessage'] ?? $genericMessage,
+                maxMessage: $options['maxMessage'] ?? $genericMessage,
+                exactMessage: $options['exactMessage'] ?? $genericMessage,
                 charsetMessage: $options['charsetMessage'] ?? null,
                 groups: $options['groups'] ?? null,
                 payload: $options['payload'] ?? null,
@@ -70,90 +56,17 @@ class Length extends SymfonyLength
 
         // Handle Symfony 8+ named parameters
         $exactlyValue = is_int($options) ? $options : $exactly;
-        $messages = $this->mapGenericMessage($message, $exactlyValue, $min, $max);
 
         parent::__construct(
             exactly: $exactlyValue,
             min: $min,
             max: $max,
             charset: $charset,
-            minMessage: $messages['minMessage'],
-            maxMessage: $messages['maxMessage'],
-            exactMessage: $messages['exactMessage'],
+            minMessage: $message,
+            maxMessage: $message,
+            exactMessage: $message,
             groups: $groups,
             payload: $payload,
         );
-    }
-
-    /**
-     * Maps a generic message to specific message parameters based on which constraints are set
-     *
-     * @param string|null $genericMessage Generic message to map
-     * @param int|null $exactly Exact length constraint value
-     * @param int|null $min Minimum length constraint value
-     * @param int|null $max Maximum length constraint value
-     * @param string|null $explicitMinMessage Explicit minMessage override
-     * @param string|null $explicitMaxMessage Explicit maxMessage override
-     * @param string|null $explicitExactMessage Explicit exactMessage override
-     *
-     * @return array<string, string|null> Array with minMessage, maxMessage, and exactMessage keys
-     */
-    private function mapGenericMessage(
-        ?string $genericMessage,
-        ?int $exactly,
-        ?int $min,
-        ?int $max,
-        ?string $explicitMinMessage = null,
-        ?string $explicitMaxMessage = null,
-        ?string $explicitExactMessage = null
-    ): array {
-        // If no generic message or all explicit messages provided, use explicit values
-        if ($genericMessage === null) {
-            return [
-                'minMessage' => $explicitMinMessage,
-                'maxMessage' => $explicitMaxMessage,
-                'exactMessage' => $explicitExactMessage,
-            ];
-        }
-
-        // Map generic message based on which constraints are set, preferring explicit messages
-        if ($exactly !== null) {
-            return [
-                'minMessage' => $explicitMinMessage,
-                'maxMessage' => $explicitMaxMessage,
-                'exactMessage' => $explicitExactMessage ?? $genericMessage,
-            ];
-        }
-
-        if ($min !== null && $max === null) {
-            return [
-                'minMessage' => $explicitMinMessage ?? $genericMessage,
-                'maxMessage' => $explicitMaxMessage,
-                'exactMessage' => $explicitExactMessage,
-            ];
-        }
-
-        if ($max !== null && $min === null) {
-            return [
-                'minMessage' => $explicitMinMessage,
-                'maxMessage' => $explicitMaxMessage ?? $genericMessage,
-                'exactMessage' => $explicitExactMessage,
-            ];
-        }
-
-        if ($min !== null && $max !== null) {
-            return [
-                'minMessage' => $explicitMinMessage ?? $genericMessage,
-                'maxMessage' => $explicitMaxMessage ?? $genericMessage,
-                'exactMessage' => $explicitExactMessage,
-            ];
-        }
-
-        // No constraints set, return explicit messages
-        return [
-            'minMessage' => $explicitMinMessage,
-            'maxMessage' => $explicitMaxMessage,
-            'exactMessage' => $explicitExactMessage,
-        ];
     }
 }


### PR DESCRIPTION
## Issue
CI fails due to a new Stan complaint (see [run](https://github.com/perplorm/perpl/actions/runs/27010675134/job/79713212995)).


## Changes
The affected line could be removed.


## Implementation Details
There were lots of conditions being evaluated in the code, but I think the situation is actually quite easy: Either the user wants a specific message, then they set the value and it will be used, or not.


## Test strategy
Relying in existing tests.


## Notes
I would like to get rid of the Validator behavior at some point. It adds requirements, has so many files that it needs its own namespace (`Propel\Runtime\Validator`), frequently causes problems with Symfony compatibility or stan/psalm - and is probably hardly used, if at all. Maybe dump it into its own repository?
