### PR TITLE
Bigint phptype

### DIFF
--- a/src/Propel/Generator/Model/Datatype/ColumnType.php
+++ b/src/Propel/Generator/Model/Datatype/ColumnType.php
@@ -114,6 +114,7 @@ enum ColumnType
             self::ENUM_BINARY,
             self::SET_BINARY
             => 'int',
+            self::BIGINT => PHP_INT_SIZE < 8 ? 'string' : 'int',
             self::REAL,
             self::FLOAT,
             self::DOUBLE

--- a/src/Propel/Generator/Model/Datatype/ColumnType.php
+++ b/src/Propel/Generator/Model/Datatype/ColumnType.php
@@ -14,6 +14,7 @@ use function implode;
 use function in_array;
 use function sort;
 use function strtoupper;
+use const PHP_INT_SIZE;
 
 enum ColumnType
 {
@@ -143,11 +144,11 @@ enum ColumnType
             self::TINYINT,
             self::SMALLINT,
             self::INTEGER,
-            self::BIGINT,
             self::BOOLEAN_EMU,
             self::ENUM_BINARY,
             self::SET_BINARY
             => PDO::PARAM_INT,
+            self::BIGINT => PHP_INT_SIZE < 8 ? PDO::PARAM_STR : PDO::PARAM_INT,
             self::VARBINARY,
             self::LONGVARBINARY,
             self::BLOB,

--- a/tests/Propel/Tests/Generator/Model/ColumnTest.php
+++ b/tests/Propel/Tests/Generator/Model/ColumnTest.php
@@ -621,7 +621,7 @@ class ColumnTest extends ModelTestCase
             [ColumnType::SMALLINT, 'int', true],
             [ColumnType::TINYINT, 'int', true],
             [ColumnType::INTEGER, 'int', true],
-            [ColumnType::BIGINT, 'string', false],
+            [ColumnType::BIGINT, 'int', false],
             [ColumnType::FLOAT, 'float', true],
             [ColumnType::DOUBLE, 'float', true],
             [ColumnType::NUMERIC, 'string', false],
@@ -649,7 +649,7 @@ class ColumnTest extends ModelTestCase
     public static function provideMappingUuidTypes()
     {
         return [
-            // column type, php type, 
+            // column type, php type,
             [ColumnType::UUID, 'string'],
             [ColumnType::UUID_BINARY, 'string'],
         ];

--- a/tests/Propel/Tests/Generator/Model/ColumnTest.php
+++ b/tests/Propel/Tests/Generator/Model/ColumnTest.php
@@ -621,7 +621,7 @@ class ColumnTest extends ModelTestCase
             [ColumnType::SMALLINT, 'int', true],
             [ColumnType::TINYINT, 'int', true],
             [ColumnType::INTEGER, 'int', true],
-            [ColumnType::BIGINT, 'int', false],
+            [ColumnType::BIGINT, PHP_INT_SIZE === 8 ? 'int' : 'string', PHP_INT_SIZE === 8],
             [ColumnType::FLOAT, 'float', true],
             [ColumnType::DOUBLE, 'float', true],
             [ColumnType::NUMERIC, 'string', false],

--- a/tests/Propel/Tests/Generator/Model/ColumnTest.php
+++ b/tests/Propel/Tests/Generator/Model/ColumnTest.php
@@ -21,6 +21,7 @@ use Propel\Generator\Platform\MysqlPlatform;
 use Propel\Tests\Helpers\ColorsBackedEnum;
 use Propel\Tests\Helpers\ColorsUnitEnum;
 use Propel\Tests\TestCase;
+use const PHP_INT_SIZE;
 
 /**
  * Tests for package handling.

--- a/tests/Propel/Tests/Runtime/TypeTests/BigintTypeTest.php
+++ b/tests/Propel/Tests/Runtime/TypeTests/BigintTypeTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Propel\Tests\Runtime\TypeTests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Propel\Generator\Util\QuickBuilder;
+use Propel\Runtime\Perpl;
+use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
+use Propel\Tests\TestCase;
+use BigintTypeTest\BigintEntity;
+
+/**
+ * @group database
+ * @group mysql
+ */
+class BigintTypeTest extends BookstoreTestBase
+{
+    /**
+     * @return void
+     */
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        static::createSchema();
+    }
+
+    /**
+     * @return void
+     */
+    public static function tearDownAfterClass(): void
+    {
+        $connection = Perpl::getServiceContainer()->getConnection('bookstore');
+        $connection->exec('DROP TABLE IF EXISTS bigint_entity;');
+
+        parent::tearDownAfterClass();
+    }
+
+    /**
+     * @return void
+     */
+    public static function createSchema(): void
+    {
+        $schema = <<<XML
+<database name="bookstore" namespace="BigintTypeTest">
+    <table name="bigint_entity">
+        <column name="id" primaryKey="true" type="INTEGER" autoIncrement="true"/>
+        <column name="le_bigint" type="BIGINT"/>
+        <column name="le_unsigned_bigint" sqlType="bigint unsigned"/>
+    </table>
+</database>
+XML;
+        $builder = new QuickBuilder();
+        $builder->setSchema($schema);
+        $builder->setVfs(false);
+        $builder->setPlatform(TestCase::getPlatform());
+        $connection = Perpl::getServiceContainer()->getConnection('bookstore');
+        $connection->exec('DROP TABLE IF EXISTS bigint_entity;');
+        $builder->buildSQL($connection);
+        $builder->buildClasses();
+    }
+
+    protected function fillBigintEntity(int|string|null $value, $entity = null)
+    {
+        $entity ??= new BigintEntity();
+        $entity
+            ->setBigint($value)
+            ->setBigintUnsigned($value);
+        $entity->save();
+        $entity->reload();
+
+        return $entity;
+    }
+
+    /**
+     * @return void
+     */
+    #[DataProvider('BigintValueDataProvider')]
+    public function testBigintValues(string $description, string|int $value, int $expectedBigintValue, string $expectedBigintUnsigendValue)
+    {
+        $o = (new BigintEntity())
+            ->setLeBigint($value)
+            ->setLeUnsignedBigint($value);
+        $o->save();
+        $o->reload();
+
+        $this->assertSame($expectedBigintValue, $o->getLeBigint(), "Bigint with $description");
+        $this->assertSame($expectedBigintUnsigendValue, $o->getLeUnsignedBigint(), "Unsigned Bigint with $description");
+    }
+
+    public static function BigintValueDataProvider(): array
+    {
+        $maxUnsignedBigint = '18446744073709551615';
+
+        return [
+            ['max int', PHP_INT_MAX, PHP_INT_MAX, (string)PHP_INT_MAX], // PHP_INT_MAX = 2^63 - 1 = 9223372036854775807
+            ['overflow', $maxUnsignedBigint, PHP_INT_MAX, $maxUnsignedBigint],
+        ];
+    }
+}


### PR DESCRIPTION
See https://github.com/propelorm/Propel2/pull/2029

## Issue

Currently the DB type BIGINT is handles as string in ORM code:
```php
// MyModel.php
function getMyBigintField(): string;
function setMyBigintField(string $bigIntValue): void;
```

Most likely, this is a holdover from the 32bit era, when (most) processors couldn't handle the 64bit BIGINT numbers.



## Changes
Map `BIGINT` to PHP `int` instead of `string`.



## Test strategy
Write and then read max int value (both signed and unsigned) from DB and check return type and value. 

## Notes

https://github.com/propelorm/Propel2/pull/2029#issuecomment-2852328240  raised the issue of MySQL `BIGINT UNSIGNED`, which can overflow 64bit signed int range, which is an important point in regards to BC. 
Turns out, the PDO type for `BIGINT` was set to `int` (see Propel [`PropelTypes::$mappingTypeToPDOTypeMap`](https://github.com/propelorm/Propel2/blob/92d27b41f5d510a04d0fe052a7add502ac95bbc9/src/Propel/Generator/Model/PropelTypes.php#L462)), which means the string values are turned to ints before being sent, cutting off any overflow (at least with my default PHP setup, values above `PHP_MAX_INT` become `PHP_MAX_INT`). So at least when it comes to writing, this change does not change behavior.

The stable way to declare a `BIGINT UNSIGNED` is to use a text-based mapping type (unless it is just for checking that values are positive):
```xml
<column name="my_unsigned_bigint" type="CHAR" sqlType="BIGINT UNSIGNED"/>
```
or just

```xml
<column name="my_unsigned_bigint" sqlType="BIGINT UNSIGNED"/>
```
