### PR TITLE
Postgres: Migrate custom types from schema.xml

### DIFF
--- a/src/Propel/Generator/Platform/PgsqlPlatform.php
+++ b/src/Propel/Generator/Platform/PgsqlPlatform.php
@@ -17,6 +17,8 @@ use Propel\Generator\Model\Index;
 use Propel\Generator\Model\PropelTypes;
 use Propel\Generator\Model\Table;
 use Propel\Generator\Model\Unique;
+use function array_diff;
+use function array_map;
 use function filter_var;
 use function implode;
 use function in_array;
@@ -37,6 +39,13 @@ class PgsqlPlatform extends DefaultPlatform
      * @var string
      */
     protected $createOrDropSequences = '';
+
+    /**
+     * Tracks enum type names already emitted in the current DDL generation run.
+     *
+     * @var array<string, true>
+     */
+    protected array $createdEnumTypes = [];
 
     /**
      * Initializes db specific domain mapping.
@@ -67,7 +76,23 @@ class PgsqlPlatform extends DefaultPlatform
         $this->setSchemaDomainMapping(new Domain(PropelTypes::UUID, 'uuid'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::UUID_BINARY, 'BYTEA'));
 
-        $this->setSetTypesMapping(false);
+        $this->setSetTypesMapping(true);
+    }
+
+    /**
+     * PostgreSQL uses named enum types created via CREATE TYPE, not inline ENUM() syntax.
+     * Returns VARCHAR as fallback when `sqlType` is not explicitly set.
+     * Set the `sqlType` schema attribute to specify the PostgreSQL enum type name
+     * for CREATE TYPE generation in migrations.
+     *
+     * @param \Propel\Generator\Model\Column $column
+     *
+     * @return string
+     */
+    #[\Override]
+    public function buildNativeEnumeratedColumnSqlType(Column $column): string
+    {
+        return 'VARCHAR';
     }
 
     /**
@@ -293,6 +318,64 @@ SET search_path TO public;
     }
 
     /**
+     * Prepends the table's schema name to an identifier, following the same
+     * pattern as Table::getName() for schema-qualified names.
+     *
+     * @param string $name The unqualified name
+     * @param \Propel\Generator\Model\Table|null $table The table providing schema context
+     *
+     * @return string The schema-qualified name, or the original name if no schema
+     */
+    protected function getSchemaQualifiedName(string $name, ?Table $table): string
+    {
+        if ($table === null || strpos($name, '.') !== false) {
+            return $name;
+        }
+
+        $schemaName = $table->guessSchemaName();
+
+        return $schemaName ? $schemaName . '.' . $name : $name;
+    }
+
+    /**
+     * Generates a CREATE TYPE DDL for a native enum column, if not already emitted.
+     *
+     * @param \Propel\Generator\Model\Column $column
+     *
+     * @return string
+     */
+    protected function getCreateEnumTypeDDLForColumn(Column $column): string
+    {
+        if (!in_array($column->getType(), [PropelTypes::ENUM_NATIVE, PropelTypes::SET_NATIVE], true)) {
+            return '';
+        }
+
+        // Only generate CREATE TYPE when sqlType is explicitly set
+        if (!$column->getAttribute('sqlType')) {
+            return '';
+        }
+
+        $typeName = $column->getDomain()->getSqlType();
+        if (isset($this->createdEnumTypes[$typeName])) {
+            return '';
+        }
+
+        $qualifiedTypeName = $this->getSchemaQualifiedName($typeName, $column->getTable());
+        if (isset($this->createdEnumTypes[$qualifiedTypeName])) {
+            return '';
+        }
+
+        $valuesCsv = implode(', ', array_map(
+            fn (string $value): string => "'" . $value . "'",
+            $column->getValueSet(),
+        ));
+
+        $this->createdEnumTypes[$qualifiedTypeName] = true;
+
+        return sprintf("\nCREATE TYPE %s AS ENUM (%s);\n", $this->quoteIdentifier($qualifiedTypeName), $valuesCsv);
+    }
+
+    /**
      * @param \Propel\Generator\Model\Database $database
      *
      * @return string
@@ -300,6 +383,8 @@ SET search_path TO public;
     #[\Override]
     public function getAddTablesDDL(Database $database): string
     {
+        $this->createdEnumTypes = [];
+
         $ret = $this->getAddSchemasDDL($database);
 
         foreach ($database->getTablesForSql() as $table) {
@@ -389,6 +474,11 @@ COMMIT;
     public function getAddTableDDL(Table $table): string
     {
         $ret = $this->getUseSchemaDDL($table);
+
+        foreach ($table->getColumns() as $column) {
+            $ret .= $this->getCreateEnumTypeDDLForColumn($column);
+        }
+
         $ret .= $this->getAddSequenceDDL($table);
 
         $lines = [];
@@ -487,7 +577,35 @@ DROP TABLE IF EXISTS %s CASCADE;
 ";
         $ret .= sprintf($pattern, $this->quoteIdentifier($table->getName()));
         $ret .= $this->getDropSequenceDDL($table);
+        $ret .= $this->getDropEnumTypesDDL($table);
         $ret .= $this->getResetSchemaDDL($table);
+
+        return $ret;
+    }
+
+    /**
+     * Generates DROP TYPE IF EXISTS DDL for native enum columns on a table.
+     *
+     * @param \Propel\Generator\Model\Table $table
+     *
+     * @return string
+     */
+    protected function getDropEnumTypesDDL(Table $table): string
+    {
+        $ret = '';
+
+        foreach ($table->getColumns() as $column) {
+            if (!in_array($column->getType(), [PropelTypes::ENUM_NATIVE, PropelTypes::SET_NATIVE], true)) {
+                continue;
+            }
+
+            if (!$column->getAttribute('sqlType')) {
+                continue;
+            }
+
+            $typeName = $this->getSchemaQualifiedName($column->getDomain()->getSqlType(), $table);
+            $ret .= sprintf("\nDROP TYPE IF EXISTS %s;\n", $this->quoteIdentifier($typeName));
+        }
 
         return $ret;
     }
