### PR TITLE
Cleanup reverse-engineered schema

### DIFF
--- a/src/Propel/Generator/Model/Column.php
+++ b/src/Propel/Generator/Model/Column.php
@@ -628,6 +628,14 @@ class Column extends MappingModel
     }
 
     /**
+     * @return bool
+     */
+    public function hasCustomPhpName(): bool
+    {
+        return $this->phpName && !$this->namePrefix && $this->phpName !== $this->buildPhpName();
+    }
+
+    /**
      * @return string
      */
     public function buildPhpName(): string

--- a/src/Propel/Generator/Model/Table.php
+++ b/src/Propel/Generator/Model/Table.php
@@ -189,20 +189,20 @@ class Table extends ScopedMappingModel implements IdMethod
     }
 
     /**
-     * Returns a qualified name of this table with scheme and common name
-     * separated by '_'.
+     * Get the table name, optionally prefixed with schema and underscore.
      *
-     * If autoPrefix is set. Otherwise get the common name.
+     * i.e. `my_table` or `my_schema_my_table`
+     *
+     * This is used to generate PHP name, so it should not contain tablePrefix,
+     * which only affects DB table name.
      *
      * @return string
      */
     private function getStdSeparatedName(): string
     {
-        if ($this->schema && $this->getBuildProperty('generator.schema.autoPrefix')) {
-            return $this->schema . NameGeneratorInterface::STD_SEPARATOR_CHAR . $this->getCommonName();
-        }
-
-        return $this->getCommonName();
+        return ($this->schema && $this->getBuildProperty('generator.schema.autoPrefix'))
+            ? $this->schema . NameGeneratorInterface::STD_SEPARATOR_CHAR . $this->originCommonName
+            : $this->originCommonName;
     }
 
     /**
@@ -219,15 +219,14 @@ class Table extends ScopedMappingModel implements IdMethod
         if (!$this->commonName) {
             throw new SchemaException("Attribute 'name' missing on table.");
         }
+        if ($this->database->getTablePrefix()) {
+            $this->commonName = $this->database->getTablePrefix() . $this->commonName;
+        }
 
         // retrieves the method for converting from specified name to a PHP name.
         $this->phpNamingMethod = $this->getAttribute('phpNamingMethod', $this->database->getDefaultPhpNamingMethod());
 
-        $this->phpName = $this->getAttribute('phpName', $this->buildPhpName($this->getStdSeparatedName()));
-
-        if ($this->database->getTablePrefix()) {
-            $this->commonName = $this->database->getTablePrefix() . $this->commonName;
-        }
+        $this->phpName = $this->getAttribute('phpName') ?? $this->buildPhpName($this->getStdSeparatedName());
 
         $this->idMethod = $this->getAttribute('idMethod', $this->database->getDefaultIdMethod());
         $this->allowPkInsert = $this->booleanValue($this->getAttribute('allowPkInsert'));
@@ -1278,6 +1277,14 @@ class Table extends ScopedMappingModel implements IdMethod
     }
 
     /**
+     * @return bool
+     */
+    public function hasCustomPhpName(): bool
+    {
+        return $this->phpName && $this->phpName !== $this->buildPhpName($this->originCommonName);
+    }
+
+    /**
      * Returns the auto generated PHP name value for a given name.
      *
      * @param string $name
@@ -2092,15 +2099,9 @@ class Table extends ScopedMappingModel implements IdMethod
      */
     public function getAutoIncrementPrimaryKey(): ?Column
     {
-        if ($this->getIdMethod() !== IdMethod::NO_ID_METHOD) {
-            foreach ($this->getPrimaryKey() as $pk) {
-                if ($pk->isAutoIncrement()) {
-                    return $pk;
-                }
-            }
-        }
-
-        return null;
+        return $this->getIdMethod() !== IdMethod::NO_ID_METHOD
+            ? array_find($this->getPrimaryKey(), fn (Column $pk) => $pk->isAutoIncrement())
+            : null;
     }
 
     /**

--- a/src/Propel/Generator/Reverse/AbstractSchemaParser.php
+++ b/src/Propel/Generator/Reverse/AbstractSchemaParser.php
@@ -216,7 +216,7 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
      *
      * @return \Propel\Generator\Model\VendorInfo
      */
-    protected function getNewVendorInfoObject(array $params): VendorInfo
+    protected function createVendorInfoObject(array $params): VendorInfo
     {
         $type = $this->getPlatform()->getDatabaseType();
 

--- a/src/Propel/Generator/Reverse/MysqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/MysqlSchemaParser.php
@@ -15,10 +15,14 @@ use Propel\Generator\Model\Index;
 use Propel\Generator\Model\PropelTypes;
 use Propel\Generator\Model\Table;
 use Propel\Generator\Model\Unique;
+use Propel\Generator\Model\VendorInfo;
 use Propel\Generator\Platform\MysqlPlatform;
 use Propel\Runtime\Connection\ConnectionInterface;
 use RuntimeException;
+use function array_all;
+use function array_key_exists;
 use function array_keys;
+use function array_map;
 use function assert;
 use function count;
 use function explode;
@@ -26,6 +30,7 @@ use function implode;
 use function in_array;
 use function preg_match;
 use function preg_match_all;
+use function reset;
 use function sprintf;
 use function str_ends_with;
 use function str_replace;
@@ -153,6 +158,10 @@ class MysqlSchemaParser extends AbstractSchemaParser
             $this->addColumnDescriptionsToTable($table);
         }
 
