### PR TITLE
Add Query::useGroupByXXXQuery() (BC break: subqueries)

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -6,5 +6,9 @@ coverage:
         target: 80%
         threshold: 5%
         if_ci_failed: error
+    patch:
+      default:
+        target: 80%      # Target for new code in the pull request
+        threshold: 0%    # No decrease allowed for patch
 ignore:
   - "src/**/templates/**"

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ $ composer dump-autoload
 
 Motivation for Perpl was to make features available around code-style, typing, performance and usability.
 
-## Ready for PHP 8.5
+## Ready for PHP 8.5 and Symfony 8
 
-Code is tested to run in PHP 8.5 without deprecation notices or warnings.
+Code is tested to run in PHP 8.5 and with Symfony 8 without deprecation notices or warnings.
 
 ## Type-preserving queries
 
@@ -123,14 +123,28 @@ Introduces `Criteria::combineFilters()`/`Criteria::endCombineFilters()` which bu
 ```
 Previously, this required to register the individual parts under an arbitrary name using `Criteria::addCond()` and then combining them with `Criteria::combine()`, possibly under another arbitrary name for further processing.
 
-## Read multiple behaviors from same repository
+## Group by queries by relations
 
-Propel restricts reading behaviors from repositories to one per repo. This allows to read multiple behaviors (see [#25](https://github.com/mringler/perpl/pull/25) for details).
+Aggregations can be easily added along one-to-many relations using the generated `useGroupByXXXQuery()` methods:
+```php
+$authors = AuthorQuery::create()
+    ->useGroupByBookQuery()
+        ->addAsColumn('totalBooks', 'COUNT(*)')
+    ->endUse()
+    ->findObjects();
+
+$totalBooks = $authors[0]->getVirtualColumn('totalBooks');
+```
+The main query automatically adds AS-columns from immediate subqueries.
 
 ## Fixed cross-relations
 
 Creates methods for all elements of ternary relation (Propel only uses first foreign key).
 Fixes naming issues and detects duplicates in model method names.
+
+## Read multiple behaviors from same repository
+
+Propel restricts reading behaviors from repositories to one per repo. This allows to read multiple behaviors (see [#25](https://github.com/mringler/perpl/pull/25) for details).
 
 # Contribute
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -212,6 +212,11 @@
       <code><![CDATA[addSelectColumns]]></code>
     </UndefinedMethod>
   </file>
+  <file src="src/Propel/Runtime/ActiveQuery/SqlBuilder/SelectQuerySqlBuilder.php">
+    <ConflictingReferenceConstraint>
+      <code><![CDATA[else {]]></code>
+    </ConflictingReferenceConstraint>
+  </file>
   <file src="src/Propel/Runtime/Adapter/Pdo/MssqlAdapter.php">
     <InvalidArrayOffset>
       <code><![CDATA[$orders[$orderArr[$selColArr[$selColCount]]['key']]]]></code>

--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -15,7 +15,6 @@ use Propel\Generator\Model\PropelTypes;
 use Propel\Generator\Model\Table;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\ActiveQuery\FilterExpression\FilterFactory;
-use Propel\Runtime\ActiveQuery\ModelJoin;
 use Propel\Runtime\ActiveQuery\TypedModelCriteria;
 use Propel\Runtime\Exception\EntityNotFoundException;
 use Propel\Runtime\Exception\PropelException;
@@ -1178,8 +1177,11 @@ class QueryBuilder extends AbstractOMBuilder
     {
         $fkTable = $fk->getForeignTable();
         $relationName = $fk->getIdentifier();
+        $joinType = $this->getJoinType($fk);
+        $foreignColumns = array_filter($fk->getForeignColumns());
+        $isToMany = !$fk->isForeignPrimaryKey();
 
-        $this->addUseRelationMethods($script, $fk, $fkTable, $relationName);
+        $this->addUseRelationMethods($script, $joinType, $fkTable, $foreignColumns, $relationName, $isToMany);
     }
 
     /**
@@ -1192,24 +1194,35 @@ class QueryBuilder extends AbstractOMBuilder
      */
     protected function addUseRefFkQuery(string &$script, ForeignKey $fk): void
     {
-        $fkTable = $this->getTable()->getDatabase()->getTable($fk->getTableName());
+        $fkTable = $this->getDatabase()->getTable($fk->getTableName());
         $relationName = $fk->getIdentifierReversed();
+        $joinType = $this->getJoinType($fk);
+        $foreignColumns = $fk->getLocalColumns();
+        $isToMany = !$fk->isLocalPrimaryKey();
 
-        $this->addUseRelationMethods($script, $fk, $fkTable, $relationName);
+        $this->addUseRelationMethods($script, $joinType, $fkTable, $foreignColumns, $relationName, $isToMany);
     }
 
     /**
      * For a given relation, adds the useXXXQuery(), withXXX(), etc methods.
      *
      * @param string $script
-     * @param \Propel\Generator\Model\ForeignKey $fk
+     * @param string $joinType
      * @param \Propel\Generator\Model\Table $fkTable
+     * @param array<string> $foreignColumns
      * @param string $relationName
+     * @param bool $isToMany
      *
      * @return void
      */
-    protected function addUseRelationMethods(string &$script, ForeignKey $fk, Table $fkTable, string $relationName): void
-    {
+    protected function addUseRelationMethods(
+        string &$script,
+        string $joinType,
+        Table $fkTable,
+        array $foreignColumns,
+        string $relationName,
+        bool $isToMany
+    ): void {
         $fkQueryBuilder = $this->getStubQueryBuilder($fkTable);
         $queryClassFq = $this->getClassNameFromBuilder($fkQueryBuilder, true);
 
@@ -1219,7 +1232,9 @@ class QueryBuilder extends AbstractOMBuilder
             'foreignTablePhpName' => $fkTable->getPhpName(),
             'queryClass' => $this->declareClass($queryClassFq),
             'queryClassFq' => $queryClassFq,
-            'joinType' => $this->getJoinType($fk),
+            'joinType' => $joinType,
+            'isToMany' => $isToMany,
+            'foreignKeyTargetColumnNames' => $foreignColumns,
         ]);
     }
 

--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -235,7 +235,6 @@ class QueryBuilder extends AbstractOMBuilder
             Criteria::class,
             Exception::class,
             FilterFactory::class,
-            ModelJoin::class,
             PropelException::class,
             Perpl::class,
             TypedModelCriteria::class,

--- a/src/Propel/Generator/Builder/Om/QueryBuilder/templates/joinRelatedTemplate.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder/templates/joinRelatedTemplate.php
@@ -9,21 +9,8 @@
      */
     public function join<?= $relationName ?>(?string $relationAlias = null, ?string $joinType = <?= $joinType ?>)
     {
-        $tableMap = $this->getTableMap();
-        $relationMap = $tableMap->getRelation('<?= $relationName ?>');
+        $join = $this->createModelJoinForRelation('<?= $relationName ?>', $relationAlias, $joinType);
+        $this->addJoinObject($join, $relationAlias);
 
-        $join = new ModelJoin();
-        $join->setJoinType($joinType);
-        $leftAlias = $this->useAliasInSQL ? $this->getModelAlias() : null;
-        $join->setupJoinCondition($this, $relationMap, $leftAlias, $relationAlias);
-        $previousJoin = $this->getPreviousJoin();
-        if ($previousJoin instanceof ModelJoin) {
-            $join->setPreviousJoin($previousJoin);
-        }
-
-        if ($relationAlias) {
-            $this->addAlias($relationAlias, $relationMap->getRightTable()->getName());
-        }
-
-        return $this->addJoinObject($join, $relationAlias ?: '<?= $relationName ?>');
+        return $this;
     }

--- a/src/Propel/Generator/Builder/Om/QueryBuilder/templates/useRelationMethodsTemplate.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder/templates/useRelationMethodsTemplate.php
@@ -120,3 +120,39 @@
 
         return $q;
     }
+<?php if ($isToMany): ?>
+
+    /**
+     * Group the <?= $foreignTablePhpName ?> table by <?= $relationName ?> relation and return as useQuery.
+     *
+     * The group query is added as subquery. Use addAsColumn() to add aggregations, for top-level subqueries these automatically become virtual columns.
+     *
+     * <example>Add a total count virtual column: $query->useGroupBy<?= $relationName ?>Query()->addAsColumn('<?= $relationName ?>Total', 'COUNT(*)')->endUse()</example>
+     *
+     * @param string|null $modelAlias Inner and outer alias for subquery.
+     * @param string $joinType
+     *
+     * @return <?= $queryClassFq ?><static>
+     */
+    public function useGroupBy<?= $relationName ?>Query(string|null $modelAlias = null, string $joinType = Criteria::LEFT_JOIN)
+    {
+        /** @var <?= $queryClassFq ?><static> $gbQuery */
+        $gbQuery = <?= $queryClass ?>::create($modelAlias);
+        $modelJoin = $this->createModelJoinForRelation('<?= $relationName ?>', $modelAlias, $joinType);
+        $this->addSubquery($gbQuery, $modelAlias, $modelJoin);
+
+<?php if (count($foreignKeyTargetColumnNames) === 1): ?>
+        $grouping = $gbQuery->resolveLocalColumnByName('<?= reset($foreignKeyTargetColumnNames) ?>');
+<?php else: ?>
+        $grouping = [
+<?php foreach ($foreignKeyTargetColumnNames as $columnName): ?>
+            $gbQuery->resolveLocalColumnByName('<?= $columnName ?>'),
+<?php endforeach; ?>
+        ];
+<?php endif; ?>
+
+        return $gbQuery
+            ->groupBy($grouping)
+            ->select($grouping);
+    }
+<?php endif; ?>

--- a/src/Propel/Generator/Model/ForeignKey.php
+++ b/src/Propel/Generator/Model/ForeignKey.php
@@ -745,7 +745,7 @@ class ForeignKey extends MappingModel
      * Returns an array of local and foreign column objects
      * mapped for this foreign key.
      *
-     * @return array
+     * @return array<array{local: \Propel\Generator\Model\Column, foreign: \Propel\Generator\Model\Column|null, value: string|null}>
      */
     public function getColumnObjectsMapping(): array
     {

--- a/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
@@ -629,19 +629,23 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
     }
 
     /**
-     * Get the column aliases.
-                 *
-     * @return array<string, string> An assoc array which map the column alias names
-     *               to the alias clauses.
+     * Get the alias columns.
+     *
+     * @return array<string, string> Column alias names to clauses.
      */
     #[\Override]
     public function getAsColumns(): array
     {
         $asColumns = $this->asColumns;
 
-        foreach ($this->subqueries as $subqueryAlias => $subQuery) {
-            foreach ($subQuery->getAsColumns() as $columnAlias => $_) {
-                $asColumns[$columnAlias] = "$subqueryAlias.$columnAlias"; // passes $columnAlias through nested subqueries, but requires unique alias throughout chain
+        if ($this instanceof ModelCriteria && !$this->getParentQuery()) {
+            foreach ($this->subqueries as $subqueryAlias => $subQuery) {
+                foreach ($subQuery->getAsColumns() as $columnAlias => $_) {
+                    if ($this->asColumns[$columnAlias] ?? false) {
+                        continue;
+                    }
+                    $asColumns[$columnAlias] = "$subqueryAlias.$columnAlias"; // passes $columnAlias through nested subqueries, but requires unique alias throughout chain
+                }
             }
         }
 

--- a/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
@@ -6,6 +6,7 @@ namespace Propel\Runtime\ActiveQuery;
 
 use ArrayIterator;
 use IteratorAggregate;
+use Propel\Runtime\ActiveQuery\ColumnResolver\ColumnExpression\AbstractColumnExpression;
 use Propel\Runtime\ActiveQuery\ColumnResolver\ColumnExpression\UnresolvedColumnExpression;
 use Propel\Runtime\ActiveQuery\ColumnResolver\ColumnResolver;
 use Propel\Runtime\ActiveQuery\ColumnResolver\NormalizedFilterExpression;
@@ -558,6 +559,10 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
     {
         if (!$columnArray) {
             throw new PropelException('You must ask for at least one column');
+        }
+
+        if ($columnArray instanceof AbstractColumnExpression) {
+            $columnArray = [$columnArray];
         }
 
         $this->selectColumns = ($columnArray === '*')

--- a/src/Propel/Runtime/ActiveQuery/ColumnResolver/ColumnResolver.php
+++ b/src/Propel/Runtime/ActiveQuery/ColumnResolver/ColumnResolver.php
@@ -198,7 +198,7 @@ class ColumnResolver
      * @param \Propel\Runtime\ActiveQuery\Criteria $sourceQuery
      * @param \Propel\Runtime\ActiveQuery\Criteria $subQuery
      * @param string $tableAlias
-     * @param string $columnPhpName
+     * @param string $columnIdentifier
      * @param bool $failSilently
      *
      * @throws \Propel\Runtime\Exception\PropelException
@@ -209,24 +209,25 @@ class ColumnResolver
         Criteria $sourceQuery,
         Criteria $subQuery,
         string $tableAlias,
-        string $columnPhpName,
+        string $columnIdentifier,
         bool $failSilently = true
     ): AbstractColumnExpression {
-        if ($subQuery->getColumnClauseByAlias($columnPhpName) !== null) {
-            return new RemoteColumnExpression($sourceQuery, $tableAlias, $columnPhpName);
+        if ($subQuery->getColumnClauseByAlias($columnIdentifier) !== null) {
+            return new RemoteColumnExpression($sourceQuery, $tableAlias, $columnIdentifier);
         }
 
         $tableMap = $subQuery instanceof ModelCriteria ? $subQuery->getTableMap() : null;
-        if ($tableMap && $tableMap->hasColumnByPhpName($columnPhpName)) {
-            $columnMap = $tableMap->getColumnByPhpName($columnPhpName);
-
-            return new RemoteTypedColumnExpression($sourceQuery, $tableAlias, $columnMap->getName(), $columnMap->getPdoType(), $columnMap);
+        if ($tableMap) {
+            $columnMap = $tableMap->findColumnByName($columnIdentifier);
+            if ($columnMap) {
+                return new RemoteTypedColumnExpression($sourceQuery, $tableAlias, $columnMap->getName(), $columnMap->getPdoType(), $columnMap);
+            }
         }
 
         if (!$failSilently) {
-            throw new PropelException("Unknown column `$columnPhpName` in the subQuery with alias `$tableAlias`");
+            throw new PropelException("Unknown column `$columnIdentifier` in the subQuery with alias `$tableAlias`");
         }
 
-        return new UnresolvedColumnExpression($sourceQuery, $tableAlias, $columnPhpName);
+        return new UnresolvedColumnExpression($sourceQuery, $tableAlias, $columnIdentifier);
     }
 }

--- a/src/Propel/Runtime/ActiveQuery/ColumnResolver/ColumnResolver.php
+++ b/src/Propel/Runtime/ActiveQuery/ColumnResolver/ColumnResolver.php
@@ -106,7 +106,7 @@ class ColumnResolver
             return $this->getColumnFromSubQuery($sourceQuery, $sourceQuery->getSubquery($prefix), $prefix, $columnIdentifier, $failSilently);
         }
 
-        if (!$isMainOrJoin && $sourceQuery instanceof ModelCriteria && $sourceQuery->getPrimaryCriteria()) {
+        if (!$isMainOrJoin && $sourceQuery instanceof ModelCriteria && $sourceQuery->getParentQuery()) {
             $resolvedColumn = $this->getQueryFromOuterQuery($sourceQuery, $prefix, $columnIdentifier);
             if ($resolvedColumn) {
                 return $resolvedColumn;
@@ -139,15 +139,15 @@ class ColumnResolver
      */
     protected function getQueryFromOuterQuery(ModelCriteria $sourceQuery, string $prefix, string $columnIdentifier): ?AbstractColumnExpression
     {
-        if (!$sourceQuery->getPrimaryCriteria()) {
+        if (!$sourceQuery->getParentQuery()) {
             return null;
         }
 
         $tableAlias = null;
         $tableMap = null;
         $parentQuery = $sourceQuery;
-        while (!$tableAlias && $parentQuery->getPrimaryCriteria()) {
-            $parentQuery = $parentQuery->getPrimaryCriteria();
+        while (!$tableAlias && $parentQuery->getParentQuery()) {
+            $parentQuery = $parentQuery->getParentQuery();
             [$tableAlias, $tableMap] = $this->resolveTableIdentifierInQuery($prefix, $parentQuery);
         }
 

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -311,7 +311,7 @@ class Criteria
     /**
      * Storage of grouping data. Collection of column names.
      *
-     * @var array<string>
+     * @var array<string|\Propel\Runtime\ActiveQuery\ColumnResolver\ColumnExpression\AbstractColumnExpression>
      */
     protected array $groupByColumns = [];
 
@@ -1514,11 +1514,11 @@ class Criteria
     /**
      * Add group by column name.
      *
-     * @param string $groupBy The name of the column to group by.
+     * @param \Propel\Runtime\ActiveQuery\ColumnResolver\ColumnExpression\AbstractColumnExpression|string $groupBy The name of the column to group by.
      *
      * @return $this A modified Criteria object.
      */
-    public function addGroupByColumn(string $groupBy)
+    public function addGroupByColumn(string|AbstractColumnExpression $groupBy)
     {
         $this->groupByColumns[] = $groupBy;
 
@@ -1588,13 +1588,16 @@ class Criteria
     }
 
     /**
-     * Get group by columns.
-     *
      * @return array<string>
      */
     public function getGroupByColumns(): array
     {
-        return $this->groupByColumns;
+        if (!$this->groupByColumns) {
+            return [];
+        }
+        $resolveColumns = fn (string|AbstractColumnExpression $c) => ($c instanceof AbstractColumnExpression ? $c : $this->resolveColumn($c, true, false))->getColumnExpressionInQuery(true);
+
+        return array_map($resolveColumns, $this->groupByColumns);
     }
 
     /**

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -2035,7 +2035,7 @@ class Criteria
      * to be set before the statement is executed. The reason we do it this way
      * is to let the PDO layer handle all escaping & value formatting.
      *
-     * @param-out array $params
+     * @param-out array<mixed> $params
      *
      * @param array|null $params Parameters that are to be replaced in prepared statement.
      *

--- a/src/Propel/Runtime/ActiveQuery/FilterExpression/AbstractInnerQueryFilter.php
+++ b/src/Propel/Runtime/ActiveQuery/FilterExpression/AbstractInnerQueryFilter.php
@@ -155,7 +155,7 @@ abstract class AbstractInnerQueryFilter extends AbstractFilter
         $this->innerQuery = $innerQuery;
 
         if ($this->innerQuery instanceof ModelCriteria && $outerQuery instanceof ModelCriteria) {
-            $this->innerQuery->setPrimaryCriteria($outerQuery, null); // HACK - ColumnResolver uses primary criteria to remove aliases from topmost query
+            $this->innerQuery->setParentQuery($outerQuery, null); // HACK - ColumnResolver uses primary criteria to remove aliases from topmost query
         }
     }
 

--- a/src/Propel/Runtime/ActiveQuery/Join.php
+++ b/src/Propel/Runtime/ActiveQuery/Join.php
@@ -14,7 +14,6 @@ use function explode;
 use function implode;
 use function is_array;
 use function is_string;
-use function sprintf;
 use function strrpos;
 use function var_export;
 
@@ -760,14 +759,46 @@ class Join
                     $this->getLeftColumn($i) . $this->getOperator($i) . $this->getRightColumn($i),
                 );
             }
-            if ($joinCondition === null) {
-                $joinCondition = $criterion;
-            } else {
-                $joinCondition = $joinCondition->addAnd($criterion);
-            }
+            $joinCondition = !$joinCondition
+                ? $criterion
+                : $joinCondition->addAnd($criterion);
         }
 
         $this->joinCondition = $joinCondition;
+    }
+
+    /**
+     * Build join condition expression like `(book.author_id = author.id)`
+     *
+     * @param-out array<mixed> $params
+     *
+     * @param array<mixed> $params
+     *
+     * @return string
+     */
+    public function buildJoinConditionExpression(array &$params): string
+    {
+        if ($this->joinCondition) {
+            $filter = $this->getJoinCondition();
+            $joinCondition = $filter->buildStatement($params);
+            if ($filter->count() === 1) { // for BC with tests
+                $joinCondition = "($joinCondition)";
+            }
+
+            return $joinCondition;
+        }
+
+        $conditions = [];
+        for ($i = 0; $i < $this->count; $i++) {
+            $operator = $this->getOperator($i);
+            $conditions[] = match (true) {
+                (bool)$this->leftValues[$i] => $this->getLeftColumn($i) . $operator . var_export($this->leftValues[$i], true),
+                (bool)$this->rightValues[$i] => $this->getRightColumn($i) . $operator . var_export($this->rightValues[$i], true),
+                default => $this->getLeftColumn($i) . $operator . $this->getRightColumn($i),
+            };
+        }
+
+        return '(' . implode(' AND ', $conditions) . ')';
     }
 
     /**
@@ -789,38 +820,14 @@ class Join
      */
     public function getClause(array &$params): string
     {
-        if ($this->joinCondition === null) {
-            $conditions = [];
-            for ($i = 0; $i < $this->count; $i++) {
-                if ($this->leftValues[$i]) {
-                    $conditions[] = $this->getLeftColumn($i) . $this->getOperator($i) . var_export($this->leftValues[$i], true);
-                } elseif ($this->rightValues[$i]) {
-                        $conditions[] = $this->getRightColumn($i) . $this->getOperator($i) . var_export($this->rightValues[$i], true);
-                } else {
-                    $conditions[] = $this->getLeftColumn($i) . $this->getOperator($i) . $this->getRightColumn($i);
-                }
-            }
-            $joinCondition = sprintf('(%s)', implode(' AND ', $conditions));
-        } else {
-            $filter = $this->getJoinCondition();
-            $joinCondition = $filter->buildStatement($params);
-            if ($filter->count() === 1) { // for BC with tests
-                $joinCondition = "($joinCondition)";
-            }
-        }
-
+        $joinCondition = $this->buildJoinConditionExpression($params);
         $rightTableName = $this->getRightTableWithAlias();
 
         if ($this->isIdentifierQuotingEnabled()) {
             $rightTableName = $this->getAdapter()->quoteIdentifierTable($rightTableName);
         }
 
-        return sprintf(
-            '%s %s ON %s',
-            $this->getJoinType(),
-            $rightTableName,
-            $joinCondition,
-        );
+        return $this->getJoinType() . " $rightTableName ON $joinCondition";
     }
 
     /**

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -332,7 +332,7 @@ class ModelCriteria extends BaseModelCriteria
         if ($columnNames instanceof AbstractColumnExpression) {
             $this->addGroupByColumn($columnNames);
         } else {
-        foreach ((array)$columnNames as $columnName) {
+            foreach ((array)$columnNames as $columnName) {
                 $this->addGroupByColumn($columnName);
             }
         }
@@ -629,9 +629,9 @@ class ModelCriteria extends BaseModelCriteria
 
         if (in_array($join, $this->joins)) {
             trigger_error("Trying to add same join twice: `$name`", E_USER_WARNING);
-            } else {
-                $this->joins[$name] = $join;
-            }
+        } else {
+            $this->joins[$name] = $join;
+        }
 
         if ($setAlias) {
             $this->addAlias($name, $join->getRightTableName());
@@ -780,7 +780,7 @@ class ModelCriteria extends BaseModelCriteria
             ? new $queryClass()
             : PropelQuery::from($className);
 
-            $modelName = $modelJoin->getRelationMap()?->getName() ?? '';
+        $modelName = $modelJoin->getRelationMap()?->getName() ?? '';
         $useAlias = $relationName !== $modelName || (isset($this->aliases[$relationName]) && $this->aliases[$relationName] === $modelJoin->getRightTableName());
         $childQuery->setModelAlias($relationName, $useAlias);
 
@@ -1023,14 +1023,42 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @see Criteria::addSubquery()
      *
+     * @param \Propel\Runtime\ActiveQuery\Criteria $subQuery
+     * @param string|null $alias alias for the subQuery
+     * @param \Propel\Runtime\ActiveQuery\Join|null $join
+     *
+     * @return $this
+     */
+    #[\Override]
+    public function addSubquery(Criteria $subQuery, ?string $alias = null, Join|null $join = null)
+    {
+        parent::addSubquery($subQuery, $alias);
+        if ($subQuery instanceof BaseModelCriteria && $subQuery->modelAlias) {
+            $subQuery->useAliasInSQL = true;
+        }
+        if ($subQuery instanceof ModelCriteria) {
+            if ($join && !$alias) {
+                $alias = (string)array_key_last($this->subqueries);
+                $join->setRightTableAlias($alias);
+                $join->buildJoinCondition($this); // FIXME : shouldn't need to rebuild here
+            }
+            $subQuery->setParentQuery($this, $join);
+            $subQuery->mergeOnEndUse = false;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @deprecated use aptly named Criteria::addSubquery(), but note that it does not add select columns or replace the main table.
+     *
      * @param \Propel\Runtime\ActiveQuery\Criteria $subQuery Criteria to build the subquery from
      * @param string|null $alias alias for the subQuery
      * @param bool $addAliasAndSelectColumns Set to false if you want to manually add the aliased select columns
      *
      * @return $this
      */
-    #[\Override]
-    public function addSubquery(Criteria $subQuery, ?string $alias = null, bool $addAliasAndSelectColumns = true)
+    public function addSelectQuery(Criteria $subQuery, ?string $alias = null, bool $addAliasAndSelectColumns = true)
     {
         parent::addSubquery($subQuery, $alias);
         if ($subQuery instanceof BaseModelCriteria && $subQuery->modelAlias) {
@@ -1043,29 +1071,15 @@ class ModelCriteria extends BaseModelCriteria
 
         $alias ??= (string)array_key_last($this->subqueries); // get generated alias from parent::addSubquery()
 
-        if ($subQuery->modelTableMapName === $this->modelTableMapName) {
+        if ($subQuery->modelTableMapName === $this->modelTableMapName) { // legacy behavior: outer query passes subquery through
             $this->setModelAlias($alias, true);
         }
 
         $tableMapClassName = $subQuery->modelTableMapName;
         assert($tableMapClassName !== null);
-        $tableMapClassName::getTableMap()->addSelectColumns($this, $alias);
+        $tableMapClassName::getTableMap()->addSelectColumns($this, $alias); // legacy behavior: subquery forces select
 
         return $this;
-    }
-
-    /**
-     * @deprecated use aptly named Criteria::addSubquery().
-     *
-     * @param \Propel\Runtime\ActiveQuery\Criteria $subQueryCriteria Criteria to build the subquery from
-     * @param string|null $alias alias for the subQuery
-     * @param bool $addAliasAndSelectColumns Set to false if you want to manually add the aliased select columns
-     *
-     * @return $this
-     */
-    public function addSelectQuery(Criteria $subQueryCriteria, ?string $alias = null, bool $addAliasAndSelectColumns = true)
-    {
-        return $this->addSubquery($subQueryCriteria, $alias, $addAliasAndSelectColumns);
     }
 
     /**

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -317,7 +317,7 @@ class ModelCriteria extends BaseModelCriteria
      *    => $c->addGroupByColumn(BookTableMap::AUTHOR_ID)
      *    => $c->addGroupByColumn(BookTableMap::AUTHOR_NAME)
      *
-     * @param mixed $columnNames an array of columns name (e.g. array('Book.AuthorId', 'Book.AuthorName')) or a single column name (e.g. 'Book.AuthorId')
+     * @param \Propel\Runtime\ActiveQuery\ColumnResolver\ColumnExpression\AbstractColumnExpression|array<string|\Propel\Runtime\ActiveQuery\ColumnResolver\ColumnExpression\AbstractColumnExpression>|string $columnNames an array of columns name (e.g. array('Book.AuthorId', 'Book.AuthorName')) or a single column name (e.g. 'Book.AuthorId')
      *
      * @throws \Propel\Runtime\Exception\PropelException
      *
@@ -329,9 +329,12 @@ class ModelCriteria extends BaseModelCriteria
             throw new PropelException('You must ask for at least one column');
         }
 
+        if ($columnNames instanceof AbstractColumnExpression) {
+            $this->addGroupByColumn($columnNames);
+        } else {
         foreach ((array)$columnNames as $columnName) {
-            $localColumnName = $this->columnResolver->resolveColumn($columnName, true, false)->getColumnExpressionInQuery();
-            $this->addGroupByColumn($localColumnName);
+                $this->addGroupByColumn($columnName);
+            }
         }
 
         return $this;

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -770,7 +770,7 @@ class ModelCriteria extends BaseModelCriteria
     public function useQuery(string $relationName, ?string $queryClass = null): self
     {
         if (!isset($this->joins[$relationName])) {
-            throw new PropelException("Unknown class or alias $relationName");
+            throw new PropelException("Unknown class or alias `$relationName`");
         }
 
         /** @var \Propel\Runtime\ActiveQuery\ModelJoin $modelJoin */

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -461,11 +461,7 @@ class ModelCriteria extends BaseModelCriteria
             $join->setParentJoin($parentJoin);
         }
         $join->setRelationMap($relationMap, $leftTableAlias, $relationAlias);
-
-        if ($relationAlias !== null) {
-            $this->addAlias($relationAlias, $relationMap->getRightTable()->getName());
-        }
-        $this->addJoinObject($join, $relationAlias ?? $relationName);
+        $this->addJoinObject($join, $relationAlias);
 
         return $this;
     }
@@ -509,6 +505,33 @@ class ModelCriteria extends BaseModelCriteria
         $relationMap = $tableMap->getRelation($relationName);
 
         return [$relationMap, $relationName, $leftName, $parentJoin];
+    }
+
+    /**
+     * @param string $relationName
+     * @param string|null $rightTableAlias
+     * @param string|null $joinType
+     *
+     * @return \Propel\Runtime\ActiveQuery\ModelJoin
+     */
+    protected function createModelJoinForRelation(
+        string $relationName,
+        string|null $rightTableAlias = null,
+        string|null $joinType = Criteria::INNER_JOIN
+    ): ModelJoin {
+        $join = new ModelJoin();
+        $join->setJoinType($joinType);
+
+        $relationMap = $this->getTableMapOrFail()->getRelation($relationName);
+        $leftAlias = $this->useAliasInSQL ? $this->getModelAlias() : null;
+        $join->setupJoinCondition($this, $relationMap, $leftAlias, $rightTableAlias);
+
+        $parentJoin = $this->getParentJoin();
+        if ($parentJoin instanceof ModelJoin) {
+            $join->setParentJoin($parentJoin);
+        }
+
+        return $join;
     }
 
     /**
@@ -594,14 +617,24 @@ class ModelCriteria extends BaseModelCriteria
     #[\Override]
     public function addJoinObject(Join $join, ?string $name = null)
     {
-        if (!in_array($join, $this->joins)) { // compare equality, NOT identity
-            if ($name === null) {
-                $this->joins[] = $join;
+        $setAlias = (bool)$name;
+
+        if (!$name && $join instanceof ModelJoin) {
+            $name = $join->getRelationMap()->getName();
+        }
+
+        if (!$name) {
+            return parent::addJoinObject($join);
+        }
+
+        if (in_array($join, $this->joins)) {
+            trigger_error("Trying to add same join twice: `$name`", E_USER_WARNING);
             } else {
                 $this->joins[$name] = $join;
             }
-        } else {
-            trigger_error("Adding same join twice: `$name`", E_USER_WARNING);
+
+        if ($setAlias) {
+            $this->addAlias($name, $join->getRightTableName());
         }
 
         return $this;

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -24,7 +24,6 @@ use Propel\Runtime\Exception\ClassNotFoundException;
 use Propel\Runtime\Exception\EntityNotFoundException;
 use Propel\Runtime\Exception\LogicException;
 use Propel\Runtime\Exception\PropelException;
-use Propel\Runtime\Exception\RuntimeException;
 use Propel\Runtime\Exception\UnexpectedValueException;
 use Propel\Runtime\Map\Exception\ColumnNotFoundException;
 use Propel\Runtime\Map\RelationMap;
@@ -91,9 +90,21 @@ class ModelCriteria extends BaseModelCriteria
     public const FORMAT_ON_DEMAND = '\Propel\Runtime\Formatter\OnDemandFormatter';
 
     /**
-     * Parent query (i.e. this is a useQuery)
+     * Parent query (i.e. this is a useQuery or subquery)
      */
-    protected ModelCriteria|null $primaryCriteria = null;
+    protected ModelCriteria|null $parentQuery = null;
+
+    /**
+     * If this is a useQuery or subquery, parentJoin connects it to the (direct) parent query
+     *
+     * @var \Propel\Runtime\ActiveQuery\Join|null
+     */
+    protected Join|null $parentJoin = null;
+
+    /**
+     * If this is a useQuery, merge properties into parent query during {@see static::endUse()}
+     */
+    protected bool $mergeOnEndUse = true;
 
     /**
      * @var class-string<\Exception>
@@ -101,26 +112,9 @@ class ModelCriteria extends BaseModelCriteria
     protected string $entityNotFoundExceptionClass = EntityNotFoundException::class;
 
     /**
-     * This is introduced to prevent useQuery->join from going wrong
-     *
-     * @var \Propel\Runtime\ActiveQuery\Join|null
-     */
-    protected Join|null $previousJoin = null;
-
-    /**
      * Whether to clone the current object before termination methods
      */
     protected bool $isKeepQuery = true;
-
-    /**
-     * Indicates that this query is wrapped in an InnerQueryCriterion.
-     *
-     * Marks the query to be
-     *
-     * @see ModelCriteria::useInnerQueryFilter()
-     * @see ModelCriteria::endUse()
-     */
-    protected bool $isInnerQueryInCriterion = false;
 
     /**
      * Adds a condition on a column based on a column phpName and a value
@@ -382,29 +376,53 @@ class ModelCriteria extends BaseModelCriteria
     }
 
     /**
-     * This method returns the previousJoin for this ModelCriteria,
-     * by default this is null, but after useQuery this is set the to the join of that use
+     * In subqueries or useQueries, parent join adds this query to a parent query
      *
-     * @return \Propel\Runtime\ActiveQuery\Join|null the previousJoin for this ModelCriteria
+     * @return \Propel\Runtime\ActiveQuery\Join|null
      */
-    public function getPreviousJoin(): ?Join
+    public function getParentJoin(): ?Join
     {
-        return $this->previousJoin;
+        return $this->parentJoin;
     }
 
     /**
-     * This method sets the previousJoin for this ModelCriteria,
-     * by default this is null, but after useQuery this is set the to the join of that use
+     * Registers a join that adds this query to a parent query
      *
-     * @param \Propel\Runtime\ActiveQuery\Join $previousJoin The previousJoin for this ModelCriteria
+     * @param \Propel\Runtime\ActiveQuery\Join $parentJoin
      *
      * @return $this
      */
-    public function setPreviousJoin(Join $previousJoin)
+    public function setParentJoin(Join $parentJoin)
     {
-        $this->previousJoin = $previousJoin;
+        $this->parentJoin = $parentJoin;
 
         return $this;
+    }
+
+    /**
+     * @deprecated Use aptly named {@see static::setParentJoin()}
+     *
+     * @param \Propel\Runtime\ActiveQuery\Join $parentJoin
+     *
+     * @return $this
+     */
+    public function setPreviousJoin(Join $parentJoin)
+    {
+        trigger_deprecation('Perpl', '2.10.0', 'Use aptly named setParentJoin()');
+
+        return $this->setParentJoin($parentJoin);
+    }
+
+    /**
+     * @deprecated Use aptly named {@see static::getParentJoin()}
+     *
+     * @return \Propel\Runtime\ActiveQuery\Join|null
+     */
+    public function getPreviousJoin(): ?Join
+    {
+        trigger_deprecation('Perpl', '2.10.0', 'Use aptly named getParentJoin()');
+
+        return $this->getParentJoin();
     }
 
     /**
@@ -430,14 +448,14 @@ class ModelCriteria extends BaseModelCriteria
     public function join(string $relationSpecifier, string $joinType = Criteria::INNER_JOIN)
     {
         [$relationIdentifier, $relationAlias] = self::getClassAndAlias($relationSpecifier); // remove alias from "Book b"
-        [$relationMap, $relationName, $leftName, $previousJoin] = $this->resolveJoinContext($relationIdentifier);
+        [$relationMap, $relationName, $leftName, $parentJoin] = $this->resolveJoinContext($relationIdentifier);
         $leftTableAlias = isset($this->aliases[$leftName]) ? $leftName : null;
 
         // set up ModelJoin
         $join = new ModelJoin();
         $join->setJoinType($joinType);
-        if ($previousJoin !== null) {
-            $join->setPreviousJoin($previousJoin);
+        if ($parentJoin instanceof ModelJoin) {
+            $join->setParentJoin($parentJoin);
         }
         $join->setRelationMap($relationMap, $leftTableAlias, $relationAlias);
 
@@ -461,10 +479,10 @@ class ModelCriteria extends BaseModelCriteria
         if (!str_contains($relationIdentifier, '.')) {
             // simple relation name, refers to the current table
             $leftName = $this->getModelAliasOrName();
-            $previousJoin = $this->getPreviousJoin();
+            $parentJoin = $this->getParentJoin();
             $relationMap = $this->getTableMap()->getRelation($relationIdentifier);
 
-            return [$relationMap, $relationIdentifier, $leftName, $previousJoin];
+            return [$relationMap, $relationIdentifier, $leftName, $parentJoin];
         }
 
         // $relation looks like '$leftName.$relationName $relationAlias'
@@ -473,21 +491,21 @@ class ModelCriteria extends BaseModelCriteria
 
         // find the TableMap for the left table using the $leftName
         if ($leftName === $this->getModelAliasOrName() || $leftName === $this->getModelShortName()) {
-            $previousJoin = $this->getPreviousJoin();
+            $parentJoin = $this->getParentJoin();
             $tableMap = $this->getTableMap();
         } elseif (isset($this->joins[$leftName]) && $this->joins[$leftName] instanceof ModelJoin) {
-            $previousJoin = $this->joins[$leftName];
-            $tableMap = $previousJoin->getTableMap();
+            $parentJoin = $this->joins[$leftName];
+            $tableMap = $parentJoin->getTableMap();
         } elseif (isset($this->joins[$shortLeftName]) && $this->joins[$shortLeftName] instanceof ModelJoin) {
-            $previousJoin = $this->joins[$shortLeftName];
-            $tableMap = $previousJoin->getTableMap();
+            $parentJoin = $this->joins[$shortLeftName];
+            $tableMap = $parentJoin->getTableMap();
         } else {
             throw new PropelException("Unknown table or alias $leftName");
         }
 
         $relationMap = $tableMap->getRelation($relationName);
 
-        return [$relationMap, $relationName, $leftName, $previousJoin];
+        return [$relationMap, $relationName, $leftName, $parentJoin];
     }
 
     /**
@@ -702,20 +720,18 @@ class ModelCriteria extends BaseModelCriteria
     }
 
     /**
-     * Initializes a secondary ModelCriteria object, to be later merged with the current object
-     *
-     * @psalm-param class-string<self>|null $secondaryCriteriaClass
+     * Initializes a child ModelCriteria, to be later merged with the current object
      *
      * @see ModelCriteria::endUse()
      *
      * @param string $relationName Relation name or alias
-     * @param string|null $secondaryCriteriaClass ClassName for the ModelCriteria to be used
+     * @param class-string<self>|null $queryClass ClassName for the ModelCriteria to be used
      *
      * @throws \Propel\Runtime\Exception\PropelException
      *
-     * @return self The secondary criteria object
+     * @return self
      */
-    public function useQuery(string $relationName, ?string $secondaryCriteriaClass = null): self
+    public function useQuery(string $relationName, ?string $queryClass = null): self
     {
         if (!isset($this->joins[$relationName])) {
             throw new PropelException("Unknown class or alias $relationName");
@@ -724,48 +740,42 @@ class ModelCriteria extends BaseModelCriteria
         /** @var \Propel\Runtime\ActiveQuery\ModelJoin $modelJoin */
         $modelJoin = $this->joins[$relationName];
         $className = $modelJoin->getTableMap()?->getClassName();
-        $secondaryCriteria = $secondaryCriteriaClass
-            ? new $secondaryCriteriaClass()
+        $childQuery = $queryClass
+            ? new $queryClass()
             : PropelQuery::from($className);
 
-        if ($className !== $relationName) {
             $modelName = $modelJoin->getRelationMap()?->getName() ?? '';
-            $useAlias = $relationName !== $modelName || (isset($this->aliases[$relationName]) && $this->aliases[$relationName] === $modelJoin->getRightTableName()); // make sure
-            $secondaryCriteria->setModelAlias($relationName, $useAlias);
-        }
-        $secondaryCriteria->filterOperatorManager->setOperator($this->filterOperatorManager->getCurrentPermanentOperator());
-        $secondaryCriteria->setPrimaryCriteria($this, $modelJoin);
+        $useAlias = $relationName !== $modelName || (isset($this->aliases[$relationName]) && $this->aliases[$relationName] === $modelJoin->getRightTableName());
+        $childQuery->setModelAlias($relationName, $useAlias);
 
-        return $secondaryCriteria;
+        $childQuery->filterOperatorManager->setOperator($this->filterOperatorManager->getCurrentPermanentOperator());
+        $childQuery->setParentQuery($this, $modelJoin);
+
+        return $childQuery;
     }
 
     /**
-     * Finalizes a secondary criteria and merges it with its primary Criteria
+     * Finalizes a useQuery and merges it with its parent query
      *
      * @see Criteria::mergeWith()
      *
-     * @throws \Propel\Runtime\Exception\RuntimeException
-     *
-     * @return self|null The primary criteria object
+     * @return self|null The parent query
      */
     public function endUse(): ?self
     {
-        if ($this->isInnerQueryInCriterion) {
-            return $this->getPrimaryCriteria();
+        if (!$this->mergeOnEndUse) {
+            return $this->parentQuery;
         }
 
         if (isset($this->aliases[$this->modelAlias])) {
             $this->removeAlias((string)$this->modelAlias);
         }
 
-        $primaryCriteria = $this->getPrimaryCriteria();
-        if ($primaryCriteria === null) {
-            throw new RuntimeException('No primary criteria');
-        }
+        $parentQuery = $this->parentQuery;
+        assert($parentQuery !== null);
+        $parentQuery->mergeWith($this);
 
-        $primaryCriteria->mergeWith($this);
-
-        return $primaryCriteria;
+        return $parentQuery;
     }
 
     /**
@@ -791,8 +801,8 @@ class ModelCriteria extends BaseModelCriteria
 
         /** @var static $innerQuery */
         $innerQuery = ($queryClass === null) ? PropelQuery::from($className) : new $queryClass();
-        $innerQuery->isInnerQueryInCriterion = true;
-        $innerQuery->primaryCriteria = $this;
+        $innerQuery->mergeOnEndUse = false;
+        $innerQuery->parentQuery = $this;
         if ($modelAlias !== null) {
             $innerQuery->setModelAlias($modelAlias, true);
         }
@@ -910,37 +920,66 @@ class ModelCriteria extends BaseModelCriteria
     #[\Override]
     public function clear()
     {
-        $this->primaryCriteria = null;
+        $this->parentQuery = null;
+        $this->parentJoin = null;
+        $this->mergeOnEndUse = true;
 
         return parent::clear();
     }
 
     /**
-     * Sets the primary Criteria for this secondary Criteria
+     * Set parent query of a useQuery or subquery.
      *
-     * @param \Propel\Runtime\ActiveQuery\ModelCriteria $criteria The primary criteria
-     * @param \Propel\Runtime\ActiveQuery\Join|null $previousJoin The previousJoin for this ModelCriteria
+     * @param \Propel\Runtime\ActiveQuery\ModelCriteria $parentQuery
+     * @param \Propel\Runtime\ActiveQuery\Join|null $parentJoin
      *
      * @return $this
      */
-    public function setPrimaryCriteria(ModelCriteria $criteria, ?Join $previousJoin)
+    public function setParentQuery(ModelCriteria $parentQuery, ?Join $parentJoin)
     {
-        $this->primaryCriteria = $criteria;
-        if ($previousJoin) {
-            $this->setPreviousJoin($previousJoin);
+        $this->parentQuery = $parentQuery;
+        if ($parentJoin) {
+            $this->setParentJoin($parentJoin);
         }
 
         return $this;
     }
 
     /**
-     * Gets the primary criteria for this secondary Criteria
+     * Set parent query of useQuery or subquery.
      *
-     * @return \Propel\Runtime\ActiveQuery\ModelCriteria|null The primary criteria
+     * @return \Propel\Runtime\ActiveQuery\ModelCriteria|null
+     */
+    public function getParentQuery(): ?self
+    {
+        return $this->parentQuery;
+    }
+
+    /**
+     * @deprecated Use aptly named {@see static::setParentCriteria()}
+     *
+     * @param \Propel\Runtime\ActiveQuery\ModelCriteria $parentQuery
+     * @param \Propel\Runtime\ActiveQuery\Join|null $parentJoin
+     *
+     * @return $this
+     */
+    public function setPrimaryCriteria(ModelCriteria $parentQuery, ?Join $parentJoin)
+    {
+        trigger_deprecation('Perpl', '2.10.0', 'Use aptly named setParentCriteria()');
+
+        return $this->setParentQuery($parentQuery, $parentJoin);
+    }
+
+    /**
+     * @deprecated Use aptly named {@see static::getParentQuery()}
+     *
+     * @return \Propel\Runtime\ActiveQuery\ModelCriteria|null
      */
     public function getPrimaryCriteria(): ?self
     {
-        return $this->primaryCriteria;
+        trigger_deprecation('Perpl', '2.10.0', 'Use aptly named getParentQuery()');
+
+        return $this->getParentQuery();
     }
 
     /**

--- a/src/Propel/Runtime/ActiveQuery/ModelJoin.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelJoin.php
@@ -11,6 +11,7 @@ use Propel\Runtime\Exception\LogicException;
 use Propel\Runtime\Map\RelationMap;
 use Propel\Runtime\Map\TableMap;
 use function get_class;
+use function trigger_deprecation;
 
 /**
  * A ModelJoin is a Join object tied to a RelationMap object
@@ -30,7 +31,7 @@ class ModelJoin extends Join
     /**
      * @var \Propel\Runtime\ActiveQuery\ModelJoin|null
      */
-    protected $previousJoin;
+    protected $parentJoin;
 
     /**
      * @param \Propel\Runtime\Map\RelationMap $relationMap
@@ -191,9 +192,9 @@ class ModelJoin extends Join
      *
      * @return $this
      */
-    public function setPreviousJoin(ModelJoin $join)
+    public function setParentJoin(ModelJoin $join)
     {
-        $this->previousJoin = $join;
+        $this->parentJoin = $join;
 
         return $this;
     }
@@ -201,9 +202,35 @@ class ModelJoin extends Join
     /**
      * @return self|null
      */
+    public function getParentJoin(): ?self
+    {
+        return $this->parentJoin;
+    }
+
+    /**
+     * @deprecated Use aptly named {@see static::setParentJoin()}
+     *
+     * @param \Propel\Runtime\ActiveQuery\ModelJoin $join
+     *
+     * @return $this
+     */
+    public function setPreviousJoin(ModelJoin $join)
+    {
+        trigger_deprecation('Perpl', '2.10.0', 'Use aptly named setParentJoin()');
+
+        return $this->setParentJoin($join);
+    }
+
+    /**
+     * @deprecated Use aptly named {@see static::getParentJoin()}
+     *
+     * @return self|null
+     */
     public function getPreviousJoin(): ?self
     {
-        return $this->previousJoin;
+        trigger_deprecation('Perpl', '2.10.0', 'Use aptly named getParentJoin()');
+
+        return $this->getParentJoin();
     }
 
     /**
@@ -211,7 +238,7 @@ class ModelJoin extends Join
      */
     public function isPrimary(): bool
     {
-        return $this->previousJoin === null;
+        return $this->parentJoin === null;
     }
 
     /**
@@ -256,24 +283,24 @@ class ModelJoin extends Join
      * Starting from $startObject and continuously calling the getters to get
      * to the base object for the current join.
      *
-     * This method only works if PreviousJoin has been defined,
+     * This method only works if ({@see static::parentJoin}) is available,
      * which only happens when you provide dotted relations when calling join
      *
-     * @param object $startObject the start object all joins originate from and which has already hydrated
+     * @param object $mainObject the start object all joins originate from and which has already hydrated
      *
      * @return object The base Object of this join
      */
-    public function getObjectToRelate(object $startObject): object
+    public function getObjectToRelate(object $mainObject): object
     {
         if ($this->isPrimary()) {
-            return $startObject;
+            return $mainObject;
         }
 
-        $previousJoin = $this->getPreviousJoin();
-        $previousObject = $previousJoin->getObjectToRelate($startObject);
-        $method = 'get' . $previousJoin->getRelationMap()->getName();
+        $parentJoin = $this->getParentJoin();
+        $parentObject = $parentJoin->getObjectToRelate($mainObject);
+        $method = 'get' . $parentJoin->getRelationMap()->getName();
 
-        return $previousObject->$method();
+        return $parentObject->$method();
     }
 
     /**
@@ -287,7 +314,7 @@ class ModelJoin extends Join
         /** @phpstan-var \Propel\Runtime\ActiveQuery\ModelJoin $join */
         return parent::equals($join)
             && $this->relationMap == $join->getRelationMap()
-            && $this->previousJoin == $join->getPreviousJoin()
+            && $this->parentJoin == $join->getParentJoin()
             && $this->rightTableAlias == $join->getRightTableAlias();
     }
 
@@ -299,7 +326,7 @@ class ModelJoin extends Join
         return parent::toString()
             . ' tableMap: ' . ($this->tableMap ? get_class($this->tableMap) : 'null')
             . ' relationMap: ' . $this->relationMap->getName()
-            . ' previousJoin: ' . ($this->previousJoin ? '(' . $this->previousJoin . ')' : 'null')
+            . ' parentJoin: ' . ($this->parentJoin ? "($this->parentJoin)" : 'null')
             . ' relationAlias: ' . $this->rightTableAlias;
     }
 

--- a/src/Propel/Runtime/ActiveQuery/ModelJoin.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelJoin.php
@@ -10,7 +10,6 @@ use Propel\Runtime\ActiveQuery\FilterExpression\JoinCondition;
 use Propel\Runtime\Exception\LogicException;
 use Propel\Runtime\Map\RelationMap;
 use Propel\Runtime\Map\TableMap;
-use function get_class;
 use function trigger_deprecation;
 
 /**
@@ -279,31 +278,6 @@ class ModelJoin extends Join
     }
 
     /**
-     * This method returns the last related, but already hydrated object up until this join
-     * Starting from $startObject and continuously calling the getters to get
-     * to the base object for the current join.
-     *
-     * This method only works if ({@see static::parentJoin}) is available,
-     * which only happens when you provide dotted relations when calling join
-     *
-     * @param object $mainObject the start object all joins originate from and which has already hydrated
-     *
-     * @return object The base Object of this join
-     */
-    public function getObjectToRelate(object $mainObject): object
-    {
-        if ($this->isPrimary()) {
-            return $mainObject;
-        }
-
-        $parentJoin = $this->getParentJoin();
-        $parentObject = $parentJoin->getObjectToRelate($mainObject);
-        $method = 'get' . $parentJoin->getRelationMap()->getName();
-
-        return $parentObject->$method();
-    }
-
-    /**
      * @param \Propel\Runtime\ActiveQuery\Join $join
      *
      * @return bool
@@ -316,18 +290,6 @@ class ModelJoin extends Join
             && $this->relationMap == $join->getRelationMap()
             && $this->parentJoin == $join->getParentJoin()
             && $this->rightTableAlias == $join->getRightTableAlias();
-    }
-
-    /**
-     * @return string
-     */
-    public function __toString(): string
-    {
-        return parent::toString()
-            . ' tableMap: ' . ($this->tableMap ? get_class($this->tableMap) : 'null')
-            . ' relationMap: ' . $this->relationMap->getName()
-            . ' parentJoin: ' . ($this->parentJoin ? "($this->parentJoin)" : 'null')
-            . ' relationAlias: ' . $this->rightTableAlias;
     }
 
     /**

--- a/src/Propel/Runtime/ActiveQuery/RelationPopulator.php
+++ b/src/Propel/Runtime/ActiveQuery/RelationPopulator.php
@@ -57,7 +57,7 @@ class RelationPopulator
         $this->rightPhpName = $join->hasRelationAlias() ? $join->getRelationAlias() : $relationName;
 
         if (!$join->isPrimary()) {
-            $this->leftPhpName = $join->hasLeftTableAlias() ? $join->getLeftTableAlias() : $join->getPreviousJoin()->getRelationMap()->getName();
+            $this->leftPhpName = $join->hasLeftTableAlias() ? $join->getLeftTableAlias() : $join->getParentJoin()->getRelationMap()->getName();
         }
     }
 

--- a/src/Propel/Runtime/ActiveQuery/SqlBuilder/SelectQuerySqlBuilder.php
+++ b/src/Propel/Runtime/ActiveQuery/SqlBuilder/SelectQuerySqlBuilder.php
@@ -71,7 +71,7 @@ class SelectQuerySqlBuilder extends AbstractSqlQueryBuilder
 
         $groupBy = $this->adapter->getGroupBy($this->criteria);
         if ($groupBy) {
-            $sqlClauses[] = $this->criteria->replaceColumnNames($groupBy);
+            $sqlClauses[] = $groupBy;
         }
 
         $havingSql = $this->buildHavingClause($params);

--- a/src/Propel/Runtime/ActiveQuery/SqlBuilder/SelectQuerySqlBuilder.php
+++ b/src/Propel/Runtime/ActiveQuery/SqlBuilder/SelectQuerySqlBuilder.php
@@ -110,13 +110,13 @@ class SelectQuerySqlBuilder extends AbstractSqlQueryBuilder
     }
 
     /**
-     * @param array<mixed>|null $params
+     * @param array<mixed> $params
      * @param array<string> $sourceTableNames
-     * @param array<string> $joinClause
+     * @param array<string> $joinClauses
      *
      * @return string
      */
-    protected function buildFromClause(?array &$params, array $sourceTableNames, array $joinClause): string
+    protected function buildFromClause(array &$params, array $sourceTableNames, array $joinClauses): string
     {
         $sourceTableNames = array_unique(array_filter($sourceTableNames));
 
@@ -142,14 +142,22 @@ class SelectQuerySqlBuilder extends AbstractSqlQueryBuilder
         $sourceTableNames = array_map([$this, 'quoteIdentifierTable'], $sourceTableNames);
 
         foreach ($this->criteria->getSubqueries() as $subQueryAlias => $subQueryCriteria) {
-            $sourceTableNames[] = '(' . $subQueryCriteria->createSelectSql($params) . ') AS ' . $subQueryAlias;
+            $subquerySql = '(' . $subQueryCriteria->createSelectSql($params) . ') AS ' . $subQueryAlias;
+            if ($subQueryCriteria instanceof ModelCriteria && $subQueryCriteria->getParentJoin()) {
+                $join = $subQueryCriteria->getParentJoin();
+                $joinType = $join->getJoinType();
+                $joinCondition = $join->buildJoinConditionExpression($params);
+                $joinClauses[] = "$joinType $subquerySql ON $joinCondition";
+            } else {
+                $sourceTableNames[] = $subquerySql;
+            }
         }
 
-        $glue = ($joinClause && count($sourceTableNames) > 1) ? ' CROSS JOIN ' : ', ';
+        $glue = ($joinClauses && count($sourceTableNames) > 1) ? ' CROSS JOIN ' : ', ';
         $from = 'FROM ' . implode($glue, $sourceTableNames);
 
-        if ($joinClause) {
-            $from .= ' ' . implode(' ', $joinClause);
+        if ($joinClauses) {
+            $from .= ' ' . implode(' ', $joinClauses);
         }
 
         return $from;

--- a/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
@@ -27,14 +27,12 @@ use function count;
 use function defined;
 use function explode;
 use function implode;
-use function in_array;
 use function is_array;
 use function is_resource;
 use function is_string;
 use function preg_replace;
 use function rewind;
 use function sprintf;
-use function str_contains;
 use function str_replace;
 use function strpos;
 use function strrpos;
@@ -554,36 +552,6 @@ abstract class PdoAdapter
         }
 
         return $tableName;
-    }
-
-    /**
-     * Returns all selected columns that are selected without an aggregate function.
-     *
-     * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
-     *
-     * @return list<string>
-     */
-    public function getPlainSelectedColumns(Criteria $criteria): array
-    {
-        $selected = [];
-        foreach ($criteria->getSelectColumnsRaw() as $column) {
-            if (!$column instanceof AbstractColumnExpression) {
-                $column = $criteria->resolveColumn($column);
-            }
-            $columnName = $column->getColumnExpressionInQuery();
-
-            if (!str_contains($columnName, '(')) {
-                $selected[] = $columnName;
-            }
-        }
-
-        foreach ($criteria->getAsColumns() as $alias => $columnClause) {
-            if (!str_contains($columnClause, '(') && !in_array($columnClause, $selected, true)) {
-                $selected[] = $alias;
-            }
-        }
-
-        return $selected;
     }
 
     /**

--- a/src/Propel/Runtime/Adapter/Pdo/PgsqlAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/PgsqlAdapter.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Propel\Runtime\Adapter\Pdo;
 
 use PDO;
+use Propel\Runtime\ActiveQuery\ColumnResolver\ColumnExpression\AbstractColumnExpression;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\ActiveQuery\Lock;
 use Propel\Runtime\Adapter\AdapterInterface;
@@ -20,6 +21,7 @@ use function class_exists;
 use function implode;
 use function in_array;
 use function sprintf;
+use function str_contains;
 use function strtr;
 
 /**
@@ -196,19 +198,49 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
         $selected = $this->getPlainSelectedColumns($criteria);
         $asSelects = $criteria->getAsColumns();
 
-        foreach ($selected as $colName) {
-            if (in_array($colName, $groupBy, true)) {
+        foreach ($selected as $columnName) {
+            if (in_array($columnName, $groupBy, true)) {
                 continue;
             }
             // is a alias there that is grouped?
-            $alias = array_search($colName, $asSelects);
+            $alias = array_search($columnName, $asSelects);
             if ($alias && in_array($alias, $groupBy, true)) {
                 continue; //yes, alias is selected.
             }
-            $groupBy[] = $colName;
+            $groupBy[] = $columnName;
         }
 
         return 'GROUP BY ' . implode(',', $groupBy);
+    }
+
+    /**
+     * Returns all selected columns that are selected without an aggregate function.
+     *
+     * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
+     *
+     * @return list<string>
+     */
+    public function getPlainSelectedColumns(Criteria $criteria): array
+    {
+        $selected = [];
+        foreach ($criteria->getSelectColumnsRaw() as $column) {
+            if (!$column instanceof AbstractColumnExpression) {
+                $column = $criteria->resolveColumn($column, true);
+            }
+            $columnName = $column->getColumnExpressionInQuery(true);
+
+            if (!str_contains($columnName, '(')) {
+                $selected[] = $columnName;
+            }
+        }
+
+        foreach ($criteria->getAsColumns() as $alias => $columnClause) {
+            if (!str_contains($columnClause, '(') && !in_array($columnClause, $selected, true)) {
+                $selected[] = $criteria->isIdentifierQuotingEnabled() ? $this->quoteIdentifier($alias) : $alias;
+            }
+        }
+
+        return $selected;
     }
 
     /**

--- a/tests/Propel/Tests/Helpers/Assertion/MatchesFormattedVendorSql.php
+++ b/tests/Propel/Tests/Helpers/Assertion/MatchesFormattedVendorSql.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Propel\Tests\Helpers\Assertion;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Propel\Tests\TestCase;
+use function in_array;
+use function sprintf;
+use function strlen;
+use function substr;
+use function substr_replace;
+use function var_export;
+
+final class MatchesFormattedVendorSql extends Constraint
+{
+    /**
+     * @var array<string>
+     */
+    private const FORMAT_CHARS = [' ', "\n"];
+
+    private string $formattedVendorSql;
+
+    private int $expectedCharPos = 0;
+
+    private int $actualCharPos = 0;
+
+    public function __construct(string $formattedVendorSql)
+    {
+        $this->formattedVendorSql = TestCase::toVendorSql($formattedVendorSql);
+    }
+
+    #[\Override]
+    public function toString(): string
+    {
+        return 'SQL matches reference';
+    }
+
+    #[\Override]
+    protected function matches(mixed $actualSql): bool
+    {
+        $expectedSql = $this->formattedVendorSql;
+
+        $this->expectedCharPos = 0;
+        $this->actualCharPos = 0;
+
+        $expectedInputLength = strlen($expectedSql);
+        $actualInputLength = strlen($actualSql);
+
+        // inside quotes
+        while ($this->expectedCharPos < $expectedInputLength && $this->actualCharPos < $actualInputLength) {
+            $actualChar = $actualSql[$this->actualCharPos];
+            $expectedChar = $expectedSql[$this->expectedCharPos];
+
+            if ($actualChar === $expectedChar || ($actualChar === ' ' && $expectedChar = "\n")) {
+                $this->expectedCharPos++;
+                $this->actualCharPos++;
+
+                continue;
+            }
+
+            // cannot pad between words (when previous and current are alnum)
+            if (ctype_alnum($actualChar) && $this->actualCharPos !== 0 && ctype_alnum($actualSql[$this->actualCharPos-1])) {
+                return false;
+            }
+
+            while ($actualChar !== $expectedChar && $this->expectedCharPos < $expectedInputLength && in_array($expectedChar, self::FORMAT_CHARS)) {
+                $expectedChar = $expectedSql[++$this->expectedCharPos];
+            }
+
+            if ($actualChar !== $expectedChar) {
+                return false;
+            }
+        }
+
+        for (; $this->expectedCharPos < $expectedInputLength; $this->expectedCharPos++) {
+            if (!in_array($expectedChar, self::FORMAT_CHARS)) {
+                return false;
+            }
+        }
+
+        return $this->actualCharPos >= $actualInputLength;
+    }
+
+    #[\Override]
+    protected function failureDescription(mixed $other): string
+    {
+        $diffIndicator = '[------>]';
+        $expectedWithDiffIndicator = substr_replace($this->formattedVendorSql, $diffIndicator, $this->expectedCharPos, 0);
+        $expected = $this->actualCharPos < strlen($other)
+            ? var_export(substr($other, $this->actualCharPos), true)
+            : '<end of input>';
+
+        return sprintf(
+            "actual SQL:\n\n%s\n\nmatches expected SQL:\n\n%s\n\nexpected (after $diffIndicator): %s",
+            var_export($other, true),
+            var_export($expectedWithDiffIndicator, true),
+            $expected,
+        );
+    }
+}

--- a/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaReplaceNameTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaReplaceNameTest.php
@@ -186,7 +186,7 @@ class CriteriaReplaceNameTest extends TestCase
         $joinCondition = 'Author.Id = numberOfBooks.AuthorId';
         
         $authorQuery = AuthorQuery::create()
-        ->addSubquery($numberOfBooksQuery, 'numberOfBooks', false)
+        ->addSubquery($numberOfBooksQuery, 'numberOfBooks')
         ->where($joinCondition)
         ->withColumn('numberOfBooks.NumberOfBooks', 'NumberOfBooks');
 

--- a/tests/Propel/Tests/Runtime/ActiveQuery/FilterExpression/ColumnReplacementInSubqueryTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/FilterExpression/ColumnReplacementInSubqueryTest.php
@@ -62,7 +62,7 @@ class ColumnReplacementInSubqueryTest extends TestCaseFixtures
             ->where($inputClause, $value)
         ;
 
-        $expectedSql =  'SELECT book.id, saut.id, saut.first_name, saut.last_name, saut.email, saut.age, saut.MyAsColumn AS MyAsColumn '.
+        $expectedSql =  'SELECT book.id, saut.MyAsColumn AS MyAsColumn '.
                         'FROM book, ' .
                         '(' .
                             'SELECT aut.id AS MyAsColumn ' . 

--- a/tests/Propel/Tests/Runtime/ActiveQuery/JoinTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/JoinTest.php
@@ -152,8 +152,11 @@ class JoinTest extends BaseTestCase
         $j->setJoinType(Criteria::LEFT_JOIN);
         $j->addExplicitCondition('log', 'AUTHOR_ID', null, 'author', 'ID', 'a', Join::EQUAL);
         $j->addLocalValueCondition('log', 'target_type', null, 'author', Join::EQUAL);
+
         $params = [];
-        $this->assertEquals('LEFT JOIN author a ON (log.AUTHOR_ID=a.ID AND log.target_type=\'author\')', $j->getClause($params));
+        $sql = $j->getClause($params);
+        $expected = 'LEFT JOIN author a ON (log.AUTHOR_ID=a.ID AND log.target_type=\'author\')';
+        $this->assertEquals($expected, $sql);
     }
 
     /**

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
@@ -722,9 +722,11 @@ class ModelCriteriaTest extends BookstoreTestBase
      */
     public function testGroupByUnknownColumnError()
     {
-        $c = BookQuery::create()->groupBy('Propel\Tests\Bookstore\Book.AuthorId');
+        $c = BookQuery::create()
+            ->groupBy('Book.Foo');
+
         $this->expectException(UnknownColumnException::class);
-        $c->groupBy('Book.Foo');
+        $c->createSelectSql($params);
     }
 
     /**

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaUseGroupByQueryTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaUseGroupByQueryTest.php
@@ -1,0 +1,245 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Tests\Runtime\ActiveQuery;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Tests\Bookstore\AuthorQuery;
+use Propel\Tests\Bookstore\BookQuery;
+use Propel\Tests\Bookstore\BookstoreEmployeeQuery;
+use Propel\Tests\Bookstore\Map\AuthorTableMap;
+use Propel\Tests\Bookstore\Map\BookTableMap;
+use Propel\Tests\Bookstore\Map\ReviewTableMap;
+use Propel\Tests\Bookstore\RecordLabelQuery;
+use Propel\Tests\Helpers\Bookstore\BookstoreDataPopulator;
+use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
+
+/**
+ * @group database
+ */
+class ModelCriteriaUseGroupByQueryTest extends BookstoreTestBase
+{
+    /**
+     * @return void
+     */
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        BookstoreDataPopulator::depopulate();
+        BookstoreDataPopulator::populate();
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        AuthorTableMap::clearInstancePool();
+        BookTableMap::clearInstancePool();
+        ReviewTableMap::clearInstancePool();
+    }
+
+    protected string $bookColumns = 'book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id';
+
+    /**
+     * @return void
+     */
+    public function testBasicSql()
+    {
+        $query = BookQuery::create()
+        ->useGroupByReviewQuery()
+            ->addAsColumn('totalReviews', 'COUNT(*)')
+        ->endUse();
+
+        $expectedSql = <<<SQL
+        SELECT $this->bookColumns, subquery_1.totalReviews AS totalReviews 
+        FROM book
+        LEFT JOIN (
+            SELECT review.book_id, COUNT(*) AS totalReviews 
+            FROM review
+            GROUP BY review.book_id
+        ) AS subquery_1 ON (book.id=subquery_1.book_id)
+SQL;
+        $this->assertQueryAndCount($expectedSql, [2, null, null, null], $query, 'totalReviews');
+    }
+
+    /**
+     * @return void
+     */
+    public function testSqlWithAlias()
+    {
+        $query = BookQuery::create()
+        ->useGroupByReviewQuery('r')
+            ->addAsColumn('totalReviews', 'COUNT(*)')
+        ->endUse();
+
+        $expectedSql = <<<SQL
+        SELECT $this->bookColumns, r.totalReviews AS totalReviews 
+        FROM book
+        LEFT JOIN (
+            SELECT r.book_id, COUNT(*) AS totalReviews 
+            FROM review r 
+            GROUP BY r.book_id
+        ) AS r ON (book.id=r.book_id)
+SQL;
+
+        $this->assertQueryAndCount($expectedSql, [2, null, null, null], $query, 'totalReviews');
+    }
+
+    /**
+     * @return void
+     */
+    public function testNestedGroupBy()
+    {
+        $query = AuthorQuery::create()
+        ->useGroupByBookQuery('b')
+            ->useGroupByReviewQuery('r')
+                ->addAsColumn('reviewsCount', 'COUNT(*)')
+            ->endUse()
+            ->addAsColumn('totalReviews', 'SUM(r.reviewsCount)')
+        ->endUse()
+        ->orderBy('author.first_name');
+
+        $expectedSql = <<<SQL
+        SELECT author.id, author.first_name, author.last_name, author.email, author.age, b.totalReviews AS totalReviews 
+        FROM author 
+        LEFT JOIN (
+            SELECT b.author_id, SUM(r.reviewsCount) AS totalReviews 
+            FROM book b 
+            LEFT JOIN (
+                SELECT r.book_id, COUNT(*) AS reviewsCount 
+                FROM review r 
+                GROUP BY r.book_id
+            ) AS r ON (b.id=r.book_id) 
+            GROUP BY b.author_id
+        ) AS b ON (author.id=b.author_id) 
+        ORDER BY author.first_name ASC
+SQL;
+        $this->assertQueryAndCount($expectedSql, [null, null, 2, null], $query, 'totalReviews');
+
+    }
+
+    /**
+     * @return void
+     */
+    public function testFilterThroughInnerJoin()
+    {
+        $query = BookQuery::create()
+        ->useGroupByReviewQuery('r', Criteria::INNER_JOIN)
+            ->addAsColumn('totalReviews', 'COUNT(*)')
+        ->endUse();
+
+        $expectedSql = <<<SQL
+        SELECT $this->bookColumns, r.totalReviews AS totalReviews 
+        FROM book 
+        INNER JOIN (
+            SELECT r.book_id, COUNT(*) AS totalReviews
+            FROM review r 
+            GROUP BY r.book_id
+        ) AS r ON (book.id=r.book_id)
+SQL;
+        $this->assertQueryAndCount($expectedSql, [2], $query, 'totalReviews');
+    }
+
+    /**
+     * @return void
+     */
+    public function testMultiKeyRelation()
+    {
+        $query = RecordLabelQuery::create()
+        ->useGroupByReleasePoolQuery('p')
+            ->addAsColumn('totalReleases', 'COUNT(*)')
+        ->endUse()
+        ->orderBy('totalReleases');
+        
+        $expectedSql = <<<SQL
+        SELECT record_label.id, record_label.abbr, record_label.name, p.totalReleases AS totalReleases 
+        FROM record_label 
+        LEFT JOIN (
+            SELECT p.record_label_id, p.record_label_abbr, COUNT(*) AS totalReleases
+            FROM release_pool p
+            GROUP BY p.record_label_id,p.record_label_abbr
+        ) AS p ON (record_label.id=p.record_label_id AND record_label.abbr=p.record_label_abbr) 
+        ORDER BY totalReleases ASC
+SQL;
+        $this->assertQueryAndCount($expectedSql, [1,3], $query, 'totalReleases');
+    }
+
+    /**
+     * @return void
+     */
+    public function testGroupByWithManyToMany()
+    {
+        $query = BookQuery::create()
+        ->useGroupByBookListRelQuery('list', Criteria::INNER_JOIN)
+            ->useBookClubListQuery('club')
+                ->filterByTheme('Happiness')
+            ->endUse()
+            ->addAsColumn('listAppearances', 'COUNT(*)')
+        ->endUse()
+        ->orderBy('title');
+        
+        $expectedSql = <<<SQL
+        SELECT $this->bookColumns, list.listAppearances AS listAppearances
+        FROM book
+        INNER JOIN (
+            SELECT list.book_id, COUNT(*) AS listAppearances
+            FROM book_x_list list 
+            INNER JOIN book_club_list club ON (list.book_club_list_id=club.id) 
+            WHERE club.theme=:p1 
+            GROUP BY list.book_id
+        ) AS list ON (book.id=list.book_id)
+        ORDER BY book.title ASC
+SQL;
+
+        $this->assertQueryAndCount($expectedSql, [1,1], $query, 'listAppearances');
+    }
+
+    /**
+     * @return void
+     */
+    public function testGroupBySelfJoin()
+    {
+        $query = BookstoreEmployeeQuery::create()
+        ->useGroupBySubordinateQuery('s', Criteria::INNER_JOIN)
+            ->addAsColumn('teamSize', 'COUNT(*)')
+        ->endUse()
+        ->orderBy('name');
+
+        $expectedSql = <<<SQL
+        SELECT bookstore_employee.id, bookstore_employee.class_key, 
+            bookstore_employee.name, bookstore_employee.job_title,
+            bookstore_employee.supervisor_id, bookstore_employee.salary,
+            s.teamSize AS teamSize 
+        FROM bookstore_employee
+        INNER JOIN (
+            SELECT s.supervisor_id, COUNT(*) AS teamSize 
+            FROM bookstore_employee s 
+            GROUP BY s.supervisor_id
+        ) AS s ON (bookstore_employee.id=s.supervisor_id)
+        ORDER BY bookstore_employee.name ASC
+SQL;
+
+        $this->assertQueryAndCount($expectedSql, [1], $query, 'teamSize');
+    }
+
+    /**
+     * @param string $expectedSql
+     * @param array $expectedCount
+     * @param Criteria $query
+     * @param string $countName
+     * @return void
+     */
+    public function assertQueryAndCount(string $expectedSql, array $expectedCount, Criteria $query, string $countName)
+    {
+        $this->assertVendorSql($expectedSql, $query);
+
+        $objects = $query->findObjects();
+        $counts = $objects->getColumnValues($countName);
+        $this->assertEquals($expectedCount, $counts);
+    }
+}

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaUseQueryTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaUseQueryTest.php
@@ -9,6 +9,7 @@
 namespace Propel\Tests\Runtime\ActiveQuery;
 
 use Propel\Runtime\ActiveQuery\ModelCriteria;
+use Propel\Runtime\Exception\PropelException;
 use Propel\Runtime\Propel;
 use Propel\Tests\Bookstore\AuthorQuery;
 use Propel\Tests\Bookstore\BookQuery;
@@ -183,5 +184,12 @@ class ModelCriteriaUseQueryTest extends BookstoreTestBase
         $expectedSQL = $this->getSql("SELECT $columns FROM book LEFT JOIN author ON (book.author_id=author.id) WHERE ((book.price=:p1 OR (author.age=:p2 OR author.first_name=:p3)) OR book.title=:p4) AND book.isbn=:p5");
 
         $this->assertEquals($expectedSQL, $sql);
+    }
+
+    public function testExceptionOnUnknownRelation(): void
+    {
+        $this->expectException(PropelException::class);
+        $this->expectExceptionMessage('Unknown class or alias `LeUnknownRelation`');
+        BookQuery::create()->useQuery('LeUnknownRelation');
     }
 }

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaUseQueryTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaUseQueryTest.php
@@ -36,7 +36,7 @@ class ModelCriteriaUseQueryTest extends BookstoreTestBase
 
         $c2 = $c->useQuery('Author');
         $this->assertTrue($c2 instanceof AuthorQuery, 'useQuery() returns a secondary Criteria');
-        $this->assertEquals($c, $c2->getPrimaryCriteria(), 'useQuery() sets the primary Criteria os the secondary Criteria');
+        $this->assertEquals($c, $c2->getParentQuery(), 'useQuery() sets the primary Criteria os the secondary Criteria');
         $c2->where('Author.FirstName = ?', 'john');
         $c2->limit(5);
 
@@ -70,7 +70,7 @@ class ModelCriteriaUseQueryTest extends BookstoreTestBase
 
         $c2 = $c->useQuery('a');
         $this->assertTrue($c2 instanceof AuthorQuery, 'useQuery() returns a secondary Criteria');
-        $this->assertEquals($c, $c2->getPrimaryCriteria(), 'useQuery() sets the primary Criteria os the secondary Criteria');
+        $this->assertEquals($c, $c2->getParentQuery(), 'useQuery() sets the primary Criteria os the secondary Criteria');
         $this->assertEquals(['a' => 'author'], $c2->getAliases(), 'useQuery() sets the secondary Criteria alias correctly');
         $c2->where('a.FirstName = ?', 'john');
         $c2->limit(5);
@@ -122,7 +122,7 @@ class ModelCriteriaUseQueryTest extends BookstoreTestBase
         $c->leftJoin('Propel\Tests\Bookstore\BookstoreContest.Work');
         $c2 = $c->useQuery('Work');
         $this->assertTrue($c2 instanceof BookQuery, 'useQuery() returns a secondary Criteria');
-        $this->assertEquals($c, $c2->getPrimaryCriteria(), 'useQuery() sets the primary Criteria os the secondary Criteria');
+        $this->assertEquals($c, $c2->getParentQuery(), 'useQuery() sets the primary Criteria os the secondary Criteria');
         //$this->assertEquals(array('a' => 'author'), $c2->getAliases(), 'useQuery() sets the secondary Criteria alias correctly');
         $c2->where('Work.Title = ?', 'War And Peace');
 
@@ -146,7 +146,7 @@ class ModelCriteriaUseQueryTest extends BookstoreTestBase
         $c->leftJoin('Propel\Tests\Bookstore\BookstoreContest.Work w');
         $c2 = $c->useQuery('w');
         $this->assertTrue($c2 instanceof BookQuery, 'useQuery() returns a secondary Criteria');
-        $this->assertEquals($c, $c2->getPrimaryCriteria(), 'useQuery() sets the primary Criteria os the secondary Criteria');
+        $this->assertEquals($c, $c2->getParentQuery(), 'useQuery() sets the primary Criteria os the secondary Criteria');
         $this->assertEquals(['w' => 'book'], $c2->getAliases(), 'useQuery() sets the secondary Criteria alias correctly');
         $c2->where('w.Title = ?', 'War And Peace');
 

--- a/tests/Propel/Tests/Runtime/ActiveQuery/QuotingTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/QuotingTest.php
@@ -43,9 +43,9 @@ class QuotingTest extends TestCaseFixturesDatabase
         $this->assertGreaterThan(0, $group->getId());
 
         if ($this->runningOnPostgreSQL()) {
-            $expected = $this->getSql(sprintf("INSERT INTO `group` (`id`, `title`, `as`) VALUES (%s, 'Test Group', 3)", $group->getId()));
+            $expected = static::toVendorSql(sprintf("INSERT INTO `group` (`id`, `title`, `as`) VALUES (%s, 'Test Group', 3)", $group->getId()));
         } else {
-            $expected = $this->getSql("INSERT INTO `group` (`id`, `title`, `as`) VALUES (NULL, 'Test Group', 3)");
+            $expected = static::toVendorSql("INSERT INTO `group` (`id`, `title`, `as`) VALUES (NULL, 'Test Group', 3)");
         }
         $this->assertEquals($expected, $this->getLastQuery());
     }
@@ -61,7 +61,7 @@ class QuotingTest extends TestCaseFixturesDatabase
         $group->save();
         $group->delete();
 
-        $expected = $this->getSql('DELETE FROM `group` WHERE `group`.`id`=' . $group->getId());
+        $expected = static::toVendorSql('DELETE FROM `group` WHERE `group`.`id`=' . $group->getId());
         $this->assertEquals($expected, $this->getLastQuery());
     }
 
@@ -77,7 +77,7 @@ class QuotingTest extends TestCaseFixturesDatabase
         $group->setAs(2);
         $group->save();
 
-        $expected = $this->getSql('UPDATE `group` SET `as`=2 WHERE `group`.`id`=' . $group->getId());
+        $expected = static::toVendorSql('UPDATE `group` SET `as`=2 WHERE `group`.`id`=' . $group->getId());
         $this->assertEquals($expected, $this->getLastQuery());
     }
 
@@ -89,14 +89,13 @@ class QuotingTest extends TestCaseFixturesDatabase
         $groupQuery = GroupQuery::create();
 
         $groupQuery
-        ->joinAuthor()
         ->useAuthorQuery()
         ->filterByName('Author filter')
         ->endUse()
         ->populateJoinedRelation('Author')
         ->find();
 
-        $expected = $this->getSql("SELECT `group`.`id`, `group`.`title`, `group`.`by`, `group`.`as`, `group`.`author_id`, quoting_author.id, quoting_author.name, quoting_author.type_id FROM `group` LEFT JOIN quoting_author ON (`group`.`author_id`=quoting_author.id) WHERE quoting_author.name='Author filter'");
+        $expected = static::toVendorSql("SELECT `group`.`id`, `group`.`title`, `group`.`by`, `group`.`as`, `group`.`author_id`, quoting_author.id, quoting_author.name, quoting_author.type_id FROM `group` LEFT JOIN quoting_author ON (`group`.`author_id`=quoting_author.id) WHERE quoting_author.name='Author filter'");
         $this->assertEquals($expected, $this->getLastQuery());
     }
 
@@ -108,14 +107,13 @@ class QuotingTest extends TestCaseFixturesDatabase
         $authorQuery = AuthorQuery::create();
 
         $authorQuery
-        ->joinAuthorType()
         ->useAuthorTypeQuery()
         ->filterByTitle('Author type title')
         ->endUse()
         ->populateJoinedRelation('AuthorType')
         ->find();
 
-        $expected = $this->getSql("SELECT quoting_author.id, quoting_author.name, quoting_author.type_id, `quoting_author_type`.`id`, `quoting_author_type`.`title` FROM quoting_author LEFT JOIN `quoting_author_type` ON (quoting_author.type_id=`quoting_author_type`.`id`) WHERE `quoting_author_type`.`title`='Author type title'");
+        $expected = static::toVendorSql("SELECT quoting_author.id, quoting_author.name, quoting_author.type_id, `quoting_author_type`.`id`, `quoting_author_type`.`title` FROM quoting_author LEFT JOIN `quoting_author_type` ON (quoting_author.type_id=`quoting_author_type`.`id`) WHERE `quoting_author_type`.`title`='Author type title'");
         $this->assertEquals($expected, $this->getLastQuery());
     }
 
@@ -131,7 +129,7 @@ class QuotingTest extends TestCaseFixturesDatabase
         ->orderBy('AuthorId')
         ->find();
 
-        $expected = $this->getSql('SELECT `g`.`id`, `g`.`title`, `g`.`by`, `g`.`as`, `g`.`author_id` FROM `group` `g` WHERE `g`.`id` > 0 ORDER BY `g`.`as` ASC,`g`.`author_id` ASC');
+        $expected = static::toVendorSql('SELECT `g`.`id`, `g`.`title`, `g`.`by`, `g`.`as`, `g`.`author_id` FROM `group` `g` WHERE `g`.`id` > 0 ORDER BY `g`.`as` ASC,`g`.`author_id` ASC');
         $this->assertEquals($expected, $this->getLastQuery());
 
         AuthorQuery::create('g')
@@ -141,10 +139,10 @@ class QuotingTest extends TestCaseFixturesDatabase
         ->find();
 
         if ($this->runningOnPostgreSQL()) {
-            $expected = $this->getSql('SELECT g.id, g.name, g.type_id FROM quoting_author g GROUP BY g.id,g.name,g.type_id HAVING g.id > 0');
+            $expected = static::toVendorSql('SELECT g.id, g.name, g.type_id FROM quoting_author g GROUP BY g.id,g.name,g.type_id HAVING g.id > 0');
         } else {
             // note that this only works with MySQL because the query return no data, otherwise an "Expression of SELECT list is not in GROUP BY" error would be thrown
-            $expected = $this->getSql('SELECT g.id, g.name, g.type_id FROM quoting_author g GROUP BY g.id HAVING g.id > 0');
+            $expected = static::toVendorSql('SELECT g.id, g.name, g.type_id FROM quoting_author g GROUP BY g.id HAVING g.id > 0');
         }
         $this->assertEquals($expected, $this->getLastQuery());
 
@@ -152,14 +150,14 @@ class QuotingTest extends TestCaseFixturesDatabase
         ->where('g.As > 0')
         ->find();
 
-        $expected = $this->getSql('SELECT `group`.`id`, `group`.`title`, `group`.`by`, `group`.`as`, `group`.`author_id` FROM `group` WHERE `group`.`as` > 0');
+        $expected = static::toVendorSql('SELECT `group`.`id`, `group`.`title`, `group`.`by`, `group`.`as`, `group`.`author_id` FROM `group` WHERE `group`.`as` > 0');
         $this->assertEquals($expected, $this->getLastQuery());
 
         AuthorQuery::create('g')
         ->where('g.Id > 0')
         ->find();
 
-        $expected = $this->getSql('SELECT quoting_author.id, quoting_author.name, quoting_author.type_id FROM quoting_author WHERE quoting_author.id > 0');
+        $expected = static::toVendorSql('SELECT quoting_author.id, quoting_author.name, quoting_author.type_id FROM quoting_author WHERE quoting_author.id > 0');
         $this->assertEquals($expected, $this->getLastQuery());
     }
 

--- a/tests/Propel/Tests/Runtime/ActiveQuery/QuotingTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/QuotingTest.php
@@ -178,11 +178,12 @@ class QuotingTest extends TestCaseFixturesDatabase
         ->having('group.As > 0')
         ->find($con);
 
-        if ($this->runningOnPostgreSQL()) {
-            $expected = $this->getSql('SELECT `group`.`id`, `group`.`title`, `group`.`by`, `group`.`as`, `group`.`author_id` FROM `group` GROUP BY `group`.`as`,`group`.`id`,`group`.`title`,`group`.`by`,`group`.`author_id` HAVING `group`.`as` > 0');
-        } else {
-            $expected = $this->getSql('SELECT `group`.`id`, `group`.`title`, `group`.`by`, `group`.`as`, `group`.`author_id` FROM `group` GROUP BY `group`.`as` HAVING `group`.`as` > 0');
-        }
+        $groupBy = $this->runningOnPostgreSQL()
+            ? '`group`.`as`,`group`.`id`,`group`.`title`,`group`.`by`,`group`.`author_id`'
+            : '`group`.`as`';
+    
+        $expected = static::toVendorSql("SELECT `group`.`id`, `group`.`title`, `group`.`by`, `group`.`as`, `group`.`author_id` FROM `group` GROUP BY $groupBy HAVING `group`.`as` > 0");
+
         $this->assertEquals($expected, $this->getLastQuery());
     }
 }

--- a/tests/Propel/Tests/Runtime/ActiveQuery/SubQueryTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/SubQueryTest.php
@@ -24,6 +24,7 @@ use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
  */
 class SubQueryTest extends BookstoreTestBase
 {
+    protected string $bookColumns = 'book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id';
     /**
      * @return void
      */
@@ -45,7 +46,7 @@ class SubQueryTest extends BookstoreTestBase
         $params = [];
         $result = $criteria->createSelectSql($params);
 
-        $this->assertEquals($expectedSql, $result, $message);
+        $this->assertEquals(static::toVendorSql($expectedSql), $result, $message);
         $this->assertEquals($expectedParams, $params, $message);
     }
 
@@ -61,23 +62,21 @@ class SubQueryTest extends BookstoreTestBase
         $c = new BookQuery();
         $c->setAutoAddTable(false);
         BookTableMap::addSelectColumns($c, 'subCriteriaAlias');
-        $c->addSubquery($subCriteria, 'subCriteriaAlias', false);
+        $c->addSubquery($subCriteria, 'subCriteriaAlias');
         $c->groupBy('subCriteriaAlias.AuthorId');
 
+        $sql = 'SELECT subCriteriaAlias.id, subCriteriaAlias.title, subCriteriaAlias.isbn, subCriteriaAlias.price, subCriteriaAlias.publisher_id, subCriteriaAlias.author_id FROM (SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id FROM book ORDER BY book.title ASC) AS subCriteriaAlias GROUP BY subCriteriaAlias.author_id';
         if ($this->isDb('pgsql')) {
-            $sql = $this->getSql('SELECT subCriteriaAlias.id, subCriteriaAlias.title, subCriteriaAlias.isbn, subCriteriaAlias.price, subCriteriaAlias.publisher_id, subCriteriaAlias.author_id FROM (SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id FROM book ORDER BY book.title ASC) AS subCriteriaAlias GROUP BY subCriteriaAlias.author_id,subCriteriaAlias.id,subCriteriaAlias.title,subCriteriaAlias.isbn,subCriteriaAlias.price,subCriteriaAlias.publisher_id');
-        } else {
-            $sql = $this->getSql('SELECT subCriteriaAlias.id, subCriteriaAlias.title, subCriteriaAlias.isbn, subCriteriaAlias.price, subCriteriaAlias.publisher_id, subCriteriaAlias.author_id FROM (SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id FROM book ORDER BY book.title ASC) AS subCriteriaAlias GROUP BY subCriteriaAlias.author_id');
+            $sql .= ',subCriteriaAlias.id,subCriteriaAlias.title,subCriteriaAlias.isbn,subCriteriaAlias.price,subCriteriaAlias.publisher_id';
         }
 
-        $params = [];
-        $this->assertCriteriaTranslation($c, $sql, $params, 'addSubQueryCriteriaInFrom() combines two queries successfully');
+        $this->assertCriteriaTranslation($c, $sql, [], 'addSubQueryCriteriaInFrom() combines two queries successfully');
     }
 
     /**
      * @return void
      */
-    public function testSubQueryWithoutSelect()
+    public function testSubQueryWithAlias()
     {
         $subCriteria = new BookQuery();
         // no addSelectColumns()
@@ -86,7 +85,7 @@ class SubQueryTest extends BookstoreTestBase
         $c->addSubquery($subCriteria, 'subCriteriaAlias');
         $c->filterByPrice(20, Criteria::LESS_THAN);
 
-        $sql = $this->getSql('SELECT subCriteriaAlias.id, subCriteriaAlias.title, subCriteriaAlias.isbn, subCriteriaAlias.price, subCriteriaAlias.publisher_id, subCriteriaAlias.author_id FROM (SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id FROM book) AS subCriteriaAlias WHERE subCriteriaAlias.price<:p1');
+        $sql = "SELECT $this->bookColumns FROM book, (SELECT $this->bookColumns FROM book) AS subCriteriaAlias WHERE book.price<:p1";
 
         $params = [
             ['table' => 'book', 'column' => 'price', 'value' => 20],
@@ -105,7 +104,8 @@ class SubQueryTest extends BookstoreTestBase
         $c->addSubquery($subCriteria); // no alias
         $c->filterByPrice(20, Criteria::LESS_THAN);
 
-        $sql = $this->getSql('SELECT subquery_1.id, subquery_1.title, subquery_1.isbn, subquery_1.price, subquery_1.publisher_id, subquery_1.author_id FROM (SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id FROM book) AS subquery_1 WHERE subquery_1.price<:p1');
+
+        $sql = "SELECT $this->bookColumns FROM book, (SELECT $this->bookColumns FROM book) AS subquery_1 WHERE book.price<:p1";
 
         $params = [
             ['table' => 'book', 'column' => 'price', 'value' => 20],
@@ -116,72 +116,15 @@ class SubQueryTest extends BookstoreTestBase
     /**
      * @return void
      */
-    public function testSubQueryWithoutAliasAndSelect()
-    {
-        $subCriteria = new BookQuery();
-        // no select
-
-        $c = new BookQuery();
-        $c->addSubquery($subCriteria); // no alias
-        $c->filterByPrice(20, Criteria::LESS_THAN);
-
-        $sql = $this->getSql('SELECT subquery_1.id, subquery_1.title, subquery_1.isbn, subquery_1.price, subquery_1.publisher_id, subquery_1.author_id FROM (SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id FROM book) AS subquery_1 WHERE subquery_1.price<:p1');
-
-        $params = [
-            ['table' => 'book', 'column' => 'price', 'value' => 20],
-        ];
-        $this->assertCriteriaTranslation($c, $sql, $params, 'addSubquery() forges a unique alias and adds select columns by default');
-    }
-
-    /**
-     * @return void
-     */
     public function testSubQueryWithoutAliasSeveral()
     {
-        $c1 = BookQuery::create()->filterByPrice(10, Criteria::GREATER_THAN);
-        $c2 = BookQuery::create()->filterByPrice(20, Criteria::LESS_THAN);
+        $c = BookQuery::create()
+            ->addSubquery(BookQuery::create()) // no alias
+            ->addSubquery(BookQuery::create()) // no alias
+        ;
 
-        $c3 = BookQuery::create()
-            ->addSubquery($c1) // no alias
-            ->addSubquery($c2) // no alias
-            ->filterByTitle('War%', Criteria::LIKE);
-
-        $subquery1Columns = 'subquery_1.id, subquery_1.title, subquery_1.isbn, subquery_1.price, subquery_1.publisher_id, subquery_1.author_id';
-        $subquery2Columns = 'subquery_2.id, subquery_2.title, subquery_2.isbn, subquery_2.price, subquery_2.publisher_id, subquery_2.author_id';
-        $bookColumns = 'book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id';
-        $sql = $this->getSql("SELECT $subquery1Columns, $subquery2Columns FROM (SELECT $bookColumns FROM book WHERE book.price>:p2) AS subquery_1, (SELECT $bookColumns FROM book WHERE book.price<:p3) AS subquery_2 WHERE subquery_2.title LIKE :p1");
-
-        $params = [
-            ['table' => 'book', 'column' => 'title', 'value' => 'War%'],
-            ['table' => 'book', 'column' => 'price', 'value' => 10],
-            ['table' => 'book', 'column' => 'price', 'value' => 20],
-        ];
-
-        $this->assertCriteriaTranslation($c3, $sql, $params, 'addSelectQuery() forges a unique alias if none is given');
-    }
-
-    /**
-     * @return void
-     */
-    public function testSubQueryWithoutAliasRecursive()
-    {
-        $c1 = new BookQuery();
-
-        $c2 = new BookQuery();
-        $c2->addSubquery($c1); // no alias
-        $c2->filterByPrice(20, Criteria::LESS_THAN);
-
-        $c3 = new BookQuery();
-        $c3->addSubquery($c2); // no alias
-        $c3->filterByTitle('War%', Criteria::LIKE);
-
-        $sql = $this->getSql('SELECT subquery_2.id, subquery_2.title, subquery_2.isbn, subquery_2.price, subquery_2.publisher_id, subquery_2.author_id FROM (SELECT subquery_1.id, subquery_1.title, subquery_1.isbn, subquery_1.price, subquery_1.publisher_id, subquery_1.author_id FROM (SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id FROM book) AS subquery_1 WHERE subquery_1.price<:p2) AS subquery_2 WHERE subquery_2.title LIKE :p1');
-
-        $params = [
-            ['table' => 'book', 'column' => 'title', 'value' => 'War%'],
-            ['table' => 'book', 'column' => 'price', 'value' => 20],
-        ];
-        $this->assertCriteriaTranslation($c3, $sql, $params, 'addSubquery() forges a unique alias if none is given');
+        $subqueryAliases = array_keys($c->getSubqueries());
+        $this->assertSame(['subquery_1', 'subquery_2'], $subqueryAliases);
     }
 
     public function testErrorOnDuplicatedAlias(): void
@@ -221,7 +164,7 @@ class SubQueryTest extends BookstoreTestBase
         $c2->addSubquery($c1, 'subQuery');
         $c2->filterByPrice(20, Criteria::LESS_THAN);
 
-        $sql = $this->getSql('SELECT subQuery.id, subQuery.title, subQuery.isbn, subQuery.price, subQuery.publisher_id, subQuery.author_id FROM (SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id FROM book LEFT JOIN author ON (book.author_id=author.id) WHERE author.last_name=:p2) AS subQuery WHERE subQuery.price<:p1');
+        $sql = "SELECT $this->bookColumns FROM book, (SELECT $this->bookColumns FROM book LEFT JOIN author ON (book.author_id=author.id) WHERE author.last_name=:p2) AS subQuery WHERE book.price<:p1";
 
         $params = [
             ['table' => 'book', 'column' => 'price', 'value' => 20],
@@ -241,21 +184,23 @@ class SubQueryTest extends BookstoreTestBase
         $c = new BookQuery();
         $c->addSubquery($subCriteria, 'subCriteriaAlias');
         // and use filterByPrice method!
-        $c->filterByPrice(20, Criteria::LESS_THAN);
+        $c->filterByPrice(20, Criteria::LESS_THAN)
+            ->where('subCriteriaAlias.title LIKE ?', '%Tin%');
 
-        $sql = $this->getSql('SELECT subCriteriaAlias.id, subCriteriaAlias.title, subCriteriaAlias.isbn, subCriteriaAlias.price, subCriteriaAlias.publisher_id, subCriteriaAlias.author_id FROM (SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id FROM book WHERE book.author_id=:p2) AS subCriteriaAlias WHERE subCriteriaAlias.price<:p1');
+        $sql = "SELECT $this->bookColumns FROM book, (SELECT $this->bookColumns FROM book WHERE book.author_id=:p3) AS subCriteriaAlias WHERE book.price<:p1 AND subCriteriaAlias.title LIKE :p2";
 
         $params = [
             ['table' => 'book', 'column' => 'price', 'value' => 20],
+            ['table' => 'book', 'column' => 'title', 'value' => '%Tin%'],
             ['table' => 'book', 'column' => 'author_id', 'value' => 123],
         ];
-        $this->assertCriteriaTranslation($c, $sql, $params, 'addSubQueryCriteriaInFrom() combines two queries successfully');
+        $this->assertCriteriaTranslation($c, $sql, $params);
     }
 
     /**
      * @return void
      */
-    public function testSubQueryRecursive()
+    public function testSubQueryNested()
     {
         // sort the books (on date, if equal continue with id), filtered by a publisher
         $sortedBookQuery = new BookQuery();
@@ -273,21 +218,11 @@ class SubQueryTest extends BookstoreTestBase
         $c->addSubquery($latestBookQuery, 'latestBookQuery');
         $c->filterByPrice(12, Criteria::LESS_THAN);
 
-        if ($this->isDb('pgsql')) {
-            $sql = $this->getSql('SELECT latestBookQuery.id, latestBookQuery.title, latestBookQuery.isbn, latestBookQuery.price, latestBookQuery.publisher_id, latestBookQuery.author_id ' .
-            'FROM (SELECT sortedBookQuery.id, sortedBookQuery.title, sortedBookQuery.isbn, sortedBookQuery.price, sortedBookQuery.publisher_id, sortedBookQuery.author_id FROM ' .
-            '(SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id FROM book WHERE book.publisher_id=:p2 ORDER BY book.title DESC,book.id DESC) AS sortedBookQuery ' .
-            'GROUP BY sortedBookQuery.author_id,sortedBookQuery.id,sortedBookQuery.title,sortedBookQuery.isbn,sortedBookQuery.price,sortedBookQuery.publisher_id) AS latestBookQuery WHERE latestBookQuery.price<:p1');
-        } else {
-            $sql = $this->getSql('SELECT latestBookQuery.id, latestBookQuery.title, latestBookQuery.isbn, latestBookQuery.price, latestBookQuery.publisher_id, latestBookQuery.author_id ' .
-            'FROM (SELECT sortedBookQuery.id, sortedBookQuery.title, sortedBookQuery.isbn, sortedBookQuery.price, sortedBookQuery.publisher_id, sortedBookQuery.author_id ' .
-            'FROM (SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id ' .
-            'FROM book ' .
-            'WHERE book.publisher_id=:p2 ' .
-            'ORDER BY book.title DESC,book.id DESC) AS sortedBookQuery ' .
-            'GROUP BY sortedBookQuery.author_id) AS latestBookQuery ' .
-            'WHERE latestBookQuery.price<:p1');
-        }
+        $groupBy = $this->isDb('pgsql')
+            ? "sortedBookQuery.author_id," . str_replace(' ', '', $this->bookColumns)
+            : 'sortedBookQuery.author_id';
+
+        $sql = "SELECT $this->bookColumns FROM book, (SELECT $this->bookColumns FROM book, (SELECT $this->bookColumns FROM book WHERE book.publisher_id=:p2 ORDER BY book.title DESC,book.id DESC) AS sortedBookQuery GROUP BY $groupBy) AS latestBookQuery WHERE book.price<:p1";
 
         $params = [
             ['table' => 'book', 'column' => 'price', 'value' => 12],
@@ -304,11 +239,11 @@ class SubQueryTest extends BookstoreTestBase
         $subCriteria = new BookQuery();
 
         $c = new BookQuery();
-        $c->addSubquery($subCriteria, 'alias1', false);
+        $c->addSubquery($subCriteria, 'alias1');
         $c->select(['alias1.Id']);
         $c->setAutoAddTable(false);
 
-        $sql = $this->getSql('SELECT alias1.id AS "alias1.Id" FROM (SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id FROM book) AS alias1');
+        $sql = 'SELECT alias1.id AS "alias1.Id" FROM (SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id FROM book) AS alias1';
 
         $params = [];
         $this->assertCriteriaTranslation($c, $sql, $params, 'addSubquery() forges a unique alias and adds select columns by default');
@@ -328,7 +263,7 @@ class SubQueryTest extends BookstoreTestBase
 
         $query = Propel::getConnection()->getLastExecutedQuery();
 
-        $sql = $this->getSql('SELECT COUNT(*) FROM (SELECT subCriteriaAlias.id, subCriteriaAlias.title, subCriteriaAlias.isbn, subCriteriaAlias.price, subCriteriaAlias.publisher_id, subCriteriaAlias.author_id FROM (SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id FROM book) AS subCriteriaAlias WHERE subCriteriaAlias.price<20) propelmatch4cnt');
+        $sql =static::toVendorSql("SELECT COUNT(*) FROM (SELECT $this->bookColumns FROM book, (SELECT $this->bookColumns FROM book) AS subCriteriaAlias WHERE book.price<20) propelmatch4cnt");
 
         $this->assertEquals($sql, $query, 'addSubquery() doCount is defined as complexQuery');
     }

--- a/tests/Propel/Tests/TestCase.php
+++ b/tests/Propel/Tests/TestCase.php
@@ -31,6 +31,8 @@ class TestCase extends PHPUnitTestCase
     }
 
     /**
+     * @deprecated Use aptly named {@see static::toVendorSql}
+     *
      * Makes the sql compatible with the current database.
      * Means: replaces ` etc.
      *
