### PR TITLE
Resolve schema in synced table behavior 

### DIFF
--- a/src/Propel/Generator/Behavior/OutputGroup/OgTableMapModifier.php
+++ b/src/Propel/Generator/Behavior/OutputGroup/OgTableMapModifier.php
@@ -52,7 +52,7 @@ class OgTableMapModifier
     /**
      * @param \Propel\Generator\Builder\Om\TableMapBuilder $builder
      *
-     * @return array<array{'column_index'?: array<int>, 'relation'?: array<string>}> $outputGroups
+     * @return array<array{'column_index'?: array<int>, 'relation'?: array<string>}>
      */
     protected function buildOutputGroups(TableMapBuilder $builder): array
     {

--- a/src/Propel/Generator/Behavior/SyncedTable/SyncedTableBehaviorDeclaration.php
+++ b/src/Propel/Generator/Behavior/SyncedTable/SyncedTableBehaviorDeclaration.php
@@ -34,6 +34,11 @@ abstract class SyncedTableBehaviorDeclaration extends BehaviorWithParameterAcces
     /**
      * @var string
      */
+    public const PARAMETER_KEY_SCHEMA = 'schema';
+
+    /**
+     * @var string
+     */
     public const PARAMETER_KEY_SYNCED_PHPNAME = 'synced_phpname';
 
     /**
@@ -159,6 +164,7 @@ abstract class SyncedTableBehaviorDeclaration extends BehaviorWithParameterAcces
     {
         return [
             static::PARAMETER_KEY_SYNCED_TABLE => '',
+            static::PARAMETER_KEY_SCHEMA => null,
             static::PARAMETER_KEY_SYNCED_PHPNAME => null,
             static::PARAMETER_KEY_ADD_PK => null,
             static::PARAMETER_KEY_SYNC => 'true',
@@ -180,6 +186,15 @@ abstract class SyncedTableBehaviorDeclaration extends BehaviorWithParameterAcces
     public function getSyncedTableName(): ?string
     {
         return $this->getParameter(static::PARAMETER_KEY_SYNCED_TABLE);
+    }
+
+    /**
+     * @return string|null
+     */
+    #[\Override]
+    public function getSyncedTableSchema(): ?string
+    {
+        return $this->getParameter(static::PARAMETER_KEY_SCHEMA);
     }
 
     /**

--- a/src/Propel/Generator/Behavior/SyncedTable/TableSyncer/TableSyncer.php
+++ b/src/Propel/Generator/Behavior/SyncedTable/TableSyncer/TableSyncer.php
@@ -25,6 +25,7 @@ use function array_unique;
 use function count;
 use function in_array;
 use function reset;
+use function str_contains;
 
 /**
  * Creates the the synced table according to the given behavior.
@@ -72,11 +73,18 @@ class TableSyncer
         $database = $sourceTable->getDatabase();
         $syncedTableName = $this->config->resolveSyncedTableName();
 
-        $tableExistsInSchema = $database->hasTable($syncedTableName);
-
-        $syncedTable = $tableExistsInSchema ?
-            $database->getTable($syncedTableName) :
-            $this->createSyncedTable($sourceTable);
+        $syncedTable = $database->getTable($syncedTableName);
+        $schemaDelimiter = $database->getSchemaDelimiter();
+        if (
+            $syncedTable === null
+            && $sourceTable->getSchema()
+            && !str_contains($syncedTableName, $schemaDelimiter)
+        ) {
+            $syncedTableName = $sourceTable->getSchema() . $schemaDelimiter . $syncedTableName;
+            $syncedTable = $database->getTable($syncedTableName);
+        }
+        $tableExistsInSchema = $syncedTable !== null;
+        $syncedTable ??= $this->createSyncedTable($sourceTable);
 
         $this->resolveInheritance($syncedTable);
 

--- a/src/Propel/Generator/Behavior/SyncedTable/TableSyncer/TableSyncer.php
+++ b/src/Propel/Generator/Behavior/SyncedTable/TableSyncer/TableSyncer.php
@@ -25,7 +25,6 @@ use function array_unique;
 use function count;
 use function in_array;
 use function reset;
-use function str_contains;
 
 /**
  * Creates the the synced table according to the given behavior.
@@ -71,20 +70,13 @@ class TableSyncer
     protected function buildSyncedTable(Table $sourceTable): Table
     {
         $database = $sourceTable->getDatabase();
-        $syncedTableName = $this->config->resolveSyncedTableName();
+        $schema = $this->config->getSyncedTableSchema() ?? $sourceTable->getSchema();
+        $syncedTableName = ($schema ? $schema . $database->getSchemaDelimiter() : '') . $this->config->resolveSyncedTableName();
 
-        $syncedTable = $database->getTable($syncedTableName);
-        $schemaDelimiter = $database->getSchemaDelimiter();
-        if (
-            $syncedTable === null
-            && $sourceTable->getSchema()
-            && !str_contains($syncedTableName, $schemaDelimiter)
-        ) {
-            $syncedTableName = $sourceTable->getSchema() . $schemaDelimiter . $syncedTableName;
-            $syncedTable = $database->getTable($syncedTableName);
-        }
-        $tableExistsInSchema = $syncedTable !== null;
-        $syncedTable ??= $this->createSyncedTable($sourceTable);
+        $tableExistsInSchema = $database->hasTable($syncedTableName);
+        $syncedTable = $tableExistsInSchema
+            ? $database->getTable($syncedTableName)
+            : $this->createSyncedTable($sourceTable);
 
         $this->resolveInheritance($syncedTable);
 
@@ -111,7 +103,7 @@ class TableSyncer
             'name' => $this->config->resolveSyncedTableName(),
             'phpName' => $this->config->getSyncedTablePhpName(),
             'package' => $sourceTable->getPackage(),
-            'schema' => $sourceTable->getSchema(),
+            'schema' => $this->config->getSyncedTableSchema() ?? $sourceTable->getSchema(),
             'namespace' => $sourceTable->getNamespace() ? '\\' . $sourceTable->getNamespace() : null,
             'identifierQuoting' => $sourceTable->isIdentifierQuotingEnabled(),
         ];
@@ -145,7 +137,8 @@ class TableSyncer
         $behavior->setId('sync_to_table_' . $targetTable->getName());
         $behavior->setTable($sourceTable);
         $defaultParameters = [
-            SyncedTableBehaviorDeclaration::PARAMETER_KEY_SYNCED_TABLE => $targetTable->getName(),
+            SyncedTableBehaviorDeclaration::PARAMETER_KEY_SYNCED_TABLE => $targetTable->getCommonName(),
+            SyncedTableBehaviorDeclaration::PARAMETER_KEY_SCHEMA => $this->config->getSyncedTableSchema(),
             SyncedTableBehaviorDeclaration::PARAMETER_KEY_SYNC => 'true',
             SyncedTableBehaviorDeclaration::PARAMETER_KEY_SYNC_INDEXES => 'true',
             SyncedTableBehaviorDeclaration::PARAMETER_KEY_SYNC_UNIQUE_AS => 'unique',

--- a/src/Propel/Generator/Behavior/SyncedTable/TableSyncer/TableSyncerConfigInterface.php
+++ b/src/Propel/Generator/Behavior/SyncedTable/TableSyncer/TableSyncerConfigInterface.php
@@ -26,6 +26,11 @@ interface TableSyncerConfigInterface
     /**
      * @return string|null
      */
+    public function getSyncedTableSchema(): ?string;
+
+    /**
+     * @return string|null
+     */
     public function getSyncedTablePhpName(): ?string;
 
     /**

--- a/tests/Propel/Tests/Generator/Behavior/SyncedTable/SyncedTableBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/SyncedTable/SyncedTableBehaviorTest.php
@@ -1,23 +1,9 @@
 <?php
 
-/*
- *	$Id$
- * This file is part of the Propel package.
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- *
- * @license MIT License
- */
-
-/**
- * MIT License. This file is part of the Propel package.
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Propel\Tests\Generator\Behavior\SyncedTable;
 
 use Exception;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Propel\Generator\Exception\EngineException;
 use Propel\Generator\Model\Database;
 use Propel\Generator\Model\Diff\TableComparator;
@@ -1051,5 +1037,37 @@ EOF;
         $this->assertCount(2, $database->getTables());
         $this->assertNotNull($targetTable);
         $this->assertTrue($targetTable->hasColumn('custom_column'));
+    }
+    
+    /**
+     * @return string[][]
+     */
+    public static function SchemaTestDataProvider(): array
+    {
+        return [
+            ['', 'target_table'],
+            ['fooSchema', 'fooSchema§target_table'],
+            ['barSchema', 'barSchema§target_table'],
+        ];
+    }
+
+    #[DataProvider('SchemaTestDataProvider')]
+    public function testWithSchema(string|null $schema, string $expectedTableNameFq): void
+    {
+
+        $inputSchemaXml = <<<EOT
+<database>
+    <table name="source_table" schema="fooSchema">
+        <behavior name="synced_table">
+            <parameter name="table_name" value="target_table"/>
+            <parameter name="schema" value="$schema"/>
+        </behavior>
+    </table>
+</database>
+EOT;
+
+        $database = $this->buildDatabaseFromSchema($inputSchemaXml);
+        $generatedTable = $database->getTables()[1];
+        $this->assertSame($expectedTableNameFq, $generatedTable->getName());
     }
 }