+        if (!$this->addVendorInfo) {
+            $this->bundleEngineInformation($database);
+        }
+
         return count($database->getTables());
     }
 
@@ -257,7 +266,7 @@ class MysqlSchemaParser extends AbstractSchemaParser
         $column->setNotNull($null === 'NO');
 
         if ($this->addVendorInfo) {
-            $vi = $this->getNewVendorInfoObject($row);
+            $vi = $this->createVendorInfoObject($row);
             $column->addVendorInfo($vi);
         }
 
@@ -654,7 +663,7 @@ EOT;
                     $indexes[$name] = new Index($name);
                 }
                 if ($this->addVendorInfo) {
-                    $vi = $this->getNewVendorInfoObject($row);
+                    $vi = $this->createVendorInfoObject($row);
                     $indexes[$name]->addVendorInfo($vi);
                 }
                 $indexes[$name]->setTable($table);
@@ -716,9 +725,40 @@ EOT;
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
         if (!$this->addVendorInfo) {
             // since we depend on `Engine` in the MysqlPlatform, we always have to extract this vendor information
-            $row = ['Engine' => $row ? $row['Engine'] : null];
+            $row = ['Engine' => $row['Engine'] ?? null];
         }
-        $vi = $this->getNewVendorInfoObject($row);
+        $vi = $this->createVendorInfoObject($row);
         $table->addVendorInfo($vi);
+    }
+
+    /**
+     * If all tables share the same Engine (i.e. InnoDb), put it on the database rather than on the table.
+     *
+     * @param \Propel\Generator\Model\Database $database
+     *
+     * @return void
+     */
+    protected function bundleEngineInformation(Database $database)
+    {
+        $tableVendorInfos = array_map(fn (Table $table) => $table->getVendorInformation()['mysql'] ?? null, $database->getTables());
+        $tableEngines = array_map(fn (VendorInfo|null $vi) => $vi?->getParameter('Engine'), $tableVendorInfos);
+        if (!$tableEngines) {
+            return;
+        }
+        $engine = reset($tableEngines);
+        $allSameEngine = array_all($tableEngines, fn (string|null $e) => $e === $engine);
+        if (!$allSameEngine) {
+            return;
+        }
+        $dbVendorInfos = $database->getVendorInformation();
+        if (!array_key_exists('mysql', $dbVendorInfos)) {
+            $database->addVendorInfo($this->createVendorInfoObject([]));
+        }
+        $database->getVendorInfoForType('mysql')->setParameter('Engine', $engine);
+        foreach ($tableVendorInfos as $tableVendorInfo) {
+            $params = $tableVendorInfo->getParameters();
+            unset($params['Engine']);
+            $tableVendorInfo->setParameters($params);
+        }
     }
 }

--- a/src/Propel/Generator/Schema/Dumper/XmlDumper.php
+++ b/src/Propel/Generator/Schema/Dumper/XmlDumper.php
@@ -221,13 +221,12 @@ class XmlDumper implements DumperInterface
         }
 
         $idMethod = $table->getIdMethod();