@@ -41,6 +43,21 @@ class TestCase extends PHPUnitTestCase
      * @return mixed
      */
     protected static function getSql($sql, $source = 'mysql', $target = null)
+    {
+        return static::toVendorSql($sql, $source, $target);
+    }
+
+    /**
+     * Makes the sql compatible with the current database.
+     * Means: replaces ` etc.
+     *
+     * @param string $sql
+     * @param string $source
+     * @param string|null $target
+     *
+     * @return mixed
+     */
+    protected static function toVendorSql($sql, $source = 'mysql', $target = null)
     {
         $target ??= static::getDriver();
 

--- a/tests/Propel/Tests/TestCase.php
+++ b/tests/Propel/Tests/TestCase.php
@@ -15,6 +15,8 @@ use Propel\Generator\Model\Column;
 use Propel\Generator\Model\Database;
 use Propel\Generator\Platform\PlatformInterface;
 use Propel\Generator\Platform\SqlitePlatform;
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Tests\Helpers\Assertion\MatchesFormattedVendorSql;
 use ReflectionClass;
 use ReflectionProperty;
 use function is_object;
@@ -57,7 +59,7 @@ class TestCase extends PHPUnitTestCase
      *
      * @return mixed
      */
-    protected static function toVendorSql($sql, $source = 'mysql', $target = null)
+    public static function toVendorSql($sql, $source = 'mysql', $target = null)
     {
         $target ??= static::getDriver();
 
@@ -72,6 +74,12 @@ class TestCase extends PHPUnitTestCase
         }
 
         return $sql;
+    }
+
+    final protected static function assertVendorSql(string $expectedSql, Criteria $query, string $message = '')
+    {
+        $sql = $query->createSelectSql($params);
+        static::assertThat($sql, new MatchesFormattedVendorSql($expectedSql), $message);
     }
 
     /**


### PR DESCRIPTION
## Issue
Currently, there is no good way to create group by queries.

## Changes
Generates `useGroupByXXXQuery()` methods on query classes for each one-to-many relation. This creates a query for the target table that will be added as a subquery. It is configured with groupings for the foreign key column and a join to the main table:
```php
$authors = AuthorQuery::create()
    ->useGroupByBookQuery()
        ->addAsColumn('totalBooks', 'COUNT(*)')
    ->endUse()
    ->findObjects();

$totalBooks = $authors[0]->getVirtualColumn('totalBooks');
```
This creates a SQL query similar to this:
```sql
SELECT <author columns>, subquery.totalBooks AS totalBooks
FROM author LEFT JOIN (
    SELECT book.author_id, COUNT(*) AS totalBooks
    FROM book
    GROUP BY book.author_id
) AS subquery ON (author.id = subquery.author_id)
```

Note: The main query automatically adds AS-columns from immediate subqueries.

## Implementation Details
- new `useGroupByXXXQuery()` methods are generated with other `useXXX` methods 
- `ModelQuery::addSubquery()` has been simplified (breaks BC, see below)
- `SelectQueryBuilder` can add subqueries with join (rather than cross join) if join condition is provided
- building a ModelJoin from relation data was moved from generated `joinXXX()` methods into a new method `ModelCriteria::createModelJoinForRelation()`
- building join conditions from ModelJoin can be done independently of whole join expression
- `ModelCriteria::select()` and `ModelCriteria::groupBy()`now can process resolved column objects to avoid string parsing
- `ModelCriteria::primaryCriteria` and `ModelQuery::previousJoin` are now renamed `ModelCriteria::parentQuery` and `ModelQuery::parentJoin` to indicate that they represent a join tree relation, which is parent/child, not first/second

### BC break of Propel2 subquery behavior

The Propel implementation of subqueries (`ModelCriteria::addSelectQuery()`) is very peculiar. When adding a subquery with the same model as the parent query (i.e. `BookQuery::create()->addSubquery(BookQuery::create())`), the subquery replaces the table access in the outer query (`SELECT * FROM (SELECT * FROM book) AS subquery`). This is the only behavior that is properly tested (in `tests/Propel/Tests/Runtime/ActiveQuery/SubQueryTest.php`), but I don't see the purpose of this. If the parent query just pipes everything through, you can just omit it and get the exact same result.

Subqueries with other models were added with a `CROSS JOIN` and all their columns were automatically added to the parent query. While users can add join conditions through `where`, it is not clear why the columns where added. When building models, additional select columns are ignored, so this achieves nothing (except maybe screw up hydration when used with `populateRelation()` - the only formatter that can output these columns is the SimpleArrayFormatter I think).

Likely this was only ever half implemented, and I remember wondering about this when I started using Propel2 - the output was completely unpredictably and never how I wanted it. Godspeed to whatever that was.

The old behavior is still available through the old and now deprecated `ModelCriteria::addSelectQuery()` (in contrast to the new `ModelCriteria::addSubquery()`), but it is not tested anymore and I won't maintain it.


## Test strategy
Basic SQL structure and results are tested in `ModelCriteriaUseGroupByQueryTest`, the old subquery tests were adjusted though they are as meaningless as before.

## Notes

For now, this is experimental. There might be bugs and interface of new methods might change if necessary. It is ultimately quite simple and builds on existing functionality, so I think it should basically work, but there might be edge cases that I have not thought of yet.
 
Also, at the moment, when passing an alias to the `useGroupBy` method, it is used inside the subquery and for the subquery itself, not sure if this proves feasible.