--- a/tests/Propel/Tests/Generator/Behavior/SyncedTable/SyncedTableBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/SyncedTable/SyncedTableBehaviorTest.php
@@ -1023,4 +1023,33 @@ $actualDb
 
 EOT;
     }
+
+    /**
+     * @return void
+     */
+    public function testReusesExistingArchiveTableInSchema()
+    {
+        $schema = <<<EOF
+<database schema="foo_schema">
+    <table name="source_table">
+        <column name="id" type="INTEGER"/>
+        <behavior name="synced_table">
+            <parameter name="table_name" value="target_table"/>
+        </behavior>
+    </table>
+
+    <table name="target_table">
+        <column name="id" type="INTEGER"/>
+        <column name="custom_column" type="VARCHAR"/>
+    </table>
+</database>
+EOF;
+        $database = $this->buildDatabaseFromSchema($schema, null, new MysqlPlatform());
+
+        $targetTable = $database->getTable('foo_schema.target_table');
+
+        $this->assertCount(2, $database->getTables());
+        $this->assertNotNull($targetTable);
+        $this->assertTrue($targetTable->hasColumn('custom_column'));
+    }
 }


### PR DESCRIPTION
See https://github.com/propelorm/Propel2/pull/2070

## Issue
Synced table behavior does not find existing target table when source table uses schema

## Changes
Introduces a new parameter `schema` to synced table behavior which allows to provide target table schema name.
If no schema is provided, the schema of the source table is used, similar as with foreign keys.

## Implementation Details
Based on https://github.com/propelorm/Propel2/pull/2070


## Test strategy
Unit tests.