-        if ($idMethod !== IdMethod::NO_ID_METHOD) {
+        if ($idMethod !== $database->getDefaultIdMethod() && $idMethod !== IdMethod::NO_ID_METHOD) {
             $tableNode->setAttribute('idMethod', $idMethod);
         }
 
-        $phpName = $table->getPhpName();
-        if ($phpName) {
-            $tableNode->setAttribute('phpName', $phpName);
+        if ($table->hasCustomPhpName()) {
+            $tableNode->setAttribute('phpName', $table->getPhpName());
         }
 
         $package = $table->getPackage();
@@ -387,9 +386,8 @@ class XmlDumper implements DumperInterface
         $columnNode = $parentNode->appendChild($this->document->createElement('column'));
         $columnNode->setAttribute('name', $column->getName());
 
-        $phpName = $column->getPhpName();
-        if ($phpName) {
-            $columnNode->setAttribute('phpName', $phpName);
+        if ($column->hasCustomPhpName()) {
+            $columnNode->setAttribute('phpName', $column->getPhpName());
         }
 
         $columnNode->setAttribute('type', $column->getType());

--- a/src/Propel/Generator/Schema/Dumper/XmlDumper.php
+++ b/src/Propel/Generator/Schema/Dumper/XmlDumper.php
@@ -185,6 +185,9 @@ class XmlDumper implements DumperInterface
      */
     private function appendVendorInformationNode(VendorInfo $vendorInfo, DOMNode $parentNode): void
     {
+        if (!$vendorInfo->getParameters()) {
+            return;
+        }
         /** @var \DOMElement $vendorNode */
         $vendorNode = $parentNode->appendChild($this->document->createElement('vendor'));
         $vendorNode->setAttribute('type', $vendorInfo->getType());

--- a/tests/Propel/Tests/Generator/Builder/Util/SchemaReaderJoinSchemaTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Util/SchemaReaderJoinSchemaTest.php
@@ -23,12 +23,12 @@ class SchemaReaderJoinSchemaTest extends TestCase
 <?xml version="1.0" encoding="utf-8"?>
 <app-data>
   <database name="default" defaultIdMethod="native" schema="foo" defaultPhpNamingMethod="underscore">
-    <table name="table1" idMethod="native" phpName="Table1">
-      <column name="id" phpName="Id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
+    <table name="table1">
+      <column name="id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
     </table>
-    <table name="table2" schema="bar" idMethod="native" phpName="Table2">
-      <column name="id" phpName="Id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
-      <column name="table1_id" phpName="Table1Id" type="INTEGER"/>
+    <table name="table2" schema="bar">
+      <column name="id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
+      <column name="table1_id" type="INTEGER"/>
       <foreign-key foreignTable="table1" foreignSchema="foo" name="table2_fk_6e7121">
         <reference local="table1_id" foreign="id"/>
       </foreign-key>

--- a/tests/Propel/Tests/Generator/Builder/Util/SchemaReaderTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Util/SchemaReaderTest.php
@@ -96,8 +96,8 @@ EOF;
 <?xml version="1.0" encoding="utf-8"?>
 <app-data>
   <database name="foo" defaultIdMethod="native" defaultPhpNamingMethod="underscore">
-    <table name="bar" idMethod="native" phpName="Bar">
-      <column name="id" phpName="Id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
+    <table name="bar">
+      <column name="id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
     </table>
   </database>
 </app-data>
@@ -118,8 +118,8 @@ EOF;
 <?xml version="1.0" encoding="utf-8"?>
 <app-data>
   <database name="foo" defaultIdMethod="native" defaultPhpNamingMethod="underscore">
-    <table name="bar" idMethod="native" phpName="Bar">
-      <column name="id" phpName="Id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
+    <table name="bar">
+      <column name="id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
     </table>
   </database>
 </app-data>
@@ -137,11 +137,11 @@ EOF;
 <?xml version="1.0" encoding="utf-8"?>
 <app-data>
   <database name="foo" defaultIdMethod="native" defaultPhpNamingMethod="underscore">
-    <table name="bar1" idMethod="native" phpName="Bar1">
-      <column name="id" phpName="Id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
+    <table name="bar1">
+      <column name="id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
     </table>
-    <table name="bar2" idMethod="native" phpName="Bar2" skipSql="true" forReferenceOnly="true">
-      <column name="id" phpName="Id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
+    <table name="bar2" skipSql="true" forReferenceOnly="true">
+      <column name="id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
     </table>
   </database>
 </app-data>

--- a/tests/Propel/Tests/Generator/Command/DatabaseReverseTest.php
+++ b/tests/Propel/Tests/Generator/Command/DatabaseReverseTest.php
@@ -65,7 +65,7 @@ class DatabaseReverseTest extends TestCaseFixturesDatabase
         $this->assertCount(1, $table);
         $table = $table[0];
         $this->assertEquals('acct_access_role', $table['name']);
-        $this->assertEquals('AcctAccessRole', $table['phpName']);
+        $this->assertEquals(null, $table['phpName']);
         $this->assertCount(2, $table->xpath('column'));
     }
 

--- a/tests/Propel/Tests/Generator/Model/ColumnTest.php
+++ b/tests/Propel/Tests/Generator/Model/ColumnTest.php
@@ -9,12 +9,14 @@
 namespace Propel\Tests\Generator\Model;
 
 use PDO;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Propel\Generator\Exception\EngineException;
 use Propel\Generator\Exception\SchemaException;
 use Propel\Generator\Model\Column;
 use Propel\Generator\Model\PropelTypes;
 use Propel\Tests\Helpers\ColorsBackedEnum;
 use Propel\Tests\Helpers\ColorsUnitEnum;
+use Propel\Tests\TestCase;
 
 /**
  * Tests for package handling.
@@ -1173,5 +1175,41 @@ class ColumnTest extends ModelTestCase
         $this->expectException(SchemaException::class);
         $this->expectExceptionMessage('Column `table.foo`: Combining binary ENUM/SET type with a PHP enum type (`phpType="Propel\Tests\Helpers\ColorsUnitEnum"` is not supported');
         $this->buildColumnFromSchema('<column name="foo" type="ENUM_BINARY" phpType="' . ColorsUnitEnum::class. '"/>');
+    }
+
+    public static function HasCustomPhpNameDataProvider(): array
+    {
+        /** @var array<array{Column, bool, string}> */
+        $data = [];
+
+        $data[] = [new Column('foo'), false, 'Default name is not custom.'];
+
+        $column = new Column('foo');
+        $column->setPhpName('Foo');
+        $data[] = [$column, false, 'Manually set default name is still default.'];
+
+        $column = new Column('foo');
+        $column->setPhpName(null);
+        $data[] = [$column, false, 'No PhpName'];
+
+        $column = new Column('foo');
+        $column->setPhpName('foo');
+        $data[] = [$column, true, 'Custom name should be case sensitive.'];
+
+        $column = new Column('foo');
+        $column->setPhpName('NotFoo');
+        $data[] = [$column, true, 'Has custom value.'];
+
+        $column = new Column('foo');
+        (new TestCase(''))->setObjectPropertyValue($column, 'namePrefix', 'col');
+        $data[] = [$column, false, 'Prefixed name is not default.'];
+
+        return $data;
+    }
+
+    #[DataProvider('HasCustomPhpNameDataProvider')]
+    public function testHasCustomPhpName(Column $column, bool $expected, string $description): void
+    {
+        $this->assertSame($expected, $column->hasCustomPhpName(), $description);
     }
 }

--- a/tests/Propel/Tests/Generator/Model/TableTest.php
+++ b/tests/Propel/Tests/Generator/Model/TableTest.php
@@ -8,12 +8,16 @@
 
 namespace Propel\Tests\Generator\Model;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use Propel\Generator\Config\QuickGeneratorConfig;
 use Propel\Generator\Exception\EngineException;
 use Propel\Generator\Exception\InvalidArgumentException;
 use Propel\Generator\Model\Column;
 use Propel\Generator\Model\Database;
 use Propel\Generator\Model\Index;
+use Propel\Generator\Model\Schema;
 use Propel\Generator\Model\Table;
+use Propel\Tests\TestCase;
 
 /**
  * Unit test suite for Table model class.
@@ -1075,5 +1079,49 @@ class TableTest extends ModelTestCase
             ->will($this->returnValue($options['pg_transaction']));
 
         return $column;
+    }
+
+    public static function HasCustomPhpNameDataProvider(): array
+    {
+        /** @var array<array{Table, bool, string}> */
+        $data = [];
+
+        $data[] = [new Table('foo'), false, 'Default name is not custom.'];
+
+        $table = new Table('foo');
+        $table->setPhpName('Foo');
+        $data[] = [$table, false, 'Manually set default name is still default.'];
+
+        $table = new Table('foo');
+        $table->setPhpName('foo');
+        $data[] = [$table, true, 'Custom name should be case sensitive.'];
+
+        $table = new Table('foo');
+        $table->setPhpName('NotFoo');
+        $data[] = [$table, true, 'Has custom value.'];
+
+        $table = new Table('foo');
+        $table->setPhpName('Foo');
+        $table->setCommonName('bar'); // sets Table::originCommonName which stores name from schema
+        $data[] = [$table, true, 'Custom name is checked against original name.'];
+
+        $config = new QuickGeneratorConfig(['propel.generator.schema.autoPrefix' => true]);
+        $schema = new Schema();
+        $schema->setGeneratorConfig($config);
+        $db = new Database();
+        $schema->addDatabase($db);
+        $table = new Table('foo');
+        $table->setDatabase($db);
+        $table->setSchema('Le');
+        $table->getPhpName(); // setup default phpname 
+        $data[] = [$table, true, 'Prefixed table name is custom.'];
+
+        return $data;
+    }
+
+    #[DataProvider('HasCustomPhpNameDataProvider')]
+    public function testHasCustomPhpName(Table $table, bool $expected, string $description): void
+    {
+        $this->assertSame($expected, $table->hasCustomPhpName(), $description);
     }
 }