@@ -517,6 +635,11 @@ DROP TABLE IF EXISTS %s CASCADE;
 
         $ddl = [$this->quoteIdentifier($col->getName())];
         $sqlType = $domain->getSqlType();
+
+        // Schema-qualify native enum type references
+        if (in_array($col->getType(), [PropelTypes::ENUM_NATIVE, PropelTypes::SET_NATIVE], true) && $col->getAttribute('sqlType')) {
+            $sqlType = $this->getSchemaQualifiedName($sqlType, $col->getTable());
+        }
         $table = $col->getTable();
         if ($col->isAutoIncrement() && $table && $table->getIdMethodParameters() == null) {
             $sqlType = $col->getType() === PropelTypes::BIGINT ? 'bigserial' : 'serial';
@@ -653,11 +776,70 @@ ALTER TABLE %s RENAME TO %s;
     {
         $ret = parent::getModifyTableDDL($tableDiff);
 
+        $prefix = $this->getAlterEnumTypesDDL($tableDiff);
+
         if ($this->createOrDropSequences) {
-            $ret = $this->createOrDropSequences . $ret;
+            $prefix .= $this->createOrDropSequences;
+            $this->createOrDropSequences = '';
         }
 
-        $this->createOrDropSequences = '';
+        return $prefix . $ret;
+    }
+
+    /**
+     * Compares enum valueSets between from/to tables and generates ALTER TYPE ADD VALUE DDL.
+     *
+     * @param \Propel\Generator\Model\Diff\TableDiff $tableDiff
+     *
+     * @throws \Propel\Generator\Exception\EngineException
+     *
+     * @return string
+     */
+    protected function getAlterEnumTypesDDL(TableDiff $tableDiff): string
+    {
+        $ret = '';
+        $fromTable = $tableDiff->getFromTable();
+        $toTable = $tableDiff->getToTable();
+
+        foreach ($toTable->getColumns() as $toColumn) {
+            if (!in_array($toColumn->getType(), [PropelTypes::ENUM_NATIVE, PropelTypes::SET_NATIVE], true)) {
+                continue;
+            }
+
+            if (!$toColumn->getAttribute('sqlType') || !$toColumn->getValueSet()) {
+                continue;
+            }
+
+            $fromColumn = $fromTable->hasColumn($toColumn->getName())
+                ? $fromTable->getColumn($toColumn->getName())
+                : null;
+
+            if (!$fromColumn || !$fromColumn->getValueSet()) {
+                continue;
+            }
+
+            $qualifiedTypeName = $this->getSchemaQualifiedName($toColumn->getDomain()->getSqlType(), $toTable);
+
+            $removedValues = array_diff($fromColumn->getValueSet(), $toColumn->getValueSet());
+            if ($removedValues) {
+                throw new EngineException(sprintf(
+                    'Column \'%s\' on table \'%s\': PostgreSQL does not support removing values from an enum type. '
+                    . 'Values removed: %s. This must be handled manually.',
+                    $toColumn->getName(),
+                    $toTable->getName(),
+                    implode(', ', $removedValues),
+                ));
+            }
+
+            $newValues = array_diff($toColumn->getValueSet(), $fromColumn->getValueSet());
+            foreach ($newValues as $value) {
+                $ret .= sprintf(
+                    "\nALTER TYPE %s ADD VALUE IF NOT EXISTS '%s';\n",
+                    $this->quoteIdentifier($qualifiedTypeName),
+                    $value,
+                );
+            }
+        }
 
         return $ret;
     }
@@ -880,12 +1062,17 @@ DROP SEQUENCE %s CASCADE;
     #[\Override]
     public function getAddColumnsDDL(array $columns): string
     {
+        $enumDDL = '';
+        foreach ($columns as $column) {
+            $enumDDL .= $this->getCreateEnumTypeDDLForColumn($column);
+        }
+
         $ret = '';
         foreach ($columns as $column) {
             $ret .= $this->getAddColumnDDL($column);
         }
 
-        return $ret;
+        return $enumDDL . $ret;
     }
 
     /**

--- a/src/Propel/Generator/Reverse/PgsqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/PgsqlSchemaParser.php
@@ -272,7 +272,8 @@ class PgsqlSchemaParser extends AbstractSchemaParser
             is_nullable,
             numeric_precision,
             numeric_scale,
-            character_maximum_length
+            character_maximum_length,
+            udt_name
         FROM information_schema.columns
         WHERE
             table_schema IN ($searchPath) AND table_name = ?
@@ -304,6 +305,18 @@ class PgsqlSchemaParser extends AbstractSchemaParser
             }
 
             $autoincrement = null;
+            $enumValues = null;
+            $enumTypeName = null;
+
+            // Detect PostgreSQL native enum types (USER-DEFINED with enum values)
+            if (strtoupper($type) === 'USER-DEFINED' && isset($row['udt_name'])) {
+                $enumSchema = $table->getSchema() ?: $table->getDatabase()->getSchema() ?: 'public';
+                $enumValues = $this->getEnumValues($row['udt_name'], $enumSchema);
+                if ($enumValues !== null) {
+                    $enumTypeName = $row['udt_name'];
+                    $type = 'enum';
+                }
+            }
 
             // if column has a default
 
@@ -318,10 +331,14 @@ class PgsqlSchemaParser extends AbstractSchemaParser
                 $default = null;
             }
 
-            $propelType = $this->getMappedPropelType($type);
-            if (!$propelType) {
-                $propelType = Column::DEFAULT_TYPE;
-                $this->warn('Column [' . $table->getName() . '.' . $name . '] has a column type (' . $type . ') that Propel does not support.');
+            if ($enumTypeName !== null) {
+                $propelType = PropelTypes::ENUM_NATIVE;
+            } else {
+                $propelType = $this->getMappedPropelType($type);
+                if (!$propelType) {
+                    $propelType = Column::DEFAULT_TYPE;
+                    $this->warn('Column [' . $table->getName() . '.' . $name . '] has a column type (' . $type . ') that Propel does not support.');
+                }
             }
 
             if (isset(static::$defaultTypeSizes[$type]) && $size == static::$defaultTypeSizes[$type]) {
@@ -341,6 +358,13 @@ class PgsqlSchemaParser extends AbstractSchemaParser
                 $column->getDomain()->replaceScale($scale);
             }
 
+            if ($enumTypeName !== null) {
+                $column->getDomain()->replaceSqlType($enumTypeName);
+                if ($enumValues) {
+                    $column->setValueSet($enumValues);
+                }
+            }
+
             if ($default !== null) {
                 $isExpression = $this->isColumnDefaultExpression($default);
                 if (!$isExpression) {
@@ -354,6 +378,35 @@ class PgsqlSchemaParser extends AbstractSchemaParser
 
             $table->addColumn($column);
         }
+    }
+
+    /**
+     * Queries pg_enum to retrieve enum values for a PostgreSQL enum type.
+     *
+     * @param string $typeName The enum type name (udt_name)
+     * @param string $schema The schema containing the type
+     *
+     * @return array<string>|null Enum values in sort order, or null if not an enum type
+     */
+    protected function getEnumValues(string $typeName, string $schema): ?array
+    {
+        $stmt = $this->dbh->prepare("
+            SELECT e.enumlabel
+            FROM pg_enum e
+            JOIN pg_type t ON e.enumtypid = t.oid
+            JOIN pg_namespace n ON t.typnamespace = n.oid
+            WHERE t.typname = ? AND n.nspname = ?
+            ORDER BY e.enumsortorder
+        ");
+
+        if ($stmt === false) {
+            return null;
+        }
+
+        $stmt->execute([$typeName, $schema]);
+        $values = $stmt->fetchAll(PDO::FETCH_COLUMN, 0);
+
+        return $values ?: null;
     }
 
     /**

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectEnumNativeColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectEnumNativeColumnTypeTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Propel\Tests\Generator\Builder\Om;
+
+use EnumNativeBackedEntity;
+use EnumNativeBackedEntityQuery;
+use EnumNativeUnitEntity;
+use EnumNativeUnitEntityQuery;
+use Map\EnumNativeBackedEntityTableMap;
+use Map\EnumNativeUnitEntityTableMap;
+use Propel\Generator\Platform\PgsqlPlatform;
+use Propel\Generator\Util\QuickBuilder;
+use Propel\Runtime\Adapter\Pdo\PgsqlAdapter;
+use Propel\Tests\Helpers\ColorsBackedEnum;
+use Propel\Tests\Helpers\ColorsBasicEnum;
+use Propel\Tests\TestCase;
+
+/**
+ * Tests runtime behavior of ENUM_NATIVE columns with PHP enums on PostgreSQL.
+ *
+ * @group pgsql
+ * @group database
+ */
+class GeneratedObjectEnumNativeColumnTypeTest extends TestCase
+{
+    private static bool $built = false;
+
+    public function setUp(): void
+    {
+        if (strtolower(getenv('DB') ?: '') !== 'pgsql') {
+            $this->markTestSkipped('Test requires PostgreSQL (set DB=pgsql).');
+        }
+
+        if (self::$built) {
+            return;
+        }
+
+        $backedEnumClass = ColorsBackedEnum::class;
+        $unitEnumClass = ColorsBasicEnum::class;
+        $schema = <<<EOF
+<database name="enum_native_test">
+    <table name="enum_native_backed_entity">
+        <column name="id" primaryKey="true" type="INTEGER" autoIncrement="true"/>
+        <column name="color" type="ENUM_NATIVE" valueSet="red,blue,yellow" sqlType="enum_native_backed_color" phpType="$backedEnumClass"/>
+        <column name="nullable_color" type="ENUM_NATIVE" valueSet="red,blue,yellow" sqlType="enum_native_backed_color" phpType="$backedEnumClass" required="false"/>
+    </table>
+    <table name="enum_native_unit_entity">
+        <column name="id" primaryKey="true" type="INTEGER" autoIncrement="true"/>
+        <column name="color" type="ENUM_NATIVE" valueSet="Red,Blue,Yellow" sqlType="enum_native_unit_color" phpType="$unitEnumClass"/>
+        <column name="nullable_color" type="ENUM_NATIVE" valueSet="Red,Blue,Yellow" sqlType="enum_native_unit_color" phpType="$unitEnumClass" required="false"/>
+    </table>
+</database>
+EOF;
+
+        $host = getenv('DB_HOSTNAME') ?: '127.0.0.1';
+        $dbName = getenv('DB_NAME') ?: 'test';
+        $dsn = "pgsql:host=$host;dbname=$dbName";
+        $user = getenv('DB_USER') ?: null;
+        $pass = getenv('DB_PW') ?: null;
+
+        $builder = new QuickBuilder();
+        $builder->setSchema($schema);
+        $builder->setPlatform(new PgsqlPlatform());
+
+        $builder->build($dsn, $user, $pass, new PgsqlAdapter());
+
+        self::$built = true;
+    }
+
+    // --- BackedEnum tests ---
+
+    public function testBackedEnumInsertAndHydrate(): void
+    {
+        $entity = new EnumNativeBackedEntity();
+        $entity->setColor(ColorsBackedEnum::Red);
+        $entity->save();
+
+        EnumNativeBackedEntityTableMap::clearInstancePool();
+
+        $fetched = EnumNativeBackedEntityQuery::create()->findOneById($entity->getId());
+        $this->assertNotNull($fetched);
+        $this->assertSame(ColorsBackedEnum::Red, $fetched->getColor());
+    }
+
+    public function testBackedEnumUpdate(): void
+    {
+        $entity = new EnumNativeBackedEntity();
+        $entity->setColor(ColorsBackedEnum::Blue);
+        $entity->save();
+
+        $entity->setColor(ColorsBackedEnum::Yellow);
+        $entity->save();
+
+        EnumNativeBackedEntityTableMap::clearInstancePool();
+
+        $fetched = EnumNativeBackedEntityQuery::create()->findOneById($entity->getId());
+        $this->assertSame(ColorsBackedEnum::Yellow, $fetched->getColor());
+    }
+
+    public function testBackedEnumNullable(): void
+    {
+        $entity = new EnumNativeBackedEntity();
+        $entity->setColor(ColorsBackedEnum::Red);
+        $entity->setNullableColor(null);
+        $entity->save();
+
+        EnumNativeBackedEntityTableMap::clearInstancePool();
+
+        $fetched = EnumNativeBackedEntityQuery::create()->findOneById($entity->getId());
+        $this->assertNull($fetched->getNullableColor());
+    }
+
+    public function testBackedEnumFilter(): void
+    {
+        EnumNativeBackedEntityQuery::create()->deleteAll();
+
+        $e1 = new EnumNativeBackedEntity();
+        $e1->setColor(ColorsBackedEnum::Red);
+        $e1->save();
+
+        $e2 = new EnumNativeBackedEntity();
+        $e2->setColor(ColorsBackedEnum::Blue);
+        $e2->save();
+
+        $e3 = new EnumNativeBackedEntity();
+        $e3->setColor(ColorsBackedEnum::Red);
+        $e3->save();
+
+        $this->assertEquals(2, EnumNativeBackedEntityQuery::create()->filterByColor('red')->count());
+        $this->assertEquals(1, EnumNativeBackedEntityQuery::create()->filterByColor('blue')->count());
+    }
+
+    // --- UnitEnum tests ---
+
+    public function testUnitEnumInsertAndHydrate(): void
+    {
+        $entity = new EnumNativeUnitEntity();
+        $entity->setColor(ColorsBasicEnum::Red);
+        $entity->save();
+
+        EnumNativeUnitEntityTableMap::clearInstancePool();
+
+        $fetched = EnumNativeUnitEntityQuery::create()->findOneById($entity->getId());
+        $this->assertNotNull($fetched);
+        $this->assertSame(ColorsBasicEnum::Red, $fetched->getColor());
+    }
+
+    public function testUnitEnumUpdate(): void
+    {
+        $entity = new EnumNativeUnitEntity();
+        $entity->setColor(ColorsBasicEnum::Blue);
+        $entity->save();
+
+        $entity->setColor(ColorsBasicEnum::Yellow);
+        $entity->save();
+
+        EnumNativeUnitEntityTableMap::clearInstancePool();
+
+        $fetched = EnumNativeUnitEntityQuery::create()->findOneById($entity->getId());
+        $this->assertSame(ColorsBasicEnum::Yellow, $fetched->getColor());
+    }
+
+    public function testUnitEnumNullable(): void
+    {
+        $entity = new EnumNativeUnitEntity();
+        $entity->setColor(ColorsBasicEnum::Red);
+        $entity->setNullableColor(null);
+        $entity->save();
+
+        EnumNativeUnitEntityTableMap::clearInstancePool();
+
+        $fetched = EnumNativeUnitEntityQuery::create()->findOneById($entity->getId());
+        $this->assertNull($fetched->getNullableColor());
+    }
+
+    public function testUnitEnumFilter(): void
+    {
+        EnumNativeUnitEntityQuery::create()->deleteAll();
+
+        $e1 = new EnumNativeUnitEntity();
+        $e1->setColor(ColorsBasicEnum::Red);
+        $e1->save();
+
+        $e2 = new EnumNativeUnitEntity();
+        $e2->setColor(ColorsBasicEnum::Blue);
+        $e2->save();
+
+        $e3 = new EnumNativeUnitEntity();
+        $e3->setColor(ColorsBasicEnum::Red);
+        $e3->save();
+
+        $this->assertEquals(2, EnumNativeUnitEntityQuery::create()->filterByColor('Red')->count());
+        $this->assertEquals(1, EnumNativeUnitEntityQuery::create()->filterByColor('Blue')->count());
+    }
+
+    // Note: invalid enum value test is not possible with ENUM_NATIVE because
+    // PostgreSQL enforces valid values at the database level. The PropelException
+    // for unknown UnitEnum cases applies to non-native columns (e.g., VARCHAR with phpType).
+}

--- a/tests/Propel/Tests/Generator/Migration/BaseTest.php
+++ b/tests/Propel/Tests/Generator/Migration/BaseTest.php
@@ -9,6 +9,7 @@
 namespace Propel\Tests\Generator\Migration;
 
 use Propel\Generator\Model\PropelTypes;
+use Propel\Generator\Platform\PgsqlPlatform;
 
 /**
  * @group database
@@ -361,11 +362,15 @@ class BaseTest extends MigrationTestCase
             return $this->markTestSkipped('Test requires native SET/ENUM type.');
         }
 
+        $isPgsql = $this->getPlatform() instanceof PgsqlPlatform;
+        $enumSqlType = $isPgsql ? ' sqlType="migration_test_enum_type"' : '';
+        $setSqlType = $isPgsql ? ' sqlType="migration_test_set_type"' : '';
+
         $originXml = '
 <database>
     <table name="migration_test_enum">
-        <column name="enum_column" type="ENUM_NATIVE" valueSet="foo,bar"/>
-        <column name="set_column" type="SET_NATIVE" valueSet="foo,bar"/>
+        <column name="enum_column" type="ENUM_NATIVE" valueSet="foo,bar"' . $enumSqlType . '/>
+        <column name="set_column" type="SET_NATIVE" valueSet="foo,bar"' . $setSqlType . '/>
     </table>
 </database>
 ';
@@ -373,8 +378,8 @@ class BaseTest extends MigrationTestCase
         $targetXml = '
 <database>
     <table name="migration_test_enum">
-        <column name="enum_column" type="ENUM_NATIVE" valueSet="baz,foo,bar"/>
-        <column name="set_column" type="SET_NATIVE" valueSet="baz,foo,bar"/>
+        <column name="enum_column" type="ENUM_NATIVE" valueSet="baz,foo,bar"' . $enumSqlType . '/>
+        <column name="set_column" type="SET_NATIVE" valueSet="baz,foo,bar"' . $setSqlType . '/>
     </table>
 </database>
 ';

--- a/tests/Propel/Tests/Generator/Platform/EnumeratedColumnTypesTest.php
+++ b/tests/Propel/Tests/Generator/Platform/EnumeratedColumnTypesTest.php
@@ -32,12 +32,12 @@ class EnumeratedColumnTypesTest extends TestCase
             DefaultPlatform::class,
             MssqlPlatform::class,
             OraclePlatform::class,
-            PgsqlPlatform::class,
             SqlitePlatform::class,
         ];
 
         $platformsWithNativeType = [
             MysqlPlatform::class,
+            PgsqlPlatform::class,
         ];
 
         $data = [];
@@ -124,6 +124,68 @@ class EnumeratedColumnTypesTest extends TestCase
         $ddl = $platform->getColumnDDL($column);
 
         $this->assertEquals($expectedColumnDdl, $ddl);
+    }
+
+    public function testIsPhpBackedEnumType(): void
+    {
+        $this->assertTrue(PropelTypes::isPhpBackedEnumType(ColorsBackedEnum::class));
+        $this->assertFalse(PropelTypes::isPhpBackedEnumType(ColorsBasicEnum::class));
+        $this->assertFalse(PropelTypes::isPhpBackedEnumType('string'));
+        $this->assertFalse(PropelTypes::isPhpBackedEnumType(\stdClass::class));
+    }
+
+    public function testColumnWithPhpTypeBackedEnum(): void
+    {
+        $columnXml = '<column name="color" type="VARCHAR" size="16" phpType="' . ColorsBackedEnum::class . '"/>';
+        $column = $this->buildColumnFromSchema(new DefaultPlatform(), false, $columnXml);
+
+        $this->assertTrue($column->isPhpBackedEnumType());
+        $this->assertTrue($column->isPhpObjectType());
+    }
+
+    public function testColumnWithPhpTypeRegularClassIsNotBackedEnum(): void
+    {
+        $columnXml = '<column name="amount" type="DECIMAL" phpType="\stdClass"/>';
+        $column = $this->buildColumnFromSchema(new DefaultPlatform(), false, $columnXml);
+
+        $this->assertFalse($column->isPhpBackedEnumType());
+        $this->assertTrue($column->isPhpObjectType());
+    }
+
+    public function testIsPhpUnitEnumType(): void
+    {
+        $this->assertTrue(PropelTypes::isPhpUnitEnumType(ColorsBasicEnum::class));
+        $this->assertFalse(PropelTypes::isPhpUnitEnumType(ColorsBackedEnum::class));
+        $this->assertFalse(PropelTypes::isPhpUnitEnumType('string'));
+        $this->assertFalse(PropelTypes::isPhpUnitEnumType(\stdClass::class));
+    }
+
+    public function testColumnWithPhpTypeUnitEnum(): void
+    {
+        $columnXml = '<column name="color" type="VARCHAR" size="16" phpType="' . ColorsBasicEnum::class . '"/>';
+        $column = $this->buildColumnFromSchema(new DefaultPlatform(), false, $columnXml);
+
+        $this->assertTrue($column->isPhpUnitEnumType());
+        $this->assertFalse($column->isPhpBackedEnumType());
+        $this->assertTrue($column->isPhpObjectType());
+    }
+
+    public function testPgsqlEnumNativeUsesSqlType(): void
+    {
+        $columnXml = '<column name="status" type="ENUM_NATIVE" valueEnum="' . ColorsBackedEnum::class . '" sqlType="status_type"/>';
+        $platform = new PgsqlPlatform();
+        $column = $this->buildColumnFromSchema($platform, false, $columnXml);
+
+        $this->assertSame('status_type', $column->getDomain()->getSqlType());
+    }
+
+    public function testPgsqlEnumNativeWithoutSqlTypeFallsBackToVarchar(): void
+    {
+        $columnXml = '<column name="status" type="ENUM_NATIVE" valueEnum="' . ColorsBackedEnum::class . '"/>';
+        $platform = new PgsqlPlatform();
+        $column = $this->buildColumnFromSchema($platform, false, $columnXml);
+
+        $this->assertSame('VARCHAR', $column->getDomain()->getSqlType());
     }
 
     /**


### PR DESCRIPTION
Incomplete feature from #128, open for anyone to finish.

Should build correct `create type` statements in Postgres, particularly for enum types.

## Issue
<!--
Please add a short description of the current behavior (without your changes),
i.e. "
    When setting the `phpType` column attribute to a PHP Enum, Perpl models try to instantiate the value
    with `new`. This leads to exceptions, since Enums have to be referenced as class constants or via `::from()`.
"-->



## Changes
<!--
Please add a short description of your changes,
i.e. "
    This PR checks if `phpType` is an enum and instantiates those correctly. It affects loading from DB (hydrate()),
    writing to DB (getAccessValueStatement()) and applying default values. 
"-->



## Implementation Details
<!--
Please add anything that helps us to reason about the changes (optional),
i.e. "
    - I'm handling BackedEnum and UnitEnum as different cases, because of how different they are. Does that make sense?
    - Visibility of `FooClass::fooMethod()` was changed to public, so I can call it from `SomeOtherClass`.
"-->



## Test strategy
<!--
Your changes will have to pass static analysis, linter, and the test suite, and any added or changed behavior needs to be validated by tests, provided by your PR.

Please add a short description of the tests required to validate this PR,
i.e. "
    - Added tests to check code output as string.
    - Runtime behavior is validated by creating dummy classes with QuickBuilder.

    Not sure if this requires actual runtime tests against database?
"

 Find out more about test suite at https://perplorm.github.io/documentation/cookbook/working-with-test-suite.html
 
 You can run checks locally using the docker containers at https://github.com/perplorm/perpl-test-docker

-->



## Notes
<!--
Remove if not needed, or add what you want to discuss.

!!! Thank you for contributing to Perpl !!!

Once submitted, we'll go through a review to get your changes merged as soon as possible.
-->