--- a/tests/Propel/Tests/Generator/Reverse/MysqlSchemaParserTest.php
+++ b/tests/Propel/Tests/Generator/Reverse/MysqlSchemaParserTest.php
@@ -9,12 +9,15 @@
 namespace Propel\Tests\Generator\Reverse;
 
 use PDO;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Propel\Generator\Config\QuickGeneratorConfig;
 use Propel\Generator\Model\Column;
 use Propel\Generator\Model\Table;
 use Propel\Generator\Model\ColumnDefaultValue;
 use Propel\Generator\Model\Database;
+use Propel\Generator\Model\VendorInfo;
 use Propel\Generator\Platform\DefaultPlatform;
+use Propel\Generator\Platform\MysqlPlatform;
 use Propel\Generator\Reverse\MysqlSchemaParser;
 use Propel\Tests\Bookstore\Map\BookTableMap;
 
@@ -256,6 +259,55 @@ EOT;
             $this->assertNull($contentTextNone->getDefaultValue(), 'TEXT column without explicit default should have no default');
         } finally {
             $this->con->exec('DROP TABLE IF EXISTS test_text_defaults');
+        }
+    }
+
+    public static function BundleVendorInfoDataProvider(): array
+    {
+        $addTable = function (Database $db, string $name, string $engine) {
+            $table = new Table($name);
+            $vi = new VendorInfo('mysql');
+            $vi->setParameters(['Engine' => $engine]);
+            $table->addVendorInfo($vi);
+            $db->addTable($table);
+        };
+
+        $sameEngineDb = new Database(null, new MysqlPlatform());
+        $addTable($sameEngineDb, 'foo', 'engine_1');
+        $addTable($sameEngineDb, 'bar', 'engine_1');
+
+        $mixedEngineDb = new Database(null, new MysqlPlatform());
+        $addTable($mixedEngineDb, 'foo', 'engine_1');
+        $addTable($mixedEngineDb, 'bar', 'engine_2');
+
+        $incompleteEngineDb = new Database(null, new MysqlPlatform());
+        $addTable($incompleteEngineDb, 'foo', 'engine_1');
+        $incompleteEngineDb->addTable(new Table('bar'));
+
+        $nonEmptyDb = new Database(null, new MysqlPlatform());
+        $addTable($nonEmptyDb, 'foo', 'engine_1');
+        $vi = $nonEmptyDb->getVendorInfoForType('mysql'); // Note: creates new VI
+        
+
+        return [ // db, expected db engine, expected table engines
+            [$sameEngineDb, 'engine_1', [null, null]],
+            [$mixedEngineDb, null, ['engine_1', 'engine_2']],
+            [$incompleteEngineDb, null, ['engine_1', null]],
+        ];
+    }
+
+    #[DataProvider('BundleVendorInfoDataProvider')]
+    public function testBundleEngine(Database $db, string|null $expectedDbEngine, array $expectTableEngines): void
+    {
+        $parser = new MysqlSchemaParser();
+        $this->callMethod($parser, 'bundleEngineInformation', [$db]);
+        $dbVendorInfo = $db->getVendorInfoForType('mysql');
+
+        $this->assertSame($expectedDbEngine, $dbVendorInfo->getParameter('Engine'));
+        foreach ($db->getTables() as $i => $table) {
+            $vi = $table->getVendorInformation()['mysql'] ?? null;
+            $tableEngine = $vi?->getParameter('Engine');
+            $this->assertSame($expectTableEngines[$i], $tableEngine);
         }
     }
 }

--- a/tests/Propel/Tests/Resources/blog-database.xml
+++ b/tests/Propel/Tests/Resources/blog-database.xml
@@ -4,14 +4,14 @@
     <parameter name="Engine" value="InnoDB"/>
     <parameter name="Charset" value="utf8"/>
   </vendor>
-  <table name="blog_post" phpName="BlogPost" package="Acme.Blog" namespace="\Acme\Model\Blog" baseClass="\Acme\Model\ActiveRecord" description="The list of posts">
-    <column name="id" phpName="Id" type="integer" size="7" primaryKey="true" autoIncrement="true" required="true"/>
-    <column name="author_id" phpName="AuthorId" type="smallint" size="3" required="true"/>
-    <column name="category_id" phpName="CategoryId" type="tinyint" size="2" required="true"/>
-    <column name="title" phpName="Title" type="varchar" size="100" required="true"/>
-    <column name="body" phpName="Body" type="clob"/>
-    <column name="average_rating" phpName="AverageRating" type="float" size="2" scale="2" description="The post rating in percentage"/>
-    <column name="price_without_decimal_places" phpName="PriceWithoutDecimalPlaces" type="DECIMAL" size="10" scale="0" description="The Price without decimal places"/>
+  <table name="blog_post" package="Acme.Blog" namespace="\Acme\Model\Blog" baseClass="\Acme\Model\ActiveRecord" description="The list of posts">
+    <column name="id" type="integer" size="7" primaryKey="true" autoIncrement="true" required="true"/>
+    <column name="author_id" type="smallint" size="3" required="true"/>
+    <column name="category_id" type="tinyint" size="2" required="true"/>
+    <column name="title" type="varchar" size="100" required="true"/>
+    <column name="body" type="clob"/>
+    <column name="average_rating" type="float" size="2" scale="2" description="The post rating in percentage"/>
+    <column name="price_without_decimal_places" type="DECIMAL" size="10" scale="0" description="The Price without decimal places"/>
     <foreign-key foreignTable="blog_author" name="fk_post_has_author" phpName="Author" refPhpName="Posts" defaultJoin="Criteria::LEFT_JOIN" onDelete="CASCADE">
       <reference local="author_id" foreign="id"/>
     </foreign-key>
@@ -35,25 +35,25 @@
       <parameter name="unique_constraint" value="true"/>
     </behavior>
   </table>
-  <table name="blog_author" phpName="BlogAuthor" package="Acme.Blog" namespace="\Acme\Model\Blog" baseClass="\Acme\Model\ActiveRecord" description="The list of authors">
-    <column name="id" phpName="Id" type="smallint" size="3" primaryKey="true" autoIncrement="true" required="true"/>
-    <column name="username" phpName="Username" type="varchar" size="15" required="true"/>
-    <column name="password" phpName="Password" type="varchar" size="40" required="true"/>
+  <table name="blog_author" package="Acme.Blog" namespace="\Acme\Model\Blog" baseClass="\Acme\Model\ActiveRecord" description="The list of authors">
+    <column name="id" type="smallint" size="3" primaryKey="true" autoIncrement="true" required="true"/>
+    <column name="username" type="varchar" size="15" required="true"/>
+    <column name="password" type="varchar" size="40" required="true"/>
     <unique name="author_password_unique_idx">
       <unique-column name="username" size="8"/>
     </unique>
   </table>
-  <table name="blog_category" phpName="BlogCategory" package="Acme.Blog" namespace="\Acme\Model\Blog" baseClass="\Acme\Model\ActiveRecord" description="The list of categories">
-    <column name="id" phpName="Id" type="tinyint" size="2" primaryKey="true" autoIncrement="true" required="true"/>
-    <column name="name" phpName="Name" type="varchar" size="40" required="true"/>
+  <table name="blog_category" package="Acme.Blog" namespace="\Acme\Model\Blog" baseClass="\Acme\Model\ActiveRecord" description="The list of categories">
+    <column name="id" type="tinyint" size="2" primaryKey="true" autoIncrement="true" required="true"/>
+    <column name="name" type="varchar" size="40" required="true"/>
   </table>
-  <table name="blog_tag" phpName="BlogTag" package="Acme.Blog" namespace="\Acme\Model\Blog" baseClass="\Acme\Model\ActiveRecord" description="The list of tags">
-    <column name="id" phpName="Id" type="integer" size="7" primaryKey="true" autoIncrement="true" required="true"/>
-    <column name="name" phpName="Name" type="varchar" size="40" required="true"/>
+  <table name="blog_tag" package="Acme.Blog" namespace="\Acme\Model\Blog" baseClass="\Acme\Model\ActiveRecord" description="The list of tags">
+    <column name="id" type="integer" size="7" primaryKey="true" autoIncrement="true" required="true"/>
+    <column name="name" type="varchar" size="40" required="true"/>
   </table>
-  <table name="blog_post_tag" phpName="BlogPostTag" package="Acme.Blog" namespace="\Acme\Model\Blog" isCrossRef="true" baseClass="\Acme\Model\ActiveRecord" description="This table was given with an absolute namespace">
-    <column name="post_id" phpName="PostId" type="integer" size="7" primaryKey="true" required="true"/>
-    <column name="tag_id" phpName="TagId" type="integer" size="7" primaryKey="true" required="true"/>
+  <table name="blog_post_tag" package="Acme.Blog" namespace="\Acme\Model\Blog" isCrossRef="true" baseClass="\Acme\Model\ActiveRecord" description="This table was given with an absolute namespace">
+    <column name="post_id" type="integer" size="7" primaryKey="true" required="true"/>
+    <column name="tag_id" type="integer" size="7" primaryKey="true" required="true"/>
     <foreign-key foreignTable="blog_post" name="fk_post_has_tags" phpName="Post" defaultJoin="Criteria::LEFT_JOIN" onDelete="CASCADE">
       <reference local="post_id" foreign="id"/>
     </foreign-key>
@@ -62,15 +62,15 @@
     </foreign-key>
   </table>
   <table name="cms_page" phpName="Page" package="Acme.Cms" namespace="\Acme\Model\Cms" baseClass="\Acme\Model\PublicationActiveRecord">
-    <column name="id" phpName="Id" type="integer" size="5" primaryKey="true" autoIncrement="true" required="true"/>
-    <column name="title" phpName="Title" type="varchar" size="150" required="true"/>
-    <column name="content" phpName="Content" type="clob">
+    <column name="id" type="integer" size="5" primaryKey="true" autoIncrement="true" required="true"/>
+    <column name="title" type="varchar" size="150" required="true"/>
+    <column name="content" type="clob">
       <vendor type="mysql">
         <parameter name="Charset" value="latin1"/>
         <parameter name="Collate" value="latin1_general_ci"/>
       </vendor>
     </column>
-    <column name="is_published" phpName="IsPublished" type="boolean" required="true" defaultValue="false"/>
+    <column name="is_published" type="boolean" required="true" defaultValue="false"/>
     <index name="page_content_fulltext_idx">
       <index-column name="content"/>
       <vendor type="mysql">
@@ -81,10 +81,10 @@
       <parameter name="Engine" value="MyISAM"/>
     </vendor>
   </table>
-  <table name="external_table" phpName="ExternalTable" package="Acme" namespace="\External" baseClass="\Acme\Model\ActiveRecord" description="A table in the \External namespace">
-    <column name="id" phpName="Id" type="integer" primaryKey="true" required="true"/>
+  <table name="external_table" package="Acme" namespace="\External" baseClass="\Acme\Model\ActiveRecord" description="A table in the \External namespace">
+    <column name="id" type="integer" primaryKey="true" required="true"/>
   </table>
-  <table name="acme_base" phpName="AcmeBase" package="Acme" baseClass="\Acme\Model\ActiveRecord" description="A table in the \Acme\Model namespace should not have a namespace declaration">
-    <column name="id" phpName="Id" type="integer" primaryKey="true" required="true"/>
+  <table name="acme_base" package="Acme" baseClass="\Acme\Model\ActiveRecord" description="A table in the \Acme\Model namespace should not have a namespace declaration">
+    <column name="id" type="integer" primaryKey="true" required="true"/>
   </table>
 </database>

--- a/tests/Propel/Tests/Resources/blog-schema.xml
+++ b/tests/Propel/Tests/Resources/blog-schema.xml
@@ -5,17 +5,17 @@
       <parameter name="Engine" value="InnoDB"/>
       <parameter name="Charset" value="utf8"/>
     </vendor>
-    <table name="blog_post" phpName="BlogPost" package="Acme.Blog" namespace="\Acme\Model\Blog" baseClass="\Acme\Model\ActiveRecord" description="The list of posts">
-      <column name="id" phpName="Id" type="integer" size="7" primaryKey="true" autoIncrement="true" required="true"/>
-      <column name="author_id" phpName="AuthorId" type="smallint" size="3" required="true"/>
-      <column name="category_id" phpName="CategoryId" type="tinyint" size="2" required="true"/>
-      <column name="title" phpName="Title" type="varchar" size="100" required="true"/>
-      <column name="body" phpName="Body" type="clob"/>
-      <column name="average_rating" phpName="AverageRating" type="float" size="2" scale="2" description="The post rating in percentage"/>
-      <column name="price_without_decimal_places" phpName="PriceWithoutDecimalPlaces" type="DECIMAL" size="10" scale="0" description="The Price without decimal places"/>
-      <column name="created_at" phpName="CreatedAt" type="TIMESTAMP"/>
-      <column name="updated_at" phpName="UpdatedAt" type="TIMESTAMP"/>
-      <column name="slug" phpName="Slug" type="VARCHAR" size="255"/>
+    <table name="blog_post" package="Acme.Blog" namespace="\Acme\Model\Blog" baseClass="\Acme\Model\ActiveRecord" description="The list of posts">
+      <column name="id" type="integer" size="7" primaryKey="true" autoIncrement="true" required="true"/>
+      <column name="author_id" type="smallint" size="3" required="true"/>
+      <column name="category_id" type="tinyint" size="2" required="true"/>
+      <column name="title" type="varchar" size="100" required="true"/>
+      <column name="body" type="clob"/>
+      <column name="average_rating" type="float" size="2" scale="2" description="The post rating in percentage"/>
+      <column name="price_without_decimal_places" type="DECIMAL" size="10" scale="0" description="The Price without decimal places"/>
+      <column name="created_at" type="TIMESTAMP"/>
+      <column name="updated_at" type="TIMESTAMP"/>
+      <column name="slug" type="VARCHAR" size="255"/>
       <foreign-key foreignTable="blog_author" name="fk_post_has_author" phpName="Author" refPhpName="Posts" defaultJoin="Criteria::LEFT_JOIN" onDelete="CASCADE">
         <reference local="author_id" foreign="id"/>
       </foreign-key>
@@ -48,25 +48,25 @@
         <parameter name="unique_constraint" value="true"/>
       </behavior>
     </table>
-    <table name="blog_author" phpName="BlogAuthor" package="Acme.Blog" namespace="\Acme\Model\Blog" baseClass="\Acme\Model\ActiveRecord" description="The list of authors">
-      <column name="id" phpName="Id" type="smallint" size="3" primaryKey="true" autoIncrement="true" required="true"/>
-      <column name="username" phpName="Username" type="varchar" size="15" required="true"/>
-      <column name="password" phpName="Password" type="varchar" size="40" required="true"/>
+    <table name="blog_author" package="Acme.Blog" namespace="\Acme\Model\Blog" baseClass="\Acme\Model\ActiveRecord" description="The list of authors">
+      <column name="id" type="smallint" size="3" primaryKey="true" autoIncrement="true" required="true"/>
+      <column name="username" type="varchar" size="15" required="true"/>
+      <column name="password" type="varchar" size="40" required="true"/>
       <unique name="author_password_unique_idx">
         <unique-column name="username" size="8"/>
       </unique>
     </table>
-    <table name="blog_category" phpName="BlogCategory" package="Acme.Blog" namespace="\Acme\Model\Blog" baseClass="\Acme\Model\ActiveRecord" description="The list of categories">
-      <column name="id" phpName="Id" type="tinyint" size="2" primaryKey="true" autoIncrement="true" required="true"/>
-      <column name="name" phpName="Name" type="varchar" size="40" required="true"/>
+    <table name="blog_category" package="Acme.Blog" namespace="\Acme\Model\Blog" baseClass="\Acme\Model\ActiveRecord" description="The list of categories">
+      <column name="id" type="tinyint" size="2" primaryKey="true" autoIncrement="true" required="true"/>
+      <column name="name" type="varchar" size="40" required="true"/>
     </table>
-    <table name="blog_tag" phpName="BlogTag" package="Acme.Blog" namespace="\Acme\Model\Blog" baseClass="\Acme\Model\ActiveRecord" description="The list of tags">
-      <column name="id" phpName="Id" type="integer" size="7" primaryKey="true" autoIncrement="true" required="true"/>
-      <column name="name" phpName="Name" type="varchar" size="40" required="true"/>
+    <table name="blog_tag" package="Acme.Blog" namespace="\Acme\Model\Blog" baseClass="\Acme\Model\ActiveRecord" description="The list of tags">
+      <column name="id" type="integer" size="7" primaryKey="true" autoIncrement="true" required="true"/>
+      <column name="name" type="varchar" size="40" required="true"/>
     </table>
-    <table name="blog_post_tag" phpName="BlogPostTag" package="Acme.Blog" namespace="\Acme\Model\Blog" isCrossRef="true" baseClass="\Acme\Model\ActiveRecord" description="This table was given with an absolute namespace">
-      <column name="post_id" phpName="PostId" type="integer" size="7" primaryKey="true" required="true"/>
-      <column name="tag_id" phpName="TagId" type="integer" size="7" primaryKey="true" required="true"/>
+    <table name="blog_post_tag" package="Acme.Blog" namespace="\Acme\Model\Blog" isCrossRef="true" baseClass="\Acme\Model\ActiveRecord" description="This table was given with an absolute namespace">
+      <column name="post_id" type="integer" size="7" primaryKey="true" required="true"/>
+      <column name="tag_id" type="integer" size="7" primaryKey="true" required="true"/>
       <foreign-key foreignTable="blog_post" name="fk_post_has_tags" phpName="Post" defaultJoin="Criteria::LEFT_JOIN" onDelete="CASCADE">
         <reference local="post_id" foreign="id"/>
       </foreign-key>
@@ -78,15 +78,15 @@
       </index>
     </table>
     <table name="cms_page" phpName="Page" package="Acme.Cms" namespace="\Acme\Model\Cms" baseClass="\Acme\Model\PublicationActiveRecord">
-      <column name="id" phpName="Id" type="integer" size="5" primaryKey="true" autoIncrement="true" required="true"/>
-      <column name="title" phpName="Title" type="varchar" size="150" required="true"/>
-      <column name="content" phpName="Content" type="clob">
+      <column name="id" type="integer" size="5" primaryKey="true" autoIncrement="true" required="true"/>
+      <column name="title" type="varchar" size="150" required="true"/>
+      <column name="content" type="clob">
         <vendor type="mysql">
           <parameter name="Charset" value="latin1"/>
           <parameter name="Collate" value="latin1_general_ci"/>
         </vendor>
       </column>
-      <column name="is_published" phpName="IsPublished" type="boolean" required="true" defaultValue="false"/>
+      <column name="is_published" type="boolean" required="true" defaultValue="false"/>
       <index name="page_content_fulltext_idx">
         <index-column name="content"/>
         <vendor type="mysql">
@@ -97,11 +97,11 @@
         <parameter name="Engine" value="MyISAM"/>
       </vendor>
     </table>
-    <table name="external_table" phpName="ExternalTable" package="Acme" namespace="\External" baseClass="\Acme\Model\ActiveRecord" description="A table in the \External namespace">
-      <column name="id" phpName="Id" type="integer" primaryKey="true" required="true"/>
+    <table name="external_table" package="Acme" namespace="\External" baseClass="\Acme\Model\ActiveRecord" description="A table in the \External namespace">
+      <column name="id" type="integer" primaryKey="true" required="true"/>
     </table>
-    <table name="acme_base" phpName="AcmeBase" package="Acme" baseClass="\Acme\Model\ActiveRecord" description="A table in the \Acme\Model namespace should not have a namespace declaration">
-      <column name="id" phpName="Id" type="integer" primaryKey="true" required="true"/>
+    <table name="acme_base" package="Acme" baseClass="\Acme\Model\ActiveRecord" description="A table in the \Acme\Model namespace should not have a namespace declaration">
+      <column name="id" type="integer" primaryKey="true" required="true"/>
     </table>
   </database>
 </app-data>


### PR DESCRIPTION
## Issue
When reverse-engineering with `database:reverse`, the created schema.xml file contains lots of redundant data, making it harder to understand and work with the file:
- the engine type (like "InnoDb") is put on every single table (only affects MySql)
- the `phpName" is set for every table and column, even though it is just the PascalCase version of the table name
- `idMethod` is put on every table, even though it matches database default


## Changes
- Engine type is bundled on the database, unless it differs between tables or the whole vendor information is requested.
- `phpName` is omitted on tables and columns when it is the default name
- no `idMethod` on tables

## Implementation Details
- Bundler in MySqlSchemaParser
- Checks in SchemaDumper

## Test strategy
Unit tests for detecting default names and bundling engine type. Adjusted existing reverse test.

## Notes

Old:
```xml
    <table name="blog_post" phpName="BlogPost" namespace="\Acme\Model\Blog">
      <column name="id" phpName="Id" type="integer" size="7" primaryKey="true" autoIncrement="true" required="true"/>
      <column name="author_id" phpName="AuthorId" type="smallint" size="3" required="true"/>
      <column name="category_id" phpName="CategoryId" type="tinyint" size="2" required="true"/>
      <column name="title" phpName="Title" type="varchar" size="100" required="true"/>
      <column name="body" phpName="Body" type="clob"/>
      <column name="average_rating" phpName="AverageRating" type="float" size="2" scale="2" description="The post rating in percentage"/>
      <column name="price_without_decimal_places" phpName="PriceWithoutDecimalPlaces" type="DECIMAL" size="10" scale="0" description="The Price without decimal places"/>
      <column name="created_at" phpName="CreatedAt" type="TIMESTAMP"/>
      <column name="updated_at" phpName="UpdatedAt" type="TIMESTAMP"/>
      <column name="slug" phpName="Slug" type="VARCHAR" size="255"/>
      <vendor type="mysql">
        <parameter name="Engine" value="InnoDB"/>
      </vendor>
    </table>
```
New:
```xml
    <table name="blog_post" namespace="\Acme\Model\Blog">
      <column name="id" type="integer" size="7" primaryKey="true" autoIncrement="true" required="true"/>
      <column name="author_id" type="smallint" size="3" required="true"/>
      <column name="category_id" type="tinyint" size="2" required="true"/>
      <column name="title" type="varchar" size="100" required="true"/>
      <column name="body" type="clob"/>
      <column name="average_rating" type="float" size="2" scale="2" description="The post rating in percentage"/>
      <column name="price_without_decimal_places" type="DECIMAL" size="10" scale="0" description="The Price without decimal places"/>
      <column name="created_at" type="TIMESTAMP"/>
      <column name="updated_at" type="TIMESTAMP"/>
      <column name="slug" type="VARCHAR" size="255"/>
    </table>